### PR TITLE
Lpantano patch fix samplenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Pipeline updates
 
+* Fix sample names in feature counts and dupRadar to remove suffixes added in other processes
 * Removed `genebody_coverage` process [#195](https://github.com/nf-core/rnaseq/issues/195)
 * Implemented Pearsons correlation instead of euclidean distance [#146](https://github.com/nf-core/rnaseq/issues/146)
 * Add `--stringTieIgnoreGTF` parameter [#206](https://github.com/nf-core/rnaseq/issues/206)

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -1,8 +1,8 @@
 extra_fn_clean_exts:
-    - _R1
-    - _R2
-    - .hisat
-    - '.sorted.markDups'
+    - '_R1'
+    - '_R2'
+    - '.hisat'
+    - '_subsamp'
     - '.sorted'
 
 report_comment: >

--- a/bin/dupRadar.r
+++ b/bin/dupRadar.r
@@ -20,6 +20,9 @@ if(is.na(threads) || (threads<=0)) stop("Fifth argument <nbThreads> must be a st
 
 # Remove bam file extension to generate basename
 input_bam_basename <- gsub(bamRegex, "\\1", input_bam)
+input_bam_basename <- gsub("_subsamp.*", "", input_bam_basename)
+input_bam_basename <- gsub("\\.sorted.*", "", input_bam_basename)
+input_bam_basename <- gsub("Aligned.*", "", input_bam_basename)
 
 # Debug messages (stderr)
 message("Input bam      (Arg 1): ", input_bam)

--- a/bin/mqc_features_stat.py
+++ b/bin/mqc_features_stat.py
@@ -47,7 +47,7 @@ def mqc_feature_stat(bfile, features, outfile, sname=None):
         return
 
     # Calculate percentage for each requested feature
-    fpercent = {f: (fcounts[f]/total_count)*100 for f in features if f in fcounts}
+    fpercent = {f: (fcounts[f]/total_count)*100 if f in fcounts else 0 for f in features}
     if len(fpercent) == 0:
         logger.error("Any of given features '{}' not found in the biocount file".format(", ".join(features), bfile))
         return


### PR DESCRIPTION
Fixes samplenames in the output files and multiqc report:

* Fix seqCenter to seq_center
* featureCounts  will have different names depending on the aligner. This removes all the suffixes added at some point
* dupRadar will show a name with suffixes not possible to fix during multiqc parsing. Changing the script to match the initial names
* fix script mqc_feature_stats.py to not fail if rRNA is not in the gtf file

## PR checklist
 - [X] This comment contains a description of changes (with reason)
 - [NA] If you've fixed a bug or added code that should be tested, add tests!
 - [NA] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [X] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [NA] Documentation in `docs` is updated
 - [X] `CHANGELOG.md` is updated
 - [NA] `README.md` is updated

