### PR TITLE
fix contradictory config option

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -43,7 +43,7 @@ params {
   // Ribosomal RNA removal
   removeRiboRNA = false
   save_nonrRNA_reads = false
-  rRNA_database_manifest = false
+  rRNA_database_manifest = "$baseDir/assets/rrna-db-defaults.txt"
 
   // Alignment
   aligner = 'star'
@@ -80,7 +80,6 @@ params {
   hisat_build_memory = 200 // Required amount of memory in GB to build HISAT2 index with splice sites
   readPaths = null
   star_memory = false // Cluster specific param required for hebbe
-  rRNA_database_manifest = "$baseDir/assets/rrna-db-defaults.txt"
 
   // Boilerplate options
   clusterOptions = false


### PR DESCRIPTION
merged duplicat entries for `rRNA_database_manifest` to the default mentioned in main.nf

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)