### PR TITLE
add edgeR version information to the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 1.4dev
 
 #### Pipeline updates
-* Obtain edgeR version information [#198](https://github.com/nf-core/rnaseq/issues/198)
+* Obtain edgeR + dupRadar version information [#198](https://github.com/nf-core/rnaseq/issues/198) and [#112](https://github.com/nf-core/rnaseq/issues/112)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183): added the folder "multiqc_plots" to the output.
 * Get MultiQC to write out the software versions in a .csv file [#185](https://github.com/nf-core/rnaseq/issues/185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.4dev
 
 #### Pipeline updates
+* Obtain edgeR version information [#198](https://github.com/nf-core/rnaseq/issues/198)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183): added the folder "multiqc_plots" to the output.
 * Get MultiQC to write out the software versions in a .csv file [#185](https://github.com/nf-core/rnaseq/issues/185)

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -37,6 +37,8 @@ results['StringTie'] = '<span style="color:#999999;\">N/A</span>'
 results['Preseq'] = '<span style="color:#999999;\">N/A</span>'
 results['deepTools'] = '<span style="color:#999999;\">N/A</span>'
 results['RSeQC'] = '<span style="color:#999999;\">N/A</span>'
+results['DupRadar'] = '<span style="color:#999999;\">N/A</span>'
+results['edgeR'] = '<span style="color:#999999;\">N/A</span>'
 results['MultiQC'] = '<span style="color:#999999;\">N/A</span>'
 
 # Search each file using its regex

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -18,8 +18,8 @@ regexes = {
     'StringTie': ['v_stringtie.txt', r"(\S+)"],
     'Preseq': ['v_preseq.txt', r"Version: (\S+)"],
     'RSeQC': ['v_rseqc.txt', r"read_duplication.py ([\d\.]+)"],
-    'DupRadar': ['v_dupRadar.txt', r"version (\S+)"],
-    'edgeR: ['v_edgeR.txt', r"version (\S+)"],
+    'dupRadar': ['v_dupRadar.txt', r"(\S+)"],
+    'edgeR: ['v_edgeR.txt', r"(\S+)"],
     'MultiQC': ['v_multiqc.txt', r"multiqc, version (\S+)"],
 }
 results = OrderedDict()

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -37,7 +37,7 @@ results['StringTie'] = '<span style="color:#999999;\">N/A</span>'
 results['Preseq'] = '<span style="color:#999999;\">N/A</span>'
 results['deepTools'] = '<span style="color:#999999;\">N/A</span>'
 results['RSeQC'] = '<span style="color:#999999;\">N/A</span>'
-results['DupRadar'] = '<span style="color:#999999;\">N/A</span>'
+results['dupRadar'] = '<span style="color:#999999;\">N/A</span>'
 results['edgeR'] = '<span style="color:#999999;\">N/A</span>'
 results['MultiQC'] = '<span style="color:#999999;\">N/A</span>'
 

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -19,7 +19,7 @@ regexes = {
     'Preseq': ['v_preseq.txt', r"Version: (\S+)"],
     'RSeQC': ['v_rseqc.txt', r"read_duplication.py ([\d\.]+)"],
     'dupRadar': ['v_dupRadar.txt', r"(\S+)"],
-    'edgeR: ['v_edgeR.txt', r"(\S+)"],
+    'edgeR': ['v_edgeR.txt', r"(\S+)"],
     'MultiQC': ['v_multiqc.txt', r"multiqc, version (\S+)"],
 }
 results = OrderedDict()

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -18,6 +18,8 @@ regexes = {
     'StringTie': ['v_stringtie.txt', r"(\S+)"],
     'Preseq': ['v_preseq.txt', r"Version: (\S+)"],
     'RSeQC': ['v_rseqc.txt', r"read_duplication.py ([\d\.]+)"],
+    'DupRadar': ['v_dupRadar.txt', r"version (\S+)"],
+    'edgeR: ['v_edgeR.txt', r"version (\S+)"],
     'MultiQC': ['v_multiqc.txt', r"multiqc, version (\S+)"],
 }
 results = OrderedDict()
@@ -64,7 +66,7 @@ for k,v in results.items():
     print("        <dt>{}</dt><dd><samp>{}</samp></dd>".format(k,v))
 print ("    </dl>")
 
-# Write out regexes as csv file: 
+# Write out regexes as csv file:
 with open('software_versions.csv', 'w') as f:
     for k,v in results.items():
         f.write("{}\t{}\n".format(k,v))

--- a/main.nf
+++ b/main.nf
@@ -328,7 +328,8 @@ process get_software_versions {
     picard MarkDuplicates --version &> v_markduplicates.txt  || true
     samtools --version &> v_samtools.txt
     multiqc --version &> v_multiqc.txt
-    edgeR --version &> v_edgeR.txt
+    Rscript -e "library(edgeR); write(x=as.character(packageVersion('edgeR')), file='v_edgeR.txt')"
+    Rscript -e "library(dupRadar); write(x=as.character(packageVersion('dupRadar')), file='v_dupRadar.txt')"
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -328,6 +328,7 @@ process get_software_versions {
     picard MarkDuplicates --version &> v_markduplicates.txt  || true
     samtools --version &> v_samtools.txt
     multiqc --version &> v_multiqc.txt
+    edgeR --version &> v_edgeR.txt
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
 }


### PR DESCRIPTION
Added an edgeR --version command because this information is missing in the MultiQC report (I hope this simply works for edgeR too).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] `CHANGELOG.md` is updated