### PR TITLE
Use `file` instead of `new File`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixing HISAT2 Index Building for large reference genomes [#153](https://github.com/nf-core/rnaseq/issues/153)
 * Fixing HISAT2 BAM sorting using more memory than available on the system
 * Fixing MarkDuplicates memory consumption issues following [#179](https://github.com/nf-core/rnaseq/pull/179)
+* Use `file` instead of `new File` to create the `pipeline_report.{html,txt}` files to avoid creating local directories when outputting to AWS S3 folders
 
 
 #### Dependency Updates

--- a/main.nf
+++ b/main.nf
@@ -1209,13 +1209,13 @@ workflow.onComplete {
     }
 
     // Write summary e-mail HTML to a file
-    def output_d = new File( "${params.outdir}/pipeline_info/" )
+    def output_d = file( "${params.outdir}/pipeline_info/" )
     if( !output_d.exists() ) {
       output_d.mkdirs()
     }
-    def output_hf = new File( output_d, "pipeline_report.html" )
+    def output_hf = file( output_d, "pipeline_report.html" )
     output_hf.withWriter { w -> w << email_html }
-    def output_tf = new File( output_d, "pipeline_report.txt" )
+    def output_tf = file( output_d, "pipeline_report.txt" )
     output_tf.withWriter { w -> w << email_txt }
 
     c_reset = params.monochrome_logs ? '' : "\033[0m";


### PR DESCRIPTION
As I learned [here](https://github.com/nextflow-io/nextflow/issues/1185), `file` != `new File` and `new File` doesn't know how to handle S3 paths. This leads to weird behavior like creating an `s3:` folder, with all the bucket "subfolders" when a pipeline is run:
```
 Thu 27 Jun - 09:03  ~/code/nf-core/rnaseq   origin ☊ olgabot/salmon-gencode ✔ 28☀ 
  ll --tree s3:
Permissions Size User    Date Modified Git Name
drwxr-xr-x     - olgabot 11 Jun 10:26   -- s3:
drwxr-xr-x     - olgabot 11 Jun 10:26   -- └── olgabot-maca
drwxr-xr-x     - olgabot 11 Jun 10:26   --    └── mini-maca
drwxr-xr-x     - olgabot 11 Jun 10:26   --       └── results
drwxr-xr-x     - olgabot 11 Jun 10:26   --          └── pipeline_info
.rw-r--r--   12k olgabot 11 Jun 16:40   --             ├── pipeline_report.html
.rw-r--r--  2.7k olgabot 11 Jun 16:40   --             └── pipeline_report.txt
```

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
