### PR TITLE
Fix typo, add some helper text

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,11 +82,19 @@
 
 Nextflow handles job submissions on SLURM or other environments, and supervises running the jobs. Thus the Nextflow process must run until the pipeline is finished. We recommend that you put the process running in the background through `screen` / `tmux` or similar tool. Alternatively you can run nextflow within a cluster job submitted your job scheduler.
 
-It is recommended to limit the Nextflow Java virtual machines memory. We recommend adding the following line to your environment (typically in `~/.bashrc` or `~./bash_profile`):
+It is recommended to limit the Nextflow Java virtual machines memory. We recommend adding the following line to your environment (typically in `~/.bashrc` or `~/.bash_profile`):
 
 ```bash
 NXF_OPTS='-Xms1g -Xmx4g'
 ```
+
+This could be added by either editing those files with `nano`, e.g. `nano ~/.bashrc`, or by appending those options to your `~/.bashrc` file with:
+
+```bash
+echo "export NXF_OPTS='-Xms1g -Xmx4g'" >> ~/.bashrc
+```
+
+Then, re-running the file with `source ~/.bashrc`. If you are on a Mac, replace `~/.bashrc` in all previous examples with `~/.bash_profile`.
 
 ## Running the pipeline
 


### PR DESCRIPTION
In case people are copy-pasting these commands, fixed the typo from `~./bash_profile` --> `~/.bash_profile`.

Also added some help text for how to add the command line options to the dotfiles.


## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
