### PR TITLE
Use quotes for feature counts in MultiQC

### DIFF
--- a/bin/mqc_features_stat.py
+++ b/bin/mqc_features_stat.py
@@ -53,7 +53,7 @@ def mqc_feature_stat(bfile, features, outfile, sname=None):
         return
 
     # Prepare the output strings
-    out_head, out_value, out_mqc = ("Sample", sname, mqc_main)
+    out_head, out_value, out_mqc = ("Sample", "'{}'".format(sname), mqc_main)
     for ft, pt in fpercent.items():
         out_head = "{}\tpercent_{}".format(out_head, ft)
         out_value = "{}\t{}".format(out_value, pt)
@@ -72,4 +72,3 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--output", dest='output', default='biocount_percent.tsv', type=str, help="Sample Name")
     args = parser.parse_args()
     mqc_feature_stat(args.biocount, args.features, args.output, args.sample)
-


### PR DESCRIPTION
Resolve edge-case where numeric sample IDs are parsed as numbers causing some samples to be incorrectly overwritten.

Reported and fixed by Maria N at Institute of Molecular Pathology (IMP) in Vienna - thanks Maria!