### PR TITLE
Downgrade to STAR 2.6.1d for now

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - fastqc=0.11.8
   - trim-galore=0.5.0
-  - star=2.7.0d
+  - star=2.6.1d
   - hisat2=2.1.0
   - picard=2.18.27
   - bioconductor-dupradar=1.12.1

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - fastqc=0.11.8
   - trim-galore=0.5.0
-  - star=2.6.1d
+  - star=2.6.1d #don't upgrade me - 2.7X indices incompatible with iGenomes. 
   - hisat2=2.1.0
   - picard=2.18.27
   - bioconductor-dupradar=1.12.1


### PR DESCRIPTION
As mentioned in #172, we should probably wait at least until all iGenomes resources have been updated with compatible 2.7X indices ...? 