### PR TITLE
BigWig support instead of subsample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ script:
   # Lint the pipeline code
   - "nf-core lint ${TRAVIS_BUILD_DIR}"
   # Run, build reference genome with STAR
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
+  - travis_wait 40 nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
   # Run, build reference genome with HISAT2
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner hisat2
+  - travis_wait 40 nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner hisat2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ script:
   # Lint the pipeline code
   - "nf-core lint ${TRAVIS_BUILD_DIR}"
   # Run, build reference genome with STAR
-  - travis_wait 40 nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
   # Run, build reference genome with HISAT2
-  - travis_wait 40 nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner hisat2
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner hisat2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ LABEL authors="phil.ewels@scilifelab.se" \
     description="Docker image containing all requirements for the nfcore/rnaseq pipeline"
 
 COPY environment.yml /
-RUN conda env update -n root -f /environment.yml && conda clean -a
+RUN conda env create -f /environment.yml && conda clean -a
+ENV PATH /opt/conda/envs/nfcore-rnaseq-1.0dev/bin:$PATH

--- a/conf/base.config
+++ b/conf/base.config
@@ -61,6 +61,12 @@ process {
     time = { check_max( 7.h * task.attempt, 'time' ) }
     errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
   }
+  withName:createBigWig {
+    cpus = { check_max( 8 * task.attempt, 'cpus' ) }
+    memory = { check_max( 32.GB * task.attempt, 'memory' ) }
+    time = { check_max( 7.h * task.attempt, 'time' ) }
+    errorStrategy = { task.exitStatus in [143,137] ? 'retry' : 'ignore' }
+  }
   withName:genebody_coverage {
     cpus = { check_max( 1 * task.attempt, 'cpus' ) }
     memory = { check_max( 32.GB * task.attempt, 'memory' ) }

--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,10 @@ channels:
 dependencies:
   - conda-forge::openjdk=8.0.144 # Needed for FastQC - conda build hangs without this
   - fastqc=0.11.7
-  - trim-galore=0.5
+  - trim-galore=0.5.0
   - star=2.6.0c
   - hisat2=2.1.0
-  - picard=2.18.7
+  - picard=2.18.11
   - bioconductor-dupradar=1.8.0
   - conda-forge::r-data.table=1.11.4
   - conda-forge::r-gplots=3.0.1
@@ -21,7 +21,7 @@ dependencies:
   - rseqc=2.6.4
   - samtools=1.9
   - stringtie=1.3.4
-  - subread=1.6.1
+  - subread=1.6.2
   - gffread=0.9.9
   - deeptools=3.1.1
   - multiqc=1.6

--- a/environment.yml
+++ b/environment.yml
@@ -24,3 +24,4 @@ dependencies:
   - subread=1.6.1
   - multiqc=1.5
   - gffread=0.9.9
+  - deeptools=3.1.1

--- a/main.nf
+++ b/main.nf
@@ -800,9 +800,9 @@ process genebody_coverage {
     """
     geneBody_coverage2.py \\
         -i $bigwig \\
-        -o ${bam.baseName}.rseqc \\
+        -o ${bigwig.baseName}.rseqc \\
         -r $bed12
-    mv log.txt ${bam.baseName}.rseqc.log.txt
+    mv log.txt ${bigwig.baseName}.rseqc.log.txt
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -754,7 +754,7 @@ process rseqc {
  */ 
 
 process createBigWig {
-    tag "${bam.baseName}"
+    tag "${bam.baseName - 'sortedByCoord.out'}"
     publishDir "${params.outdir}/bigwig", mode: 'copy'
 
     when:
@@ -790,7 +790,7 @@ process genebody_coverage {
     !params.skip_qc && !params.skip_genebody_coverage
 
     input:
-    file bigwig from bigwig_for_genebody.collect()
+    file bigwig from bigwig_for_genebody
     file bed12 from bed_genebody_coverage.collect()
 
     output:

--- a/main.nf
+++ b/main.nf
@@ -776,7 +776,7 @@ process createBigWig {
  * Step 4.2 Rseqc genebody_coverage
  */
 process genebody_coverage {
-    tag "${bigwig.baseName - '.bigwig'}"
+    tag "${bigwig.baseName - '.sorted'}"
        publishDir "${params.outdir}/rseqc" , mode: 'copy',
         saveAs: {filename ->
             if (filename.indexOf("geneBodyCoverage.curves.pdf") > 0)       "geneBodyCoverage/$filename"

--- a/main.nf
+++ b/main.nf
@@ -754,7 +754,7 @@ process rseqc {
  */ 
 
 process createBigWig {
-    tag "${bam.baseName - '.sorted'}"
+    tag "${bam.baseName}"
     publishDir "${params.outdir}/bigwig", mode: 'copy'
 
     when:

--- a/main.nf
+++ b/main.nf
@@ -776,7 +776,7 @@ process createBigWig {
  * Step 4.2 Rseqc genebody_coverage
  */
 process genebody_coverage {
-    tag "${bam.baseName - '.sorted'}"
+    tag "${bigwig.baseName - '.bigwig'}"
        publishDir "${params.outdir}/rseqc" , mode: 'copy',
         saveAs: {filename ->
             if (filename.indexOf("geneBodyCoverage.curves.pdf") > 0)       "geneBodyCoverage/$filename"

--- a/main.nf
+++ b/main.nf
@@ -769,7 +769,7 @@ process createBigWig {
     script:
     """
     samtools index $bam
-    bamCoverage -b $bam -p ${task.cpus} -o ${bam.baseName - 'sorted'}.bigwig
+    bamCoverage -b $bam -p ${task.cpus} -o ${bam.baseName}.bigwig
     """
 }
 /*

--- a/main.nf
+++ b/main.nf
@@ -592,7 +592,7 @@ if(params.aligner == 'star'){
     star_aligned
         .filter { logs, bams -> check_log(logs) }
         .flatMap {  logs, bams -> bams }
-    .into { bam_count; bam_rseqc; bam_preseq; bam_markduplicates; bam_featurecounts; bam_stringtieFPKM; bam_forSubsamp; bam_skipSubsamp }
+    .into { bam_count; bam_rseqc; bam_preseq; bam_markduplicates; bam_featurecounts; bam_stringtieFPKM; bam_for_genebody }
 }
 
 
@@ -675,7 +675,7 @@ if(params.aligner == 'hisat2'){
         file wherearemyfiles
 
         output:
-        file "${hisat2_bam.baseName}.sorted.bam" into bam_count, bam_rseqc, bam_preseq, bam_markduplicates, bam_featurecounts, bam_stringtieFPKM, bam_for_genebody, bam_skipSubsamp
+        file "${hisat2_bam.baseName}.sorted.bam" into bam_count, bam_rseqc, bam_preseq, bam_markduplicates, bam_featurecounts, bam_stringtieFPKM, bam_for_genebody
         file "where_are_my_files.txt"
 
         script:

--- a/main.nf
+++ b/main.nf
@@ -800,7 +800,7 @@ process genebody_coverage {
     """
     geneBody_coverage2.py \\
         -i $bigwig \\
-        -o ${bigwig.baseName}.rseqc \\
+        -o ${bigwig.baseName}.rseqc.txt \\
         -r $bed12
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -790,7 +790,7 @@ process genebody_coverage {
     !params.skip_qc && !params.skip_genebody_coverage
 
     input:
-    file bigwig from bigwig_for_genebody
+    file bigwig from bigwig_for_genebody.collect()
     file bed12 from bed_genebody_coverage.collect()
 
     output:

--- a/main.nf
+++ b/main.nf
@@ -675,7 +675,7 @@ if(params.aligner == 'hisat2'){
         file wherearemyfiles
 
         output:
-        file "${hisat2_bam.baseName}.sorted.bam" into bam_count, bam_rseqc, bam_preseq, bam_markduplicates, bam_featurecounts, bam_stringtieFPKM, bam_forSubsamp, bam_skipSubsamp
+        file "${hisat2_bam.baseName}.sorted.bam" into bam_count, bam_rseqc, bam_preseq, bam_markduplicates, bam_featurecounts, bam_stringtieFPKM, bam_for_genebody, bam_skipSubsamp
         file "where_are_my_files.txt"
 
         script:
@@ -748,31 +748,30 @@ process rseqc {
     """
 }
 
-/*
- * Step 4.1 Subsample the BAM files if necessary
- */
-bam_forSubsamp
-    .filter { it.size() > params.subsampFilesizeThreshold }
-    .map { [it, params.subsampFilesizeThreshold / it.size() ] }
-    .set{ bam_forSubsampFiltered }
-bam_skipSubsamp
-    .filter { it.size() <= params.subsampFilesizeThreshold }
-    .set{ bam_skipSubsampFiltered }
-process bam_subsample {
-    tag "${bam.baseName - '.sorted'}"
 
-    input:
-    set file(bam), val(fraction) from bam_forSubsampFiltered
+/*
+ * Step 4.1 Rseqc create BigWig coverage 
+ */ 
+
+process createBigWig {
+    tag "${bam.baseName - '.sorted'}"
+    publishDir "${params.outdir}/bigwig", mode: 'copy'
+
+    when:
+    !params.skip_qc && !params.skip_genebody_coverage
+
+    input: 
+    file bam from bam_for_genebody
 
     output:
-    file "*_subsamp.bam" into bam_subsampled
+    file "*.bigwig" into bigwig_for_genebody
 
     script:
     """
-    samtools view -s $fraction -b $bam | samtools sort -o ${bam.baseName}_subsamp.bam
+    samtools index $bam
+    bamCoverage -b $bam -p ${task.cpus} -o $bam.bigwig
     """
 }
-
 /*
  * Step 4.2 Rseqc genebody_coverage
  */
@@ -791,7 +790,7 @@ process genebody_coverage {
     !params.skip_qc && !params.skip_genebody_coverage
 
     input:
-    file bam from bam_subsampled.concat(bam_skipSubsampFiltered)
+    file bigwig from bigwig_for_genebody
     file bed12 from bed_genebody_coverage.collect()
 
     output:
@@ -799,9 +798,8 @@ process genebody_coverage {
 
     script:
     """
-    samtools index $bam
-    geneBody_coverage.py \\
-        -i $bam \\
+    geneBody_coverage2.py \\
+        -i $bigwig \\
         -o ${bam.baseName}.rseqc \\
         -r $bed12
     mv log.txt ${bam.baseName}.rseqc.log.txt

--- a/main.nf
+++ b/main.nf
@@ -802,7 +802,6 @@ process genebody_coverage {
         -i $bigwig \\
         -o ${bigwig.baseName}.rseqc \\
         -r $bed12
-    mv log.txt ${bigwig.baseName}.rseqc.log.txt
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -769,7 +769,7 @@ process createBigWig {
     script:
     """
     samtools index $bam
-    bamCoverage -b $bam -p ${task.cpus} -o $bam.bigwig
+    bamCoverage -b $bam -p ${task.cpus} -o ${bam.baseName - 'sorted'}.bigwig
     """
 }
 /*

--- a/main.nf
+++ b/main.nf
@@ -776,7 +776,7 @@ process createBigWig {
  * Step 4.2 Rseqc genebody_coverage
  */
 process genebody_coverage {
-    tag "${bigwig.baseName - '.sorted'}"
+    tag "${bigwig.baseName}"
        publishDir "${params.outdir}/rseqc" , mode: 'copy',
         saveAs: {filename ->
             if (filename.indexOf("geneBodyCoverage.curves.pdf") > 0)       "geneBodyCoverage/$filename"


### PR DESCRIPTION
First efforts to support bigWigs instead of subsampling:

- Create bigWig files using bamCoveraeg in deepTools
- Use the bigWig as suggested to create genebody_coverage using `genebody_coverage2.py` instead 
- Add remaining dependencies to environment.yaml 

This should fix #36 in the end! 