### PR TITLE
Fixed ansi summary, summary html logo, made skip pct configuratble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Minor tweaks to software version commands
 * Add information about SILVA licensing when removing rRNA to `usage.md`
+* Fixed ansi colours for pipeline summary, added summary logs of alignment results
 
 ## Version 1.4.2
 

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -29,7 +29,7 @@
     out << """
     <div style="color: #856404; background-color: #fff3cd; border-color: #ffeeba; padding: 15px; margin-bottom: 20px; border: 1px solid transparent; border-radius: 4px;">
         <h4 style="margin-top:0; color: inherit;">nf-core/rnaseq execution completed with warnings!</h4>
-        <p>The pipeline finished successfully, but the following samples were skipped due to very low alignment (&lt; 5%):</p>
+        <p>The pipeline finished successfully, but the following samples were skipped due to very low alignment (&lt; ${percent_aln_skip}%):</p>
         <ul>
             <li><code>${skipped_poor_alignment.join('</code></li><li><code>')}</code></li>
         </ul>

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -37,7 +37,7 @@ ${errorReport}
 ## nf-core/rnaseq execution completed with warnings ##
 ##################################################
 The pipeline finished successfully, but the following samples were skipped,
-due to very low alignment (less than 5%):
+due to very low alignment (less than ${percent_aln_skip}%):
 
   - ${skipped_poor_alignment.join("\n  - ")}
 """

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -600,6 +600,12 @@ allow the exon build to proceed by supplying `--hisat_build_memory 100GB`
 
 Used to turn of the edgeR MDS and heatmap. Set automatically when running on fewer than 3 samples.
 
+### `--percent_aln_skip`
+
+The pipeline will remove any samples from further processing that receive a percentage alignment below this.
+This is because downstream steps typically fail otherwise, halting the execution of the pipeline for all samples.
+Default: `5` (percent reads aligned).
+
 ### `--plaintext_email`
 
 Set to receive plain-text e-mails instead of HTML formatted.

--- a/main.nf
+++ b/main.nf
@@ -69,6 +69,7 @@ def helpMessage() {
       --saveAlignedIntermediates    Save the BAM files from the aligment step - not done by default
       --saveUnaligned               Save unaligned reads from either STAR, HISAT2 or Salmon to extra output files.
       --skipAlignment               Skip alignment altogether (usually in favor of pseudoalignment)
+      --percent_aln_skip            Percentage alignment below which samples are removed from further processing. Default: 5%
 
     Read Counting:
       --fc_extra_attributes         Define which extra parameters should also be included in featureCounts (default: 'gene_name')
@@ -998,7 +999,8 @@ if (!params.removeRiboRNA) {
  */
 // Function that checks the alignment rate of the STAR output
 // and returns true if the alignment passed and otherwise false
-skipped_poor_alignment = []
+good_alignment_scores = [:]
+poor_alignment_scores = [:]
 def check_log(logs) {
     def percent_aligned = 0;
     logs.eachLine { line ->
@@ -1007,12 +1009,16 @@ def check_log(logs) {
         }
     }
     logname = logs.getBaseName() - 'Log.final'
-    if (percent_aligned.toFloat() <= '5'.toFloat()) {
-        log.info "#################### VERY POOR ALIGNMENT RATE! IGNORING FOR FURTHER DOWNSTREAM ANALYSIS! ($logname)    >> ${percent_aligned}% <<"
-        skipped_poor_alignment << logname
+    c_reset = params.monochrome_logs ? '' : "\033[0m";
+    c_green = params.monochrome_logs ? '' : "\033[0;32m";
+    c_red = params.monochrome_logs ? '' : "\033[0;31m";
+    if (percent_aligned.toFloat() <= params.percent_aln_skip.toFloat()) {
+        log.info "#${c_red}################### VERY POOR ALIGNMENT RATE! IGNORING FOR FURTHER DOWNSTREAM ANALYSIS! ($logname)    >> ${percent_aligned}% <<${c_reset}"
+        poor_alignment_scores[logname] = percent_aligned
         return false
     } else {
-        log.info "          Passed alignment > star ($logname)   >> ${percent_aligned}% <<"
+        log.info "-${c_green}           Passed alignment > star ($logname)   >> ${percent_aligned}% <<${c_reset}"
+        good_alignment_scores[logname] = percent_aligned
         return true
     }
 }
@@ -1709,8 +1715,8 @@ workflow.onComplete {
 
     // Set up the e-mail variables
     def subject = "[nf-core/rnaseq] Successful: $workflow.runName"
-    if (skipped_poor_alignment.size() > 0) {
-        subject = "[nf-core/rnaseq] Partially Successful (${skipped_poor_alignment.size()} skipped): $workflow.runName"
+    if (poor_alignment_scores.size() > 0) {
+        subject = "[nf-core/rnaseq] Partially Successful (${poor_alignment_scores.size()} skipped): $workflow.runName"
     }
     if (!workflow.success) {
       subject = "[nf-core/rnaseq] FAILED: $workflow.runName"
@@ -1735,7 +1741,8 @@ workflow.onComplete {
     if (workflow.commitId) email_fields['summary']['Pipeline repository Git Commit'] = workflow.commitId
     if (workflow.revision) email_fields['summary']['Pipeline Git branch/tag'] = workflow.revision
     if (workflow.container) email_fields['summary']['Docker image'] = workflow.container
-    email_fields['skipped_poor_alignment'] = skipped_poor_alignment
+    email_fields['skipped_poor_alignment'] = poor_alignment_scores.keySet()
+    email_fields['percent_aln_skip'] = params.percent_aln_skip
     email_fields['summary']['Nextflow Version'] = workflow.nextflow.version
     email_fields['summary']['Nextflow Build'] = workflow.nextflow.build
     email_fields['summary']['Nextflow Compile Timestamp'] = workflow.nextflow.timestamp
@@ -1791,11 +1798,16 @@ workflow.onComplete {
         }
     }
 
-    // Write summary e-mail HTML to a file
+    // Write summaries to a file
+    // Make directory first if needed
     def output_d = new File("${params.outdir}/pipeline_info/")
     if (!output_d.exists()) {
         output_d.mkdirs()
     }
+    // Replace the email logo cid with a base64 encoded image
+    def logo_b64 = new File("$baseDir/assets/nf-core-rnaseq_logo.png").bytes.encodeBase64().toString()
+    email_html = email_html.replace('<img src="cid:nfcorepipelinelogo">', "<img src=\"data:image/png;base64, ${logo_b64}\">")
+    // Print to file
     def output_hf = file("${output_d}/pipeline_report.html")
     output_hf.withWriter { w -> w << email_html }
     def output_tf = file("${output_d}/pipeline_report.txt")
@@ -1806,20 +1818,40 @@ workflow.onComplete {
     c_green = params.monochrome_logs ? '' : "\033[0;32m";
     c_red = params.monochrome_logs ? '' : "\033[0;31m";
 
-    if (skipped_poor_alignment.size() > 0) {
-        log.info "${c_purple}[nf-core/rnaseq]${c_red} WARNING - ${skipped_poor_alignment.size()} samples skipped due to poor mapping percentages!${c_reset}"
+    if (good_alignment_scores.size() > 0){
+        total_aln_count = good_alignment_scores.size() + poor_alignment_scores.size()
+        idx = 0;
+        samp_aln = ''
+        for ( samp in good_alignment_scores ) {
+            samp_aln += "    ${samp.key}: ${samp.value}%\n"
+            idx += 1
+            if(idx > 5){
+                samp_aln += "    ..see pipeline reports for full list\n"
+                break;
+            }
+        }
+        log.info "[${c_purple}nf-core/rnaseq${c_reset}] ${c_green}${good_alignment_scores.size()}/$total_aln_count samples passed minimum ${params.percent_aln_skip}% aligned check\n${samp_aln}${c_reset}"
     }
+    if (poor_alignment_scores.size() > 0){
+        samp_aln = ''
+        poor_alignment_scores.each { samp, value ->
+            samp_aln += "    ${samp}: ${value}%\n"
+        }
+        log.info "[${c_purple}nf-core/rnaseq${c_reset}] ${c_red} WARNING - ${poor_alignment_scores.size()} samples skipped due to poor mapping percentages!\n${samp_aln}${c_reset}"
+    }
+
+
     if (workflow.stats.ignoredCount > 0 && workflow.success) {
-        log.info "${c_purple}Warning, pipeline completed, but with errored process(es) ${c_reset}"
-        log.info "${c_red}Number of ignored errored process(es) : ${workflow.stats.ignoredCount} ${c_reset}"
-        log.info "${c_green}Number of successfully ran process(es) : ${workflow.stats.succeedCount} ${c_reset}"
+        log.info "- ${c_purple}Warning, pipeline completed, but with errored process(es) ${c_reset}"
+        log.info "- ${c_red}Number of ignored errored process(es) : ${workflow.stats.ignoredCount} ${c_reset}"
+        log.info "- ${c_green}Number of successfully ran process(es) : ${workflow.stats.succeedCount} ${c_reset}"
     }
 
     if (workflow.success) {
-        log.info "${c_purple}[nf-core/rnaseq]${c_green} Pipeline completed successfully${c_reset}"
+        log.info "[${c_purple}nf-core/rnaseq${c_reset}] ${c_green} Pipeline completed successfully${c_reset}"
     } else {
         checkHostname()
-        log.info "${c_purple}[nf-core/rnaseq]${c_red} Pipeline completed with errors${c_reset}"
+        log.info "[${c_purple}nf-core/rnaseq${c_reset}] ${c_red} Pipeline completed with errors${c_reset}"
     }
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,7 @@ params {
   saveAlignedIntermediates = false
   skipAlignment = false
   saveUnaligned = false
+  percent_aln_skip = 5
 
   // Read Counting
   fc_extra_attributes = 'gene_name'


### PR DESCRIPTION
Started on one small thing and ended up fixing a bunch of minor things:

* Print summary of alignment scores on workflow completion (fixes #341)
* Made percentage threshold for skipping samples configurable
* Fixed ansi colours in summary log
* Fixed embedded logo in saved HTML report

![image](https://user-images.githubusercontent.com/465550/68749418-7b7f6500-05fe-11ea-83ee-986a35e9bba3.png)
_(NB: Normally shows up to 5 samples, this was testing that my code for truncating worked):_

---

If some samples don't make the cut (test run with `--percent_aln_skip 99.6`)

![image](https://user-images.githubusercontent.com/465550/68749457-8cc87180-05fe-11ea-816d-446ee3105360.png)

---

Saved HTML report now has proper logo instead of broken image in header:

![image](https://user-images.githubusercontent.com/465550/68749507-a10c6e80-05fe-11ea-9f0c-f8fa4e227f5e.png)
