### PR TITLE
Upping default walltime to 4.h

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -13,7 +13,7 @@ process {
 
   cpus = { check_max( 2, 'cpus' ) }
   memory = { check_max( 8.GB * task.attempt, 'memory' ) }
-  time = { check_max( 2.h * task.attempt, 'time' ) }
+  time = { check_max( 4.h * task.attempt, 'time' ) }
 
   errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'terminate' }
   maxRetries = 1


### PR DESCRIPTION
This update increases the minimum wall time to 4 hours. From our observations, 2 hour jobs would repeatedly run into the wall. Upping the limit to 4 hours seems like a non-invasive fix.  