### PR TITLE
Patch to be compatible with nuclear RNA 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,5 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon
   # Run with Salmon and no alignment
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon --skipAlignment
+  # Run with --fc_count_type transcript
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --fc_count_type transcript

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,5 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon
   # Run with Salmon and no alignment
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon --skipAlignment
-  # Run with --fc_count_type transcript
+  # Run with --fc_count_type transcript - test nuclear RNA
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --fc_count_type transcript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Pipeline updates
 
+* Add option to modify `featureCounts -t` option to assign reads to a different type than `exon`. This makes it compatible with nuclearRNAseq.
 * Fix sample names in feature counts and dupRadar to remove suffixes added in other processes
 * Removed `genebody_coverage` process [#195](https://github.com/nf-core/rnaseq/issues/195)
 * Implemented Pearsons correlation instead of euclidean distance [#146](https://github.com/nf-core/rnaseq/issues/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Pipeline updates
 
-* Add option to modify `featureCounts -t` option to assign reads to a different type than `exon`. This makes it compatible with nuclearRNAseq.
+* Add option to modify `featureCounts -t` option to assign reads to a different type than `exon`. This makes it compatible with nuclearRNAseq. For instance, it would count reads in introns and exons if `gene` is used instead. Nuclear RNA has un-spliced RNA, and introns need to be counted.
 * Fix sample names in feature counts and dupRadar to remove suffixes added in other processes
 * Removed `genebody_coverage` process [#195](https://github.com/nf-core/rnaseq/issues/195)
 * Implemented Pearsons correlation instead of euclidean distance [#146](https://github.com/nf-core/rnaseq/issues/146)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@
 * [FeatureCounts Extra Gene Names](#featurecounts-extra-gene-names)
   * [Default Attribute Type](#default-attribute-type)
   * [Extra Gene Names](#extra-gene-names)
+  * [Default Attribute](#default-type)
 * [Transcriptome mapping with Salmon](#transcriptome-mapping-with-salmon)
 * [Alignment tool](#alignment-tool)
 * [Reference genomes](#reference-genomes)
@@ -186,7 +187,6 @@ These flags affect the commands used for several steps in the pipeline - namely 
 ## FeatureCounts Extra Gene Names
 
 ### Default Attribute Type
-
 By default, the pipeline uses `gene_name` as the default gene identifier group. In case you need to adjust this, specify using the option `--fc_group_features` to use a different category present in your provided GTF file. Please also take care to use a suitable attribute to categorize the `biotype` of the selected features in your GTF then, using the option `--fc_group_features_type` (default: `gene_biotype`).
 
 ### Extra Gene Names
@@ -195,6 +195,9 @@ This behaviour can be modified by specifying `--fc_extra_attributes` when runnin
 See the user guide of the [Subread package here](http://bioinf.wehi.edu.au/subread-package/SubreadUsersGuide.pdf).
 Note that you can also specify more than one desired value, separated by a comma:
 ``--fc_extra_attributes gene_id,...``
+
+### Default Type
+By default, the pipeline uses `exon` as the default to assign reads. In case you need to adjust this, specify using the option `--fc_count_type` to use a different category present in your provided GTF file (3rd column).
 
 ## Transcriptome mapping with Salmon
 

--- a/main.nf
+++ b/main.nf
@@ -1046,7 +1046,7 @@ if (!params.skipAlignment){
           featureCounts_direction = 2
       }
       // Try to get real sample name
-      sample_name = bam_featurecounts.baseName - 'Aligned.sortedByCoord.out'
+      sample_name = bam_featurecounts.baseName - 'Aligned.sortedByCoord.out' - '_subsamp.sorted'
       """
       featureCounts -a $gtf -g ${params.fc_group_features} -t ${params.fc_count_type} -o ${bam_featurecounts.baseName}_gene.featureCounts.txt $extraAttributes -p -s $featureCounts_direction $bam_featurecounts
       featureCounts -a $gtf -g $biotype -o ${bam_featurecounts.baseName}_biotype.featureCounts.txt -p -s $featureCounts_direction $bam_featurecounts

--- a/main.nf
+++ b/main.nf
@@ -1047,7 +1047,7 @@ if (!params.skipAlignment){
       // Try to get real sample name
       sample_name = bam_featurecounts.baseName - 'Aligned.sortedByCoord.out'
       """
-      featureCounts -a $gtf -g ${params.fc_group_features} -o ${bam_featurecounts.baseName}_gene.featureCounts.txt $extraAttributes -p -s $featureCounts_direction $bam_featurecounts
+      featureCounts -a $gtf -g ${params.fc_group_features} -t ${params.fc_group_features_count} -o ${bam_featurecounts.baseName}_gene.featureCounts.txt $extraAttributes -p -s $featureCounts_direction $bam_featurecounts
       featureCounts -a $gtf -g $biotype -o ${bam_featurecounts.baseName}_biotype.featureCounts.txt -p -s $featureCounts_direction $bam_featurecounts
       cut -f 1,7 ${bam_featurecounts.baseName}_biotype.featureCounts.txt | tail -n +3 | cat $biotypes_header - >> ${bam_featurecounts.baseName}_biotype_counts_mqc.txt
       mqc_features_stat.py ${bam_featurecounts.baseName}_biotype_counts_mqc.txt -s $sample_name -f rRNA -o ${bam_featurecounts.baseName}_biotype_counts_gs_mqc.tsv

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,7 @@ params {
   // Read Counting
   fc_extra_attributes = 'gene_name'
   fc_group_features = 'gene_id'
-  fc_group_features_count = 'exon'
+  fc_count_type = 'exon'
   fc_group_features_type = 'gene_biotype'
   sampleLevel = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,7 @@ params {
   // Read Counting
   fc_extra_attributes = 'gene_name'
   fc_group_features = 'gene_id'
+  fc_group_features_count = 'exon'
   fc_group_features_type = 'gene_biotype'
   sampleLevel = false
 


### PR DESCRIPTION
This PR contains an addition to allow to assign reads to other `type` different than `exon`. For instance, RNA from nuclear samples have a lot of introns, and they are missed here.

As well, I fixed an old `seqCenter` reference and cleaned the names of samples for the `rRNA` column in multiqc.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
