### PR TITLE
Fixing bug with hisat2 building on large references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Added configurable options to specify group attributes for featureCounts [#144](https://github.com/nf-core/rnaseq/issues/144)
 * Added support for RSeqC 3.0 [#148](https://github.com/nf-core/rnaseq/issues/148)
 
+#### Bug fixes
+* Fixing HISAT2 Index Building for large reference genomes [#153](https://github.com/nf-core/rnaseq/issues/153)
+
+
 #### Dependency Updates
 * RSeQC 2.6.4 -> 3.0.0
 * Picard 2.18.15 -> 2.18.23

--- a/main.nf
+++ b/main.nf
@@ -372,7 +372,7 @@ if(params.aligner == 'hisat2' && !params.hisat2_index && params.fasta){
         file gtf from gtf_makeHISATindex
 
         output:
-        file "${fasta.baseName}.*.ht2" into hs2_indices
+        file "${fasta.baseName}.*.ht2*" into hs2_indices
 
         script:
         if( !task.memory ){


### PR DESCRIPTION
This should address https://github.com/nf-core/rnaseq/issues/153 already 👍 


tl;dr:

Hisat2 indexing builds either a `*.ht2` (for small reference genomes) or a `*.ht2l` for large reference genomes. This fails if you intend to build an index for a large , e.g. Human reference genome. 

