### PR TITLE
add cpus to mid_memory processes and genebody_coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Pipeline updates
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
+* Set number of CPUs to 4 for `mid_memory` tasks
+* Increase to 8 CPUs for `genebody_coverage`
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -20,6 +20,9 @@ process {
   maxErrors = '-1'
 
   // Process-specific resource requirements
+  withName: genebody_coverage {
+    cpus = { check_max( 8, 'cpus')}
+  }
   withName: trim_galore {
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }
@@ -38,6 +41,7 @@ process {
     memory = { check_max( 16.GB * task.attempt, 'memory' ) }
   }
   withLabel: mid_memory {
+    cpus = { check_max (4, 'cpus')}
     memory = { check_max( 32.GB * task.attempt, 'memory' ) }
     time = { check_max( 8.h * task.attempt, 'time' ) }
   }


### PR DESCRIPTION
`mid_memory` tagged processes only had 2 `cpus` assigned to them. 
This PR increases the number for `mid_memory` to 4. (Your thoughts on that?)
Also `genebody_coverage` now runs with 8 `cpus` (takes forever otherwise)


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
