### PR TITLE
Minor edit to installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ The process is very similar: running the pipeline with the option `-profile sing
 If running offline with Singularity, you'll need to download and transfer the Singularity image first:
 
 ```bash
-singularity pull --name nf-core-rnaseq-1.3.img docker://nf-core/rnaseq:1.3
+singularity pull --name nf-core-rnaseq-1.3.img docker://nfcore/rnaseq:1.3
 ```
 
 > NB: The "tag" at the end of this command corresponds to the pipeline version.


### PR DESCRIPTION
Minor edit: the docker container name does not have a hyphen. Although, you may prefer to change this such that it pulls the singularity image directly.

I ran into this while testing a pipeline with singularity.

