### PR TITLE
Add rsem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Updated Packages
 
-* Salmon 0.14.2 -> 1.0.0
+* Salmon 0.14.2 -> 1.1.0
+* multiqc 1.7 -> 1.8
+* remove pinning of matplotlib version
 
 #### Added / Removed Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### Added / Removed Packages
 
 * Added pigz 2.3.4 for parallelized trim-galore support
+* Added rsem 1.3.3 for gene/transcript quantification
 
 
 ## Version 1.4.2

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
   - defaults
 dependencies:
   ## conda-forge packages, sorting now alphabetically, without the channel prefix!
-  - matplotlib=3.0.3        # Current 3.1.0 build incompatible with multiqc=1.7
+  - matplotlib=3.0.3 # Current 3.1.0 build incompatible with multiqc=1.7
   - r-base=3.6.1
   - conda-forge::r-data.table=1.12.4
   - conda-forge::r-gplots=3.0.1.1
@@ -30,8 +30,9 @@ dependencies:
   - salmon=1.0.0
   - samtools=1.9
   - sortmerna=2.1b # for metatranscriptomics
-  - star=2.6.1d             # Don't upgrade me - 2.7X indices incompatible with iGenomes.
+  - star=2.6.1d # Don't upgrade me - 2.7X indices incompatible with iGenomes.
   - stringtie=2.0
   - subread=1.6.4
   - trim-galore=0.6.4
   - pigz=2.3.4
+  - rsem=1.3.3

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ channels:
   - defaults
 dependencies:
   ## conda-forge packages, sorting now alphabetically, without the channel prefix!
-  - matplotlib=3.0.3 # Current 3.1.0 build incompatible with multiqc=1.7
   - r-base=3.6.1
   - conda-forge::r-data.table=1.12.4
   - conda-forge::r-gplots=3.0.1.1
@@ -22,12 +21,12 @@ dependencies:
   - fastqc=0.11.8
   - gffread=0.11.4
   - hisat2=2.1.0
-  - multiqc=1.7
+  - multiqc=1.8
   - picard=2.21.1
   - preseq=2.0.3
   - qualimap=2.2.2c
   - rseqc=3.0.1
-  - salmon=1.0.0
+  - salmon=1.1.0
   - samtools=1.9
   - sortmerna=2.1b # for metatranscriptomics
   - star=2.6.1d # Don't upgrade me - 2.7X indices incompatible with iGenomes.


### PR DESCRIPTION
This adds `rsem` 1.3.3 to `environment.yml`. 
Required for #389. 

Note: at least locally, I could not resolve the environment with salmon version `1.0.0` even before adding `rsem`. 
Downgrading it to `0.14.2` resolved the issue for me. 

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [x] `CHANGELOG.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
