### PR TITLE
Update memory requirements for hisat_index_build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,20 @@
 
 ## Version 1.2dev
 
-
 #### Pipeline updates
 * Removed some outdated documentation about non-existent features
 * Config refactoring and code cleaning
 * Added a `--fcExtraAttributes` option to specify more than ENSEMBL gene names in `featureCounts`
 * Remove legacy rseqc `strandRule` config code. [#119](https://github.com/nf-core/rnaseq/issues/119)
 * Added STRINGTIE ballgown output to results folder [#125](https://github.com/nf-core/rnaseq/issues/125)
-
-
+* HiSAT index build now requests `200GB` memory, enough to use the exons / splice junction option for building.
+  * Added documentation about the `--hisatBuildMemory` option.
 
 #### Bug Fixes
 * Fixed conda bug which caused problems with environment resolution due to changes in bioconda [#113](https://github.com/nf-core/rnaseq/issues/113)
 * Fixed wrong gffread command line [#117](https://github.com/nf-core/rnaseq/issues/117)
 * Added `cpus = 1` to `workflow summary process` [#130](https://github.com/nf-core/rnaseq/issues/130)
+
 
 ## [Version 1.1](https://github.com/nf-core/rnaseq/releases/tag/1.1) - 2018-10-05
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -29,7 +29,7 @@ process {
   }
   withName:makeHISATindex {
     cpus = { check_max( 10, 'cpus' ) }
-    memory = { check_max( 80.GB * task.attempt, 'memory' ) }
+    memory = { check_max( 200.GB * task.attempt, 'memory' ) }
     time = { check_max( 5.h * task.attempt, 'time' ) }
   }
   withName:trim_galore {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -308,6 +308,15 @@ Should be a string in the format integer-unit. eg. `--max_time '2.h'`
 Use to set a top-limit for the default CPU requirement for each process.
 Should be a string in the format integer-unit. eg. `--max_cpus 1`
 
+### `--hisatBuildMemory`
+Required amount of memory in GB to build HISAT2 index with splice sites.
+The HiSAT2 index build can proceed with or without exon / splice junction information.
+To work with this, a very large amount of memory is required.
+If this memory is not available, the index build will proceed without splicing information.
+The `--hisatBuildMemory` option changes this threshold. By default it is `200GB` - if your system
+`--max_memory` is set to `128GB` but your genome is small enough to build using this, then you can
+allow the exon build to proceed by supplying `--hisatBuildMemory 100GB`
+
 ### `--plaintext_email`
 Set to receive plain-text e-mails instead of HTML formatted.
 


### PR DESCRIPTION
Allows exon / junction index building. See nf-core/rnaseq#132