### PR TITLE
Fixes an issue where multiqc wont run with `--skipBiotypeQC` option (#353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 * Minor tweaks to software version commands
 * Add information about SILVA licensing when removing rRNA to `usage.md`
 * Fixed ansi colours for pipeline summary, added summary logs of alignment results
-* Fixes an issue where multiqc fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353) 
-
+* Fixes an issue where multiqc fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353)
 
 #### Updated Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Minor tweaks to software version commands
 * Add information about SILVA licensing when removing rRNA to `usage.md`
 * Fixed ansi colours for pipeline summary, added summary logs of alignment results
+* Fixes an issue where multiqc fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353) 
 
 
 #### Updated Packages

--- a/main.nf
+++ b/main.nf
@@ -1670,7 +1670,7 @@ process multiqc {
     file ('preseq/*') from preseq_results.collect().ifEmpty([])
     file ('dupradar/*') from dupradar_results.collect().ifEmpty([])
     file ('featureCounts/*') from featureCounts_logs.collect().ifEmpty([])
-    file ('featureCounts_biotype/*') from featureCounts_biotype.collect()
+    file ('featureCounts_biotype/*') from featureCounts_biotype.collect().ifEmpty([])
     file ('salmon/*') from salmon_logs.collect().ifEmpty([])
     file ('sample_correlation_results/*') from sample_correlation_results.collect().ifEmpty([]) // If the Edge-R is not run create an Empty array
     file ('sortmerna/*') from sortmerna_logs.collect().ifEmpty([])


### PR DESCRIPTION
Add `.ifEmpty([])` suffix to the multiqc input channel for `featureCounts_biotype`

Many thanks to contributing to nf-core/rnaseq!

To ensure that your build passes, please make sure your pull request is to the `dev` branch rather than to `master`. Thank you!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ X] PR is to `dev` rather than `master`
 - [ X] This comment contains a description of changes (with reason)
 - [ X] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
