### PR TITLE
Use format strings to create new files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
 * Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183): added the folder "multiqc_plots" to the output.
 * Get MultiQC to write out the software versions in a .csv file [#185](https://github.com/nf-core/rnaseq/issues/185)
+* Use `file` instead of `new File` to create `pipeline_report.{html,txt}` files, and properly create subfolders
 
 ### Dependency Updates
 

--- a/main.nf
+++ b/main.nf
@@ -1263,9 +1263,9 @@ workflow.onComplete {
     if( !output_d.exists() ) {
       output_d.mkdirs()
     }
-    def output_hf = file( output_d, "pipeline_report.html" )
+    def output_hf = file( "${output_d}/pipeline_report.html" )
     output_hf.withWriter { w -> w << email_html }
-    def output_tf = file( output_d, "pipeline_report.txt" )
+    def output_tf = file( "${output_d}/pipeline_report.txt" )
     output_tf.withWriter { w -> w << email_txt }
 
     c_reset = params.monochrome_logs ? '' : "\033[0m";


### PR DESCRIPTION
Although the previous PR (https://github.com/nf-core/rnaseq/pull/245) passed the tests, `workflow.onComplete` failed to invoke because `file` can't take a list of paths like `new File` does. See the bottom of the build [here](https://travis-ci.org/nf-core/rnaseq/jobs/551913760)

```
ERROR ~ Failed to invoke `workflow.onComplete` event handler
 -- Check script 'main.nf' at line: 1266 or see '.nextflow.log' file for more details
```

My bad for not spotting this earlier 😅 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
