### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ The process is very similar: running the pipeline with the option `-profile sing
 If running offline with Singularity, you'll need to download and transfer the Singularity image first:
 
 ```bash
-singularity pull --name nf-core-rnaseq-1.3.img docker://nf-core/rnaseq:1.3
+singularity pull --name nfcore-rnaseq-1.3.img docker://nfcore/rnaseq:1.3
 ```
 
 > NB: The "tag" at the end of this command corresponds to the pipeline version.
@@ -98,7 +98,7 @@ singularity pull --name nf-core-rnaseq-1.3.img docker://nf-core/rnaseq:1.3
 Once transferred, use `-with-singularity` and specify the path to the image file:
 
 ```bash
-nextflow run /path/to/nf-core-rnaseq -with-singularity /path/to/nf-core-rnaseq-1.3.img
+nextflow run /path/to/nf-core-rnaseq -with-singularity /path/to/nfcore-rnaseq-1.3.img
 ```
 
 Remember to pull updated versions of the singularity image if you update the pipeline.


### PR DESCRIPTION
Received an error when trying to download and transfer the singularity image using the command located in the Singularity, Running Offline section. See below:

```bash
"[user]$ singularity pull --name nf-core-rnaseq-1.3.img docker://nf-core/rnaseq:1.3
WARNING: pull for Docker Hub is not guaranteed to produce the
WARNING: same image on repeated pull. Use Singularity Registry
WARNING: (shub://) to pull exactly equivalent images.
Docker image path: index.docker.io/nf-core/rnaseq:1.3
ERROR UNAUTHORIZED: authentication required
ERROR Check existence, naming, and permissions
Cleaning up...
ERROR: pulling container failed!"
```
I found a related issue posted in a different nf-core pipeline (see here https://github.com/nf-core/chipseq/issues/8). And was able to fix the issue by removing the "-" in nf-core.

Many thanks to contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
