### PR TITLE
Remove unnecessary string interpolation braces when defining memreqs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1151,7 +1151,7 @@ if (!params.skipAlignment){
       file "${bam.baseName}.markDups.bam.bai"
 
       script:
-      markdup_java_options = (task.memory.toGiga() > 8) ? ${params.markdup_java_options} : "\"-Xms" +  (task.memory.toGiga() / 2 )+"g "+ "-Xmx" + (task.memory.toGiga() - 1)+ "g\""
+      markdup_java_options = (task.memory.toGiga() > 8) ? params.markdup_java_options : "\"-Xms" +  (task.memory.toGiga() / 2 )+"g "+ "-Xmx" + (task.memory.toGiga() - 1)+ "g\""
       """
       picard ${markdup_java_options} MarkDuplicates \\
           INPUT=$bam \\


### PR DESCRIPTION
A very minor fix that corrects a groovy error that occurs when the user gives the markDuplicates process more than 8G of memory. 

Before the fix, the `main.nf` script runs the ternary operator check:

```
markdup_java_options = (task.memory.toGiga() > 8) ? ${params.markdup_java_options} : "Something else"
```

If the `task.memory.toGiga()` test evals to true, the first branch of the test is executed:
`${params.markdup_java_options}`. The dollar-brackets notation is only required inside string interpolation, which is not the case here - we just want the ternary operator to return the bare `params.markdup_java_options`.

This PR should resolve issue #293 

## PR checklist
 - [✓] This comment contains a description of changes (with reason)
 - [✘] If you've fixed a bug or added code that should be tested, add tests!
 - [✘] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [✓] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [✘] Make sure your code lints (`nf-core lint .`).
 - [✘] Documentation in `docs` is updated
 - [✘] `CHANGELOG.md` is updated
 - [✘] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
