### PR TITLE
Update edgeR_heatmap_MDS.r for eventual transition to R 3.4.4

### DIFF
--- a/bin/edgeR_heatmap_MDS.r
+++ b/bin/edgeR_heatmap_MDS.r
@@ -30,7 +30,7 @@ if (!require("gplots")) {
 # Load count column from all files into a list of data frames
 # Use data.tables fread as much much faster than read.table
 # Row names are GeneIDs
-temp <- lapply(args, fread, skip="Geneid", header=TRUE, colClasses=c(NA, rep("NULL", 5), NA))
+temp <- lapply(lapply(args, fread, skip="Geneid", header=TRUE), function(x){return(as.data.frame(x)[,c(1, ncol(x))])})
 
 # Merge into a single data frame
 merge.all <- function(x, y) {


### PR DESCRIPTION
After transition to R 3.4.4, behavior of `data.table::fread()` function changed.
The selection of `Geneid` and count columns with `colClasses` argument does not work anymore which result in duplicated columns during merge.

Deffering columns selection with a `lapply` and `[` operator fixes this issue.
Note that conversion to regular `data.frame` object is required because of `[` operator behavior on `data.table` objects.

All the best,

Romain.