### PR TITLE
Travis - pull :dev docker image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   # PRs to master are only ok if coming from dev branch
   - '[ $TRAVIS_PULL_REQUEST = "false" ] || [ $TRAVIS_BRANCH != "master" ] || ([ $TRAVIS_PULL_REQUEST_SLUG = $TRAVIS_REPO_SLUG ] && [ $TRAVIS_PULL_REQUEST_BRANCH = "dev" ])'
   # Pull the docker image first so the test doesn't wait for this
-  - docker pull nfcore/rnaseq
+  - docker pull nfcore/rnaseq:dev
   # Fake the tag locally so that the pipeline runs properly
-  - docker tag nfcore/rnaseq nfcore/rnaseq:latest
+  - docker tag nfcore/rnaseq:dev nfcore/rnaseq:latest
 
 install:
   # Install Nextflow


### PR DESCRIPTION
See nf-core/tools#225.

Should fix tests as we will now test with the new docker image.

Ironically, linting will fail until the next tools release is done.