### PR TITLE
Get MultiQC to save plots as stand alone files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.4dev
 
 #### Pipeline updates
-* get MultiQC to save plots as stand alone files
+* Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # nf-core/rnaseq: Changelog
 
+## Version 1.4dev
+
+#### Pipeline updates
+* get MultiQC to save plots as stand alone files
+
 ## Version 1.3
 
 #### Pipeline Updates

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -24,3 +24,5 @@ report_section_order:
 table_columns_visible:
     FastQC:
         percent_duplicates: False
+
+export_plots: true


### PR DESCRIPTION
I often have to insert figures generated by MultiQC in my reports, which means that every time I have to export them manually from the multiqc_report.html - a pretty time-consuming task.

I found out that it's also possible to get MultiQC to save plots as stand alone files, which would help who needs it and at the same time not harming who does not. I added the necessary option to true in the config file

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
