### PR TITLE
Fix containsKey if no genome is used

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -95,8 +95,8 @@ if (params.help){
 }
 
 // Check if genome exists in the config file
-if (!params.genomes.containsKey(params.genome) && params.genome) {
-  exit 1, "The provided genome '${params.genome}' is not available in the iGenomes file. Currently the available genomes are ${params.genomes.keySet().join(", ")}"
+if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
+    exit 1, "The provided genome '${params.genome}' is not available in the iGenomes file. Currently the available genomes are ${params.genomes.keySet().join(", ")}"
   }
 
 // Configurable variables


### PR DESCRIPTION
Maybe also something that could go to `master` but that can wait I guess for everything else to be merged too. 
