### PR TITLE
Fix: MultiQC - edgeR problem

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1047,7 +1047,7 @@ process multiqc {
     file ('featureCounts/*') from featureCounts_logs.collect()
     file ('featureCounts_biotype/*') from featureCounts_biotype.collect()
     file ('stringtie/stringtie_log*') from stringtie_log.collect()
-    file ('sample_correlation_results/*') from sample_correlation_results.toList() // toList() as process optional
+    file ('sample_correlation_results/*') from sample_correlation_results.collect().ifEmpty([]) // If the Edge-R is not run create an Empty array 
     file ('software_versions/*') from software_versions_yaml.collect()
     file ('workflow_summary/*') from workflow_summary_yaml.collect()
 


### PR DESCRIPTION
The problem is (from my understanding) the way `collect()` works is it returns a list object only if the channel atleast emits one value, otherwise it just remains an empty channel, which causes the process to be skipped or hang.

And `toList()` returns empty list `[]` when channel is empty (this is no problem) and list of lists when it have more than one emission i.e. like `[['a', 'b', 'c']]`. When this is given to a input as `file` it just creates a `input.(num of entires)` file with actual paths.

Tested this fixes (not very extensive though) and seems to work. I believe it should be suffice (of course correct me if I am wrong) :) 