### PR TITLE
enable RSeQC junction_annotation section in MultiQC report

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1207,6 +1207,7 @@ if (!params.skipAlignment) {
               else if (filename.indexOf("junction.xls") > 0)                      "junction_annotation/data/$filename"
               else if (filename.indexOf("splice_events.pdf") > 0)                 "junction_annotation/events/$filename"
               else if (filename.indexOf("splice_junction.pdf") > 0)               "junction_annotation/junctions/$filename"
+              else if (filename.indexOf("junction_annotation_log.txt") > 0)       "junction_annotation/$filename"
               else if (filename.indexOf("junctionSaturation_plot.pdf") > 0)       "junction_saturation/$filename"
               else if (filename.indexOf("junctionSaturation_plot.r") > 0)         "junction_saturation/rscripts/$filename"
               else filename
@@ -1226,9 +1227,9 @@ if (!params.skipAlignment) {
       script:
       """
       infer_experiment.py -i $bam_rseqc -r $bed12 > ${bam_rseqc.baseName}.infer_experiment.txt
-      junction_annotation.py -i $bam_rseqc -o ${bam_rseqc.baseName}.rseqc -r $bed12
+      junction_annotation.py -i $bam_rseqc -o ${bam_rseqc.baseName}.rseqc -r $bed12 2> ${bam_rseqc.baseName}.junction_annotation_log.txt
       bam_stat.py -i $bam_rseqc 2> ${bam_rseqc.baseName}.bam_stat.txt
-      junction_saturation.py -i $bam_rseqc -o ${bam_rseqc.baseName}.rseqc -r $bed12 2> ${bam_rseqc.baseName}.junction_annotation_log.txt
+      junction_saturation.py -i $bam_rseqc -o ${bam_rseqc.baseName}.rseqc -r $bed12
       inner_distance.py -i $bam_rseqc -o ${bam_rseqc.baseName}.rseqc -r $bed12
       read_distribution.py -i $bam_rseqc -r $bed12 > ${bam_rseqc.baseName}.read_distribution.txt
       read_duplication.py -i $bam_rseqc -o ${bam_rseqc.baseName}.read_duplication


### PR DESCRIPTION
This is PR no. 2 to address #347 
Catch the STDERRR of RSeQC junction_annotation instead of junction_saturation. Also save the log file in junction_annotation folder.
Changes tested and no need for documentation and tests updates.

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
