### PR TITLE
Minimize memory footprint of `merge_featurecounts`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - preseq=2.0.3
   - deeptools=3.2.1
   - gffread=0.11.4
-  - csvtk=0.18.2
   - qualimap=2.2.2c
   - rseqc=3.0.0
   - subread=1.6.4

--- a/main.nf
+++ b/main.nf
@@ -1051,7 +1051,7 @@ process merge_featureCounts {
     gene_ids = "<(tail -n +2 ${input_files[0]} | cut -f1,7 )"
     counts = input_files.collect{filename ->
       // Remove first line and take third column
-      "<(tail -n +2 ${filename} | cut -f3)"}.join(" ")
+      "<(tail -n +2 ${filename} | sed 's:.sorted.bam::' | cut -f8)"}.join(" ")
     """
     paste $gene_ids $counts > merged_gene_counts.txt
     """

--- a/main.nf
+++ b/main.nf
@@ -1049,7 +1049,7 @@ process clean_featureCounts {
     gene_ids = "${input_file}_gene_ids.txt"
     """
     csvtk cut -t -f "-Start,-Chr,-End,-Length,-Strand" $input_file \\
-        | sed 's/Aligned.sortedByCoord.out.markDups.bam//g' \\
+        | sed 's/Aligned.sortedByCoord.out.bam//g' \\
         > $intermediate
     cut -f 3 $intermediate > $counts
     cut -f 1,2 $intermediate > $gene_ids

--- a/main.nf
+++ b/main.nf
@@ -1046,8 +1046,10 @@ process merge_featureCounts {
     file 'merged_gene_counts.txt' into featurecounts_merged
 
     script:
-    gene_ids = "<(cut -f1,2 ${input_files[0]})"
-    counts = input_files.collect{filename -> "<(cut -f3 ${filename})"}.join(" ")
+    gene_ids = "<(tail -n +2 ${input_files[0]} | cut -f1,2 )"
+    counts = input_files.collect{filename ->
+      // Remove first line and take third column
+      "<(tail -n +2 ${filename} | cut -f3)"}.join(" ")
     """
     paste $gene_ids $counts > merged_gene_counts.txt
     """

--- a/main.nf
+++ b/main.nf
@@ -1046,6 +1046,7 @@ process merge_featureCounts {
     file 'merged_gene_counts.txt' into featurecounts_merged
 
     script:
+    // Redirection (the `<()`) for the win!
     gene_ids = "<(tail -n +2 ${input_files[0]} | cut -f1,2 )"
     counts = input_files.collect{filename ->
       // Remove first line and take third column

--- a/main.nf
+++ b/main.nf
@@ -1034,19 +1034,20 @@ process featureCounts {
  * STEP 10 - Clean featurecounts
  */
 process clean_featureCounts {
-    tag "${input_files[0].baseName - '.sorted'}"
+    tag "${input_file[0].baseName - '.sorted'}"
 
     input:
-    file input_files from featureCounts_to_clean.collect()
+    file input_file from featureCounts_to_clean
 
     output:
-    file featureCounts_to_merge
+    file output into featureCounts_to_merge
 
     script:
+    output = "${input_file}_cleaned.txt"
     """
-    csvtk cut -t -f "-Start,-Chr,-End,-Length,-Strand" \\
+    csvtk cut -t -f "-Start,-Chr,-End,-Length,-Strand" $input_file \\
         | sed 's/Aligned.sortedByCoord.out.markDups.bam//g' \\
-        > $featureCounts_to_merge
+        > $output
     """
 }
 
@@ -1066,7 +1067,7 @@ process merge_featureCounts {
 
     script:
     //if we only have 1 file, just use cat and pipe output to csvtk. Else join all files first, and then remove unwanted column names.
-    def merge = input_files instanceof Path ? 'cat' : 'csvtk join -t -f "Geneid,Start,Length,End,Chr,Strand,gene_name"'
+    def merge = input_files instanceof Path ? 'cat' : 'csvtk join -t -f "Geneid,gene_name"'
     """
     $merge $input_files > merged_gene_counts.txt
     """

--- a/main.nf
+++ b/main.nf
@@ -1047,7 +1047,8 @@ process merge_featureCounts {
 
     script:
     // Redirection (the `<()`) for the win!
-    gene_ids = "<(tail -n +2 ${input_files[0]} | cut -f1,2 )"
+    // Geneid in 1st column and gene_name in 7th
+    gene_ids = "<(tail -n +2 ${input_files[0]} | cut -f1,7 )"
     counts = input_files.collect{filename ->
       // Remove first line and take third column
       "<(tail -n +2 ${filename} | cut -f3)"}.join(" ")

--- a/main.nf
+++ b/main.nf
@@ -1110,7 +1110,7 @@ if (params.pseudo_aligner == 'salmon'){
         }
 
     process salmon_merge {
-      label 'low_memory'
+      label 'mid_memory'
       publishDir "${params.outdir}/salmon", mode: 'copy'
 
       input:


### PR DESCRIPTION
Hello,
In running the current `salmon` pipeline on a "small" dataset of ~300 RNA-seq samples, the `merge_featurecounts` step errored out with exit code `255`. Looking into it more, it seems that the operation ran out of memory. I was able to run this on a local machine and the `.command.trace` output showed that it used ~21.GB of memory:

```
nextflow.trace/v2
realtime=140436
%cpu=1645
rchar=12498004788
wchar=163107620
syscr=1531666
syscw=25205
read_bytes=131072
write_bytes=43253760
%mem=10
vmem=21335476
rss=21111964
peak_vmem=21335476
peak_rss=21111964
vol_ctxt=5289
inv_ctxt=227
```

As we will be using this pipeline on ~6000+ samples at a time, it's critical to us that the memory footprint of merging these counts is minimized to prevent failure. This PR separates out the `csvtk cut` and `csvtk join` steps to hopefully decrease the memory needed to merge the featurecounts matrices.

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
