### PR TITLE
[WIP] Add option for gzipped fasta/gtf/bed/index files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,17 @@ sudo: required
 language: python
 services: docker
 cache: pip
+jdk: openjdk8
+
 matrix:
   fast_finish: true
   include:
   - name: "Minimum Nextflow version, regular test suite"
     env: NXF_VER='0.32.0' SUITE=test
-    jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test_gz
-    jdk: openjdk8
   - name: "Latest Nextflow version, gzipped references"
     env: NXF_VER='' SUITE=test_gz
-    jdk: openjdk8
   - name: "Lint the pipeline code"
     script: nf-core lint ${TRAVIS_BUILD_DIR}
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   include:
   - name: "Minimum Nextflow version, regular test suite with STAR aligner"
     env: NXF_VER='0.32.0' SUITE=test FLAGS=
+    language: java
     jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite with STAR aligner"
     env: NXF_VER='' SUITE=test FLAGS=

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,12 @@ script:
   # Lint the documentation
   - markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   # Run with STAR
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker
   # Run with HISAT2
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --aligner hisat2
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --aligner hisat2
   # Run with STAR and Salmon
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --pseudo_aligner salmon
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --pseudo_aligner salmon
   # Run with Salmon and no alignment
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --pseudo_aligner salmon --skipAlignment
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --pseudo_aligner salmon --skipAlignment
   # Additional gzipped-only things that are only invoked if $SUITE=test_gz
   - ./test-gzipped-star-hisat2-indices.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,6 @@ install:
   - sudo apt-get install npm && npm install -g markdownlint-cli
 
 script:
-  # Lint the pipeline code
-  - nf-core lint ${TRAVIS_BUILD_DIR}
-  # Lint the documentation
-  - markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   # Run with STAR
   - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker
   # Run with HISAT2

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,13 @@ script:
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon
   # Run with Salmon and no alignment
   - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon --skipAlignment
+  # Run with gzipped references
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker
+  # Run without STAR indices
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --star_index false
+  # Run with HiSat2 + gzipped reference
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --aligner hisat2
+  # Run with HiSat2 + do-it-yourself reference
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --aligner hisat2 --hisat2_index false
+  # Run with Salmon + pre-build gzipped indices
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --pseudo_aligner salmon

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,25 @@ jdk: openjdk8
 matrix:
   fast_finish: true
   include:
-  - name: "Minimum Nextflow version, regular test suite"
-    env: NXF_VER='0.32.0' SUITE=test
+  - name: "Minimum Nextflow version, regular test suite with STAR aligner"
+    env: NXF_VER='0.32.0' SUITE=test FLAGS=
     jdk: openjdk8
-  - name: "Latest Nextflow version, regular test suite"
-    env: NXF_VER='' SUITE=test_gz
-  - name: "Latest Nextflow version, gzipped references"
-    env: NXF_VER='' SUITE=test_gz
+  - name: "Latest Nextflow version, regular test suite with STAR aligner"
+    env: NXF_VER='' SUITE=test FLAGS=
+  - name: "Latest Nextflow version, with HiSat2 aligner"
+    env: NXF_VER='' SUITE=test FLAGS='--aligner hisat2 --skipQC'
+  - name: "Latest Nextflow version, with Salmon pseudo-aligner"
+    env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
+  - name: "Latest Nextflow version, with Salmon pseudo-aligner and skipping alignment"
+    env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
+  - name: "Latest Nextflow version, gzipped references with STAR aligner"
+    env: NXF_VER='' SUITE=test_gz FLAGS=
+  - name: "Latest Nextflow version, gzipped references with HiSat2 aligner"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--aligner hisat2 --skipQC'
+  - name: "Latest Nextflow version, gzipped references with Salmon pseudo-aligner"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC'
+  - name: "Latest Nextflow version, gzipped references with Salmon pseudo-aligner and skipping alignment"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC'
   - name: "Lint the pipeline code"
     script: nf-core lint ${TRAVIS_BUILD_DIR}
     python: '3.6'
@@ -47,12 +59,6 @@ install:
 
 script:
   # Run with STAR
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker
-  # Run with HISAT2
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --aligner hisat2
-  # Run with STAR and Salmon
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --pseudo_aligner salmon
-  # Run with Salmon and no alignment
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker --pseudo_aligner salmon --skipAlignment
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker ${FLAGS}
   # Additional gzipped-only things that are only invoked if $SUITE=test_gz
   - ./test-gzipped-star-hisat2-indices.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   include:
   - name: "Minimum Nextflow version, regular test suite"
     env: NXF_VER='0.32.0' SUITE=test
+    jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test_gz
   - name: "Latest Nextflow version, gzipped references"
@@ -17,6 +18,7 @@ matrix:
     script: nf-core lint ${TRAVIS_BUILD_DIR}
     python: '3.6'
     env: NXF_VER='0.32.0'
+    jdk: openjdk8
   - name: "Lint the documentation"
     script: markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ matrix:
   include:
   - name: "Minimum Nextflow version, regular test suite"
     env: NXF_VER='0.32.0' SUITE=test
-  # - name: "Minimum Nextflow version, gzipped references"
-  #   env: NXF_VER='0.32.0' SUITE=test
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test_gz
   - name: "Latest Nextflow version, gzipped references"
     env: NXF_VER='' SUITE=test_gz
+  - name: "Lint the pipeline code"
+    script: nf-core lint ${TRAVIS_BUILD_DIR}
+  - name: "Lint the documentation"
+    script: markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
 
 before_install:
   # PRs to master are only ok if coming from dev branch
@@ -37,12 +39,6 @@ install:
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
   # Install markdownlint-cli
   - sudo apt-get install npm && npm install -g markdownlint-cli
-
-env:
-  - NXF_VER='0.32.0' SUITE=test # Specify a minimum NF version that should be tested and work
-  - NXF_VER='' SUITE=test  # Plus: get the latest NF version and check that it works
-  - NXF_VER='0.32.0' SUITE=test_gz # Specify a minimum NF version that should be tested and work
-  - NXF_VER='' SUITE=test_gz  # Plus: get the latest NF version and check that it works
 
 script:
   # Lint the pipeline code

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   - name: "Latest Nextflow version, regular test suite with STAR aligner"
     env: NXF_VER='' SUITE=test FLAGS=
   - name: "Latest Nextflow version, regular test suite with STAR aligner, force GFF"
-    env: NXF_VER='' SUITE=test FLAGS=--gtf false
+    env: NXF_VER='' SUITE=test FLAGS='--gtf false'
   - name: "Latest Nextflow version, skipQC, with HiSat2 aligner"
     env: NXF_VER='' SUITE=test FLAGS='--aligner hisat2 --skipQC'
   - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,15 @@ python: '3.6'
 cache: pip
 matrix:
   fast_finish: true
+  include:
+  - name: "Minimum Nextflow version, regular test suite"
+    env: NXF_VER='0.32.0' SUITE=test
+  # - name: "Minimum Nextflow version, gzipped references"
+  #   env: NXF_VER='0.32.0' SUITE=test
+  - name: "Latest Nextflow version, regular test suite"
+    env: NXF_VER='' SUITE=test_gz
+  - name: "Latest Nextflow version, gzipped references"
+    env: NXF_VER='' SUITE=test_gz
 
 before_install:
   # PRs to master are only ok if coming from dev branch
@@ -30,8 +39,10 @@ install:
   - sudo apt-get install npm && npm install -g markdownlint-cli
 
 env:
-  - NXF_VER='0.32.0' # Specify a minimum NF version that should be tested and work
-  - NXF_VER='' # Plus: get the latest NF version and check that it works
+  - NXF_VER='0.32.0' SUITE=test # Specify a minimum NF version that should be tested and work
+  - NXF_VER='' SUITE=test  # Plus: get the latest NF version and check that it works
+  - NXF_VER='0.32.0' SUITE=test_gz # Specify a minimum NF version that should be tested and work
+  - NXF_VER='' SUITE=test_gz  # Plus: get the latest NF version and check that it works
 
 script:
   # Lint the pipeline code
@@ -39,20 +50,12 @@ script:
   # Lint the documentation
   - markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
   # Run with STAR
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker
   # Run with HISAT2
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --aligner hisat2
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --aligner hisat2
   # Run with STAR and Salmon
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --pseudo_aligner salmon
   # Run with Salmon and no alignment
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test,docker --pseudo_aligner salmon --skipAlignment
-  # Run with gzipped references
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker
-  # Run without STAR indices
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --star_index false
-  # Run with HiSat2 + gzipped reference
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --aligner hisat2
-  # Run with HiSat2 + do-it-yourself reference
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --aligner hisat2 --hisat2_index false
-  # Run with Salmon + pre-build gzipped indices
-  - nextflow run ${TRAVIS_BUILD_DIR} -profile test_gz,docker --pseudo_aligner salmon
+  - nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --pseudo_aligner salmon --skipAlignment
+  # Additional gzipped-only things that are only invoked if $SUITE=test_gz
+  - ./test-gzipped-star-hisat2-indices.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,25 @@ matrix:
     jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite with STAR aligner"
     env: NXF_VER='' SUITE=test FLAGS=
-  - name: "Latest Nextflow version, with HiSat2 aligner"
+  - name: "Latest Nextflow version, skipQC, with HiSat2 aligner"
     env: NXF_VER='' SUITE=test FLAGS='--aligner hisat2 --skipQC'
-  - name: "Latest Nextflow version, with Salmon pseudo-aligner"
+  - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner"
     env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
-  - name: "Latest Nextflow version, with Salmon pseudo-aligner and skipping alignment"
+  - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner and skipping alignment"
     env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
-  - name: "Latest Nextflow version, gzipped references with STAR aligner"
+  - name: "Latest Nextflow version, skipQC, gzipped references with STAR aligner"
     env: NXF_VER='' SUITE=test_gz FLAGS=
-  - name: "Latest Nextflow version, gzipped references with HiSat2 aligner"
+  - name: "Latest Nextflow version, skipQC, gzipped references with HiSat2 aligner + premade indices"
     env: NXF_VER='' SUITE=test_gz FLAGS='--aligner hisat2 --skipQC'
-  - name: "Latest Nextflow version, gzipped references with Salmon pseudo-aligner"
+  - name: "Latest Nextflow version, skipQC, gzipped references with Salmon pseudo-aligner + premade indices"
     env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC'
-  - name: "Latest Nextflow version, gzipped references with Salmon pseudo-aligner and skipping alignment"
-    env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC'
+  - name: "Latest Nextflow version, skipQC, gzipped references with Salmon pseudo-aligner + premade indices and skipping alignment"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC --skipAlignment'
+  - name: "Latest Nextflow version, skipQC, gzipped references, STAR aligner, make STAR index"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--star_index false --skipQC'
+  - name: "Latest Nextflow version, skipQC, gzipped references, HiSat2 aligner, make HiSat2 index"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--hisat2_index false --skipQC --aligner hisat2'
+
   - name: "Lint the pipeline code"
     install:
       # Install nf-core/tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,18 @@ matrix:
     env: NXF_VER='0.32.0' SUITE=test FLAGS=
     language: java
     jdk: openjdk8
-  - name: "Latest Nextflow version, regular test suite with STAR aligner + GFF"
+  - name: "Latest Nextflow version, regular test suite with STAR aligner"
     env: NXF_VER='' SUITE=test FLAGS=
-  - name: "Latest Nextflow version, regular test suite with STAR aligner, force GTF usage"
-    env: NXF_VER='' SUITE=test FLAGS=--gff false
+  - name: "Latest Nextflow version, regular test suite with STAR aligner, force GFF"
+    env: NXF_VER='' SUITE=test FLAGS=--gtf false
   - name: "Latest Nextflow version, skipQC, with HiSat2 aligner"
     env: NXF_VER='' SUITE=test FLAGS='--aligner hisat2 --skipQC'
   - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner"
     env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
   - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner and skipping alignment"
     env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC'
-  - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner, skipping alignment, force GTF usage"
-    env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC --gff false'
+  - name: "Latest Nextflow version, skipQC, with Salmon pseudo-aligner, skipping alignment, force GFF usage"
+    env: NXF_VER='' SUITE=test FLAGS='--pseudo_aligner salmon --skipQC --gtf false'
   - name: "Latest Nextflow version, skipQC, gzipped references with STAR aligner"
     env: NXF_VER='' SUITE=test_gz FLAGS=
   - name: "Latest Nextflow version, skipQC, gzipped references with HiSat2 aligner + premade indices"
@@ -33,8 +33,8 @@ matrix:
     env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC --skipAlignment'
   - name: "Latest Nextflow version, skipQC, gzipped references, STAR aligner, make STAR index"
     env: NXF_VER='' SUITE=test_gz FLAGS='--star_index false --skipQC'
-  - name: "Latest Nextflow version, skipQC, gzipped references, STAR aligner, make STAR index, force GTF usage"
-    env: NXF_VER='' SUITE=test_gz FLAGS='--star_index false --skipQC --gff false'
+  - name: "Latest Nextflow version, skipQC, gzipped references, STAR aligner, make STAR index, force GFF usage"
+    env: NXF_VER='' SUITE=test_gz FLAGS='--star_index false --skipQC --gtf false'
   - name: "Latest Nextflow version, skipQC, gzipped references, HiSat2 aligner, make HiSat2 index"
     env: NXF_VER='' SUITE=test_gz FLAGS='--hisat2_index false --skipQC --aligner hisat2'
   - name: "Lint the pipeline code"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   - name: "Lint the pipeline code"
     script: nf-core lint ${TRAVIS_BUILD_DIR}
     python: '3.6'
+    env: NXF_VER='0.32.0'
   - name: "Lint the documentation"
     script: markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
   - name: "Latest Nextflow version, gzipped references with Salmon pseudo-aligner and skipping alignment"
     env: NXF_VER='' SUITE=test_gz FLAGS='--pseudo_aligner salmon --skipQC'
   - name: "Lint the pipeline code"
+    install:
+      # Install nf-core/tools
+      - pip install --upgrade pip
+      - pip install nf-core
     script: nf-core lint ${TRAVIS_BUILD_DIR}
     python: '3.6'
     env: NXF_VER='0.32.0'
@@ -50,9 +54,6 @@ install:
   - mkdir /tmp/nextflow && cd /tmp/nextflow
   - wget -qO- get.nextflow.io | bash
   - sudo ln -s /tmp/nextflow/nextflow /usr/local/bin/nextflow
-  # Install nf-core/tools
-  - pip install --upgrade pip
-  - pip install nf-core
   # Reset
   - mkdir ${TRAVIS_BUILD_DIR}/tests && cd ${TRAVIS_BUILD_DIR}/tests
   # Install markdownlint-cli
@@ -62,4 +63,4 @@ script:
   # Run with STAR
   - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker ${FLAGS}
   # Additional gzipped-only things that are only invoked if $SUITE=test_gz
-  - ./test-gzipped-star-hisat2-indices.sh
+  - ../test-gzipped-star-hisat2-indices.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,4 @@ script:
   # Run with STAR
   - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker ${FLAGS}
   # Additional gzipped-only things that are only invoked if $SUITE=test_gz
-  - ../test-gzipped-star-hisat2-indices.sh
+  - bash ../test-gzipped-star-hisat2-indices.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,25 @@
 sudo: required
 language: python
-jdk: openjdk8
 services: docker
-python: '3.6'
 cache: pip
 matrix:
   fast_finish: true
   include:
   - name: "Minimum Nextflow version, regular test suite"
     env: NXF_VER='0.32.0' SUITE=test
+    jdk: openjdk8
   - name: "Latest Nextflow version, regular test suite"
     env: NXF_VER='' SUITE=test_gz
+    jdk: openjdk8
   - name: "Latest Nextflow version, gzipped references"
     env: NXF_VER='' SUITE=test_gz
+    jdk: openjdk8
   - name: "Lint the pipeline code"
     script: nf-core lint ${TRAVIS_BUILD_DIR}
+    python: '3.6'
   - name: "Lint the documentation"
     script: markdownlint ${TRAVIS_BUILD_DIR} -c ${TRAVIS_BUILD_DIR}/.github/markdownlint.yml
+    python: '3.6'
 
 before_install:
   # PRs to master are only ok if coming from dev branch

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ matrix:
     env: NXF_VER='' SUITE=test_gz FLAGS='--star_index false --skipQC'
   - name: "Latest Nextflow version, skipQC, gzipped references, HiSat2 aligner, make HiSat2 index"
     env: NXF_VER='' SUITE=test_gz FLAGS='--hisat2_index false --skipQC --aligner hisat2'
-
   - name: "Lint the pipeline code"
     install:
       # Install nf-core/tools
@@ -67,5 +66,3 @@ install:
 script:
   # Run with STAR
   - nextflow run ${TRAVIS_BUILD_DIR} -profile ${SUITE},docker ${FLAGS}
-  # Additional gzipped-only things that are only invoked if $SUITE=test_gz
-  - bash ../test-gzipped-star-hisat2-indices.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Add `--gencode` option for compatibility of Salmon and featureCounts biotypes with GENCODE gene annotations
 * Use `file` instead of `new File` to create `pipeline_report.{html,txt}` files, and properly create subfolders
 * Add `--skipAlignment` option to only use pseudo-alignment and no alignment with STAR or HiSat2
+* Add `--compressedReference` option to use gzipped genome fasta and gene annotation files, and tar.gz'd STAR, HiSat2 and Salmon indices
 
 ### Dependency Updates
 

--- a/conf/test_gz.config
+++ b/conf/test_gz.config
@@ -1,0 +1,30 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/rnaseq -profile test
+ */
+
+params {
+  config_profile_name = 'Test profile'
+  config_profile_description = 'Minimal test dataset to check pipeline function'
+  // Limit resources so that this can run on Travis
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+  // Input data
+  singleEnd = true
+  readPaths = [
+    ['SRR4238351', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238351_subsamp.fastq.gz']],
+    ['SRR4238355', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238355_subsamp.fastq.gz']],
+    ['SRR4238359', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238359_subsamp.fastq.gz']],
+    ['SRR4238379', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238379_subsamp.fastq.gz']],
+  ]
+  // Genome references
+  fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fa.gz'
+  gtf = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf.gz'
+  transcript_fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta.gz'
+  compressedReference = true
+}

--- a/conf/test_gz.config
+++ b/conf/test_gz.config
@@ -23,12 +23,12 @@ params {
     ['SRR4238379', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238379_subsamp.fastq.gz']],
   ]
   // Genome references
-  fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genome.fa.gz'
-  gtf = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genes.gtf.gz'
-  gff = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genes.gff.gz'
+  fasta = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genome.fa.gz'
+  gtf = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gtf.gz'
+  gff = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gff.gz'
   transcript_fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta.gz'
-  hisat2_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/hisat2.tar.gz'
-  star_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/star.tar.gz'
-  salmon_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/salmon_index.tar.gz'
+  hisat2_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/hisat2.tar.gz'
+  star_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/star.tar.gz'
+  salmon_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/salmon_index.tar.gz'
   compressedReference = true
 }

--- a/conf/test_gz.config
+++ b/conf/test_gz.config
@@ -25,6 +25,7 @@ params {
   // Genome references
   fasta = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genome.fa.gz'
   gtf = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gtf.gz'
+  gff = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gff.gz'
   transcript_fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta.gz'
   hisat2_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/hisat2.tar.gz'
   star_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/star.tar.gz'

--- a/conf/test_gz.config
+++ b/conf/test_gz.config
@@ -23,8 +23,11 @@ params {
     ['SRR4238379', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238379_subsamp.fastq.gz']],
   ]
   // Genome references
-  fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fa.gz'
-  gtf = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf.gz'
+  fasta = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genome.fa.gz'
+  gtf = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gtf.gz'
   transcript_fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta.gz'
+  hisat2_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/hisat2.tar.gz'
+  star_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/star.tar.gz'
+  salmon_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/salmon_index.tar.gz'
   compressedReference = true
 }

--- a/conf/test_gz.config
+++ b/conf/test_gz.config
@@ -23,12 +23,12 @@ params {
     ['SRR4238379', ['https://github.com/nf-core/test-datasets/raw/rnaseq/testdata/SRR4238379_subsamp.fastq.gz']],
   ]
   // Genome references
-  fasta = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genome.fa.gz'
-  gtf = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gtf.gz'
-  gff = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/genes.gff.gz'
+  fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genome.fa.gz'
+  gtf = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genes.gtf.gz'
+  gff = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/genes.gff.gz'
   transcript_fasta = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta.gz'
-  hisat2_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/hisat2.tar.gz'
-  star_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/star.tar.gz'
-  salmon_index = 'https://github.com/czbiohub/test-datasets/raw/olgabot/subset-chrom-I-gzip/reference/salmon_index.tar.gz'
+  hisat2_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/hisat2.tar.gz'
+  star_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/star.tar.gz'
+  salmon_index = 'https://github.com/nf-core/test-datasets/raw/rnaseq/reference/reference/salmon_index.tar.gz'
   compressedReference = true
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,13 @@
   * [`--saveTrimmed`](#--savetrimmed)
   * [`--saveAlignedIntermediates`](#--savealignedintermediates)
   * [`--gencode`](#--gencode)
+    * ["Type" of gene](#type-of-gene)
+    * [Transcript IDs in FASTA files](#transcript-ids-in-fasta-files)
   * [`--skipAlignment`](#--skipAlignment)
+  * [`--compressedReference`](#--compressedReference)
+    * [Create compressed (tar.gz) STAR indices](#create-compressed-tar-gz-star-indices)
+    * [Create compressed (tar.gz) HiSat2 indices](#create-compressed-tar-gz-hisat2-indices)
+    * [Create compressed (tar.gz) Salmon indices](#create-compressed-tar-gz-salmon-indices)
 * [Adapter Trimming](#adapter-trimming)
   * [`--clip_r1 [int]`](#--clip_r1-int)
   * [`--clip_r2 [int]`](#--clip_r2-int)
@@ -279,10 +285,6 @@ If your `--gtf` file is in GENCODE format and you would like to run Salmon (`--p
 
 [GENCODE](gencodegenes.org/) gene annotations are slightly different from ENSEMBL or iGenome annotations in two ways.
 
-### `--skipAlignment`
-By default, the pipeline aligns the input reads to the genome using either HISAT2 or STAR and counts gene expression using featureCounts. If you prefer to skip alignment altogehter and only get transcript/gene expression counts with pseudoalignment, use this flag. Note that you will also need to specify `--psuedo_aligner salmon`. If you have a custom transcriptome, supply that with `--transcript_fasta`.
-
-
 #### "Type" of gene
 
 The `gene_biotype` field which is typically found in Ensembl GTF files contains a key word description regarding the type of gene e.g. `protein_coding`, `lincRNA`, `rRNA`. In GENCODE GTF files this field has been renamed to `gene_type`.
@@ -320,6 +322,51 @@ GENCODE version:
 ```
 
 This [issue](https://github.com/COMBINE-lab/salmon/issues/15) can be overcome by specifying the `--gencode` flag when building the Salmon index.
+
+
+### `--skipAlignment`
+By default, the pipeline aligns the input reads to the genome using either HISAT2 or STAR and counts gene expression using featureCounts. If you prefer to skip alignment altogehter and only get transcript/gene expression counts with pseudoalignment, use this flag. Note that you will also need to specify `--psuedo_aligner salmon`. If you have a custom transcriptome, supply that with `--transcript_fasta`.
+
+
+### `--compressedReference`
+
+By default, the pipeline assumes that the reference genome files are all uncompressed, i.e. raw fasta or gtf files. If instead you intend to use compressed or gzipped references, like directly from ENSEMBL
+
+```
+nextflow run --reads 'data/{R1,R2}*.fastq.gz' --compressedReference \
+    --genome ftp://ftp.ensembl.org/pub/release-97/fasta/microcebus_murinus/dna_index/Microcebus_murinus.Mmur_3.0.dna.toplevel.fa.gz \
+    --gtf ftp://ftp.ensembl.org/pub/release-97/gtf/microcebus_murinus/Microcebus_murinus.Mmur_3.0.97.gtf.gz \
+```
+
+
+This assumes that ALL of the reference files are compressed,
+
+#### Create compressed (tar.gz) STAR indices
+
+STAR indices can be created by using `--saveReference`, and then using `tar` on them:
+
+```
+cd results/reference_genome
+tar -zcvf star.tar.gz star
+```
+
+#### HISAT2 indices
+
+HiSAT2 indices can be created by using `--saveReference`, and then using `tar` on them:
+
+```
+cd results/reference_genome
+tar -zcvf hisat2.tar.gz *.hisat2_*
+```
+
+#### Salmon index
+
+Salmon indices can be created by using `--saveReference`, and then using `tar` on them:
+
+```
+cd results/reference_genome
+tar -zcvf salmon_index.tar.gz salmon_index
+```
 
 
 ## Adapter Trimming

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -325,7 +325,7 @@ This [issue](https://github.com/COMBINE-lab/salmon/issues/15) can be overcome by
 
 
 ### `--skipAlignment`
-By default, the pipeline aligns the input reads to the genome using either HISAT2 or STAR and counts gene expression using featureCounts. If you prefer to skip alignment altogehter and only get transcript/gene expression counts with pseudoalignment, use this flag. Note that you will also need to specify `--psuedo_aligner salmon`. If you have a custom transcriptome, supply that with `--transcript_fasta`.
+By default, the pipeline aligns the input reads to the genome using either HISAT2 or STAR and counts gene expression using featureCounts. If you prefer to skip alignment altogether and only get transcript/gene expression counts with pseudo alignment, use this flag. Note that you will also need to specify `--pseudo_aligner salmon`. If you have a custom transcriptome, supply that with `--transcript_fasta`.
 
 
 ### `--compressedReference`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -330,16 +330,15 @@ By default, the pipeline aligns the input reads to the genome using either HISAT
 
 ### `--compressedReference`
 
-By default, the pipeline assumes that the reference genome files are all uncompressed, i.e. raw fasta or gtf files. If instead you intend to use compressed or gzipped references, like directly from ENSEMBL
+By default, the pipeline assumes that the reference genome files are all uncompressed, i.e. raw fasta or gtf files. If instead you intend to use compressed or gzipped references, like directly from ENSEMBL:
 
 ```
 nextflow run --reads 'data/{R1,R2}*.fastq.gz' --compressedReference \
     --genome ftp://ftp.ensembl.org/pub/release-97/fasta/microcebus_murinus/dna_index/Microcebus_murinus.Mmur_3.0.dna.toplevel.fa.gz \
-    --gtf ftp://ftp.ensembl.org/pub/release-97/gtf/microcebus_murinus/Microcebus_murinus.Mmur_3.0.97.gtf.gz \
+    --gtf ftp://ftp.ensembl.org/pub/release-97/gtf/microcebus_murinus/Microcebus_murinus.Mmur_3.0.97.gtf.gz
 ```
 
-
-This assumes that ALL of the reference files are compressed,
+This assumes that ALL of the reference files are compressed, including the reference indices, e.g. for STAR, HiSat2 or Salmon. For instructions on how to create your own compressed reference files, see the instructions below. This also includes any files specified with `--additional_fasta`, which are assumed to be compressed as well when the `--compressedReference` flag is used.
 
 #### Create compressed (tar.gz) STAR indices
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -332,7 +332,7 @@ By default, the pipeline aligns the input reads to the genome using either HISAT
 
 By default, the pipeline assumes that the reference genome files are all uncompressed, i.e. raw fasta or gtf files. If instead you intend to use compressed or gzipped references, like directly from ENSEMBL:
 
-```
+```bash
 nextflow run --reads 'data/{R1,R2}*.fastq.gz' --compressedReference \
     --genome ftp://ftp.ensembl.org/pub/release-97/fasta/microcebus_murinus/dna_index/Microcebus_murinus.Mmur_3.0.dna.toplevel.fa.gz \
     --gtf ftp://ftp.ensembl.org/pub/release-97/gtf/microcebus_murinus/Microcebus_murinus.Mmur_3.0.97.gtf.gz
@@ -344,7 +344,7 @@ This assumes that ALL of the reference files are compressed, including the refer
 
 STAR indices can be created by using `--saveReference`, and then using `tar` on them:
 
-```
+```bash
 cd results/reference_genome
 tar -zcvf star.tar.gz star
 ```
@@ -353,7 +353,7 @@ tar -zcvf star.tar.gz star
 
 HiSAT2 indices can be created by using `--saveReference`, and then using `tar` on them:
 
-```
+```bash
 cd results/reference_genome
 tar -zcvf hisat2.tar.gz *.hisat2_*
 ```
@@ -362,7 +362,7 @@ tar -zcvf hisat2.tar.gz *.hisat2_*
 
 Salmon indices can be created by using `--saveReference`, and then using `tar` on them:
 
-```
+```bash
 cd results/reference_genome
 tar -zcvf salmon_index.tar.gz salmon_index
 ```

--- a/main.nf
+++ b/main.nf
@@ -471,7 +471,7 @@ if (params.compressedReference){
 
         script:
         """
-        star_index_gz --verbose --stdout --force ${gz} > ${gz.baseName}
+        gunzip -k --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }

--- a/main.nf
+++ b/main.nf
@@ -469,7 +469,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
+        star_index_gz --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }
@@ -546,7 +546,7 @@ if (params.compressedReference){
         """
     }
   }
-  if (params.star_index && params.aligner == "star"){
+  if (!params.skipAlignment && params.star_index && params.aligner == "star"){
     process gunzip_star_index {
         tag "$gz"
         publishDir path: { params.saveReference ? "${params.outdir}/reference_genome/star" : params.outdir },
@@ -565,7 +565,7 @@ if (params.compressedReference){
         """
     }
   }
-  if (params.hisat2_index && params.aligner == 'hisat2'){
+  if (!params.skipAlignment && params.hisat2_index && params.aligner == 'hisat2'){
     process gunzip_hisat_index {
         tag "$gz"
         publishDir path: { params.saveReference ? "${params.outdir}/reference_genome/hisat2" : params.outdir },

--- a/main.nf
+++ b/main.nf
@@ -239,6 +239,10 @@ if ( params.pseudo_aligner == 'salmon' ) {
 }
 
 if( params.gtf ){
+  if ( params.gff ){
+    // Prefer gtf over gff
+    log.info "Prefer GTF over GFF, so ignoring provided GFF in favor of GTF"
+  }
   if (params.compressedReference){
     gtf_gz = Channel
         .fromPath(params.gtf, checkIfExists: true)
@@ -610,8 +614,6 @@ if (params.compressedReference){
 /*
  * PREPROCESSING - Convert GFF3 to GTF
  */
-// Prefer gtf over gff
-log.info "Prefer GTF over GFF, so ignoring provided GFF in favor of GTF"
 if(params.gff && !params.gtf){
     process convertGFFtoGTF {
         tag "$gff"

--- a/main.nf
+++ b/main.nf
@@ -334,6 +334,7 @@ summary['Run Name']         = custom_runName ?: workflow.runName
 summary['Reads']            = params.reads
 summary['Data Type']        = params.singleEnd ? 'Single-End' : 'Paired-End'
 if(params.genome) summary['Genome'] = params.genome
+summary['Gzipped Refs?'] = params.compressedReference
 if(params.pico) summary['Library Prep'] = "SMARTer Stranded Total RNA-Seq Kit - Pico Input"
 summary['Strandedness']     = ( unStranded ? 'None' : forwardStranded ? 'Forward' : reverseStranded ? 'Reverse' : 'None' )
 summary['Trimming']         = "5'R1: $clip_r1 / 5'R2: $clip_r2 / 3'R1: $three_prime_clip_r1 / 3'R2: $three_prime_clip_r2 / NextSeq Trim: $params.trim_nextseq"

--- a/main.nf
+++ b/main.nf
@@ -504,7 +504,7 @@ if (params.compressedReference){
         """
     }
   }
-  if (params.transcript_fasta){
+  if (params.transcript_fasta && params.pseudo_aligner == 'salmon'){
     process gunzip_transcript_fasta {
         tag "$gz"
         publishDir path: { params.saveReference ? "${params.outdir}/reference_transcriptome" : params.outdir },

--- a/main.nf
+++ b/main.nf
@@ -498,7 +498,7 @@ if (params.compressedReference){
         """
     }
   }
-  if (params.gff){
+  if (params.gff && !params.gtf){
     process gunzip_gff {
         tag "$gz"
         publishDir path: { params.saveReference ? "${params.outdir}/reference_genome" : params.outdir },

--- a/main.nf
+++ b/main.nf
@@ -488,7 +488,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
+        gunzip -k --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }

--- a/main.nf
+++ b/main.nf
@@ -40,6 +40,7 @@ def helpMessage() {
       --bed12                       Path to bed12 file
       --saveReference               Save the generated reference files to the results directory
       --gencode                     Use fc_group_features_type = 'gene_type' and pass '--gencode' flag to Salmon
+      --compressedReference         If provided, all reference files are assumed to be gzipped and will be unzipped before using
 
     Strandedness:
       --forwardStranded             The library is forward stranded
@@ -390,6 +391,10 @@ process get_software_versions {
     unset DISPLAY && qualimap rnaseq  > v_qualimap.txt 2>&1 || true
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
+}
+
+if (params.compressedReference){
+  
 }
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -469,7 +469,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip -v --force ${gz} > ${gz.baseName}
+        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }
@@ -488,7 +488,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip -v --force ${gz} > ${gz.baseName}
+        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }
@@ -506,7 +506,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip -v --force ${gz} > ${gz.baseName}
+        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }
@@ -524,7 +524,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip -v --force ${gz} > ${gz.baseName}
+        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }
@@ -542,7 +542,7 @@ if (params.compressedReference){
 
         script:
         """
-        gunzip -v --force ${gz} > ${gz.baseName}
+        gunzip --verbose --stdout --force ${gz} > ${gz.baseName}
         """
     }
   }

--- a/main.nf
+++ b/main.nf
@@ -452,10 +452,12 @@ if (params.compressedReference){
   // necessary indices for STAR, HiSAT2, Salmon already exist, or if
   // params.transcript_fasta is provided as then the transcript sequences don't
   // need to be extracted.
-  if (params.fasta && ((!params.skipAlignment &&
-                            !(params.star_index || params.hisat2_index))
-                        || (params.pseudo_aligner == "salmon"
-                              && !(params.transcript_fasta || params.salmon_index)))){
+  need_star_index = params.aligner == 'star' && !params.star_index
+  need_hisat2_index = params.aligner == 'hisat2' && !params.hisat2_index
+  need_aligner_index = need_hisat2_index || need_star_index
+  alignment_no_indices = !params.skipAlignment && need_aligner_index
+  psuedoalignment_no_indices = params.pseudo_aligner == "salmon" && !(params.transcript_fasta || params.salmon_index)
+  if (params.fasta && (alignment_no_indices || psuedoalignment_no_indices)){
     process gunzip_genome_fasta {
         tag "$gz"
         publishDir path: { params.saveReference ? "${params.outdir}/reference_genome" : params.outdir },

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
   splicesites = false
   saveReference = false
   gencode = false
+  compressedReference = false
 
   // Strandedness
   forwardStranded = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,6 +109,7 @@ profiles {
   docker { docker.enabled = true }
   singularity { singularity.enabled = true }
   test { includeConfig 'conf/test.config' }
+  test_gz { includeConfig 'conf/test_gz.config' }
 }
 
 // Load igenomes.config if required

--- a/test-gzipped-star-hisat2-indices.sh
+++ b/test-gzipped-star-hisat2-indices.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ev
+bundle exec rake:units
+if [ "${SUITE}" = "test_gz" ]; then
+  # Run without premade STAR indices - made within nextflow
+  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --star_index false
+
+  # Run with HiSat2 and no premade indices -- do-it-yourself reference
+  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --aligner hisat2 --hisat2_index false
+fi

--- a/test-gzipped-star-hisat2-indices.sh
+++ b/test-gzipped-star-hisat2-indices.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ev
-bundle exec rake:units
 if [ "${SUITE}" = "test_gz" ]; then
   # Run without premade STAR indices - made within nextflow
   nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --star_index false --skipQC

--- a/test-gzipped-star-hisat2-indices.sh
+++ b/test-gzipped-star-hisat2-indices.sh
@@ -3,8 +3,8 @@ set -ev
 bundle exec rake:units
 if [ "${SUITE}" = "test_gz" ]; then
   # Run without premade STAR indices - made within nextflow
-  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --star_index false
+  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --star_index false --skipQC
 
   # Run with HiSat2 and no premade indices -- do-it-yourself reference
-  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --aligner hisat2 --hisat2_index false
+  nextflow run ${TRAVIS_BUILD_DIR} -profile $SUITE,docker --aligner hisat2 --hisat2_index false --skipQC
 fi


### PR DESCRIPTION
Still a work in progress.. basically one could directly use http/ftp-hosted reference e.g. from ENSEMBL or GENCODE without needing to decompress them.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
~ - [ ] `README.md` is updated~
