### PR TITLE
Fix mem sort for HISAT2 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 #### Bug fixes
 * Fixing HISAT2 Index Building for large reference genomes [#153](https://github.com/nf-core/rnaseq/issues/153)
+* Fixing HISAT2 BAM sorting using more memory than available on the system
 
 
 #### Dependency Updates

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,7 +47,7 @@ process {
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }
   withName:hisat2_sortOutput {
-    cpus = { check_max( 5, 'cpus' ) }
+    cpus = { check_max( 4, 'cpus' ) }
     memory = { check_max( 32.GB * task.attempt, 'memory' ) }
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,7 +47,7 @@ process {
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }
   withName:hisat2_sortOutput {
-    cpus = { check_max( 4, 'cpus' ) }
+    cpus = { check_max( 5, 'cpus' ) }
     memory = { check_max( 32.GB * task.attempt, 'memory' ) }
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,7 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 1000000000) / task.cpus}" : ''
+        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 3000000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\

--- a/main.nf
+++ b/main.nf
@@ -675,7 +675,7 @@ if(params.aligner == 'hisat2'){
         """
         samtools sort \\
             $hisat2_bam \\
-            -@ ${task.cpus} -m ${avail_mem} \\
+            -@ ${task.cpus} ${avail_mem} \\
             -o ${hisat2_bam.baseName}.sorted.bam
         samtools index ${hisat2_bam.baseName}.sorted.bam
         """

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,8 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 6000000000) / task.cpus}" : ''
+        def suff_mem = ("${(task.memory.toBytes() - 6000000000) / task.cpus}" > 2000000000) ? 'true' : 'false'
+        def avail_mem = (task.memory && suff_mem) ? "-m" + "${(task.memory.toBytes() - 6000000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,7 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 100000000) / task.cpus}" : ''
+        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 1000000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\

--- a/main.nf
+++ b/main.nf
@@ -675,7 +675,7 @@ if(params.aligner == 'hisat2'){
         """
         samtools sort \\
             $hisat2_bam \\
-            -@ ${task.cpus} -m 2G \\
+            -@ ${task.cpus} -m ${avail_mem} \\
             -o ${hisat2_bam.baseName}.sorted.bam
         samtools index ${hisat2_bam.baseName}.sorted.bam
         """

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,7 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 3000000000) / task.cpus}" : ''
+        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 5000000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,7 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 5000000000) / task.cpus}" : ''
+        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 6000000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\

--- a/main.nf
+++ b/main.nf
@@ -675,7 +675,7 @@ if(params.aligner == 'hisat2'){
         """
         samtools sort \\
             $hisat2_bam \\
-            -@ ${task.cpus} $avail_mem \\
+            -@ ${task.cpus} -m 2G \\
             -o ${hisat2_bam.baseName}.sorted.bam
         samtools index ${hisat2_bam.baseName}.sorted.bam
         """

--- a/main.nf
+++ b/main.nf
@@ -671,7 +671,7 @@ if(params.aligner == 'hisat2'){
         file "where_are_my_files.txt"
 
         script:
-        def avail_mem = task.memory ? "-m ${task.memory.toBytes() / task.cpus}" : ''
+        def avail_mem = task.memory ? "-m ${(task.memory.toBytes() - 100000000) / task.cpus}" : ''
         """
         samtools sort \\
             $hisat2_bam \\


### PR DESCRIPTION
Copying in the conversation from nf-core slack:

So we keep seeing some issues with the RNAseq workflow when sorting the hisat2 output - memory requested on the server seems to be *higher* than what is provided, thus the jobs get killed by the scheduler...
e.g. something like `Excceed job memory limit 63348736 > 82914560`
which happens here https://github.com/nf-core/rnaseq/blob/e8376373da8c1dfb0cae5372947cf5b241056076/main.nf#L676
I'd suggest dropping this memory request, as I never really saw issues without it in other pipelines sorting BAM files...
Sarek e.g. does this somewhat similar thing to set it permanently to `2G` https://github.com/SciLifeLab/Sarek/blob/88921e6944604d077afd8a5bc0a89b8e93937313/main.nf#L174
Suggestions ?