### PR TITLE
Fixing binac updated Singularity version

### DIFF
--- a/conf/binac.config
+++ b/conf/binac.config
@@ -10,7 +10,7 @@ singularity {
 }
 
 process {
-  beforeScript = 'module load devel/singularity/2.4.1'
+  beforeScript = 'module load devel/singularity/2.6.0'
   executor = 'pbs'
   queue = 'short'
 }


### PR DESCRIPTION
This just updates Singularity to 2.6.0 on the cluster. Former module not available anymore! 