### PR TITLE
Refactor rseqc BAM subsampling for memory efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ LABEL authors="phil.ewels@scilifelab.se" \
     description="Docker image containing all requirements for the nfcore/rnaseq pipeline"
 
 COPY environment.yml /
-RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/nfcore-rnaseq-1.5dev/bin:$PATH
+RUN conda env update -n root -f /environment.yml && conda clean -a

--- a/Singularity
+++ b/Singularity
@@ -6,13 +6,9 @@ Bootstrap:docker
     DESCRIPTION Container image containing all requirements for the nf-core/rnaseq pipeline
     VERSION 1.5dev
 
-%environment
-    PATH=/opt/conda/envs/nfcore-rnaseq-1.5dev/bin:$PATH
-    export PATH
-
 %files
     environment.yml /
 
 %post
-    /opt/conda/bin/conda env create -f /environment.yml
+    /opt/conda/bin/conda env update -n root -f /environment.yml
     /opt/conda/bin/conda clean -a

--- a/conf/test.config
+++ b/conf/test.config
@@ -19,6 +19,8 @@ params {
     ['SRR4238359', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238359_subsamp.fastq.gz']],
     ['SRR4238379', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238379_subsamp.fastq.gz']],
   ]
+  // Subsample some (but not all) files
+  subsampFilesizeThreshold = 4000000
   // Genome references
   fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fa'
   gtf = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf'

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
   splicesites = false
   outdir = './results'
   hisatBuildMemory = 200 // Required amount of memory in GB to build HISAT2 index with splice sites
+  subsampFilesizeThreshold = 10000000000 // Don't subsample BAMs for RSeQC gene_body_coverage if less than this
   saveReference = false
   saveTrimmed = false
   saveAlignedIntermediates = false


### PR DESCRIPTION
I had a stab at rewriting how the BAM subsampling works for the RSeQC gene body coverage.

The previous use of `cat` and `shuf` required the entire BAM file to be read into memory, which kind of defeated the purpose a little and meant that the process still broke with large files (see #36).

Here I use `samtools view` with the `-s` flag which subsamples randomly with a single pass. However, this only works with a fraction, not a read number target, so I have to try to calculate this based on the filesize.

This is a bit of a guess currently - needs testing with some big files to see how many reads the subsampling actually spits out.

I'm not very happy with how this turned out to be honest. Code can hopefully be simplified a bit and logic moved from bash to groovy when https://github.com/nextflow-io/nextflow/issues/731 is implemented. Could potentially also use a channel filtering approach as suggested [here](https://stackoverflow.com/questions/47401518/nextflow-is-an-input-file-empty) by @pditommaso  (this would probably be nicest).

***Bonus:*** added more command line flags for STAR processes to tell it how much memory is available.

Phil