### PR TITLE
force matplotlib to be 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * trim-galore 0.5.0 -> 0.6.1
 * qualimap 2.2.2b
 * matplotlib 3.0.3
+* r-base 3.5.1
 
 ## [Version 1.2](https://github.com/nf-core/rnaseq/releases/tag/1.2) - 2018-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 1.4dev
 
 #### Dependency Updates
+* Force matplotlib=3.0.3
 * Added salmon=0.14.0
 
 ## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
@@ -46,6 +47,7 @@
 * deeptools 3.2.0 -> 3.2.1
 * trim-galore 0.5.0 -> 0.6.1
 * qualimap 2.2.2b
+* matplotlib 3.0.3
 
 ## [Version 1.2](https://github.com/nf-core/rnaseq/releases/tag/1.2) - 2018-12-12
 

--- a/environment.yml
+++ b/environment.yml
@@ -28,3 +28,4 @@ dependencies:
   - multiqc=1.7
   - salmon=0.14.0
   - matplotlib=3.0.3
+  - r-base=3.5.1

--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - deeptools=3.2.1
   - multiqc=1.7
   - salmon=0.14.0
+  - matplotlib=3.0.3


### PR DESCRIPTION
There is an error right now that makes multiqc fails in fastqc, qualimap and similar in travis.

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [X] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
