### PR TITLE
AWS megatests - don't run on forks

### DIFF
--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   run-awstest:
+    if: ${{ github.repository }} == 'nf-core/rnaseq'
     name: Run AWS test
     runs-on: ubuntu-latest
     steps:
@@ -28,4 +29,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_KEY_SECRET}}
           TOWER_ACCESS_TOKEN: ${{secrets.TOWER_ACCESS_TOKEN}}
         run: |
-          aws batch submit-job --region eu-west-1 --job-name nf-core-rnaseq --job-queue 'default-8b3836e0-5eda-11ea-96e5-0a2c3f6a2a32' --job-definition nextflow --container-overrides '{"command": ["nf-core/rnaseq", "-r '"${GITHUB_SHA}"' -profile test --outdir s3://nf-core-awsmegatests/rnaseq/results-'"${GITHUB_SHA}"' -w s3://nf-core-awsmegatests/rnaseq/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}' 
+          aws batch submit-job \
+            --region eu-west-1 \
+            --job-name nf-core-rnaseq \
+            --job-queue 'default-8b3836e0-5eda-11ea-96e5-0a2c3f6a2a32' \
+            --job-definition nextflow \
+            --container-overrides '{"command": ["nf-core/rnaseq", "-r '"${GITHUB_SHA}"' -profile test --outdir s3://nf-core-awsmegatests/rnaseq/results-'"${GITHUB_SHA}"' -w s3://nf-core-awsmegatests/rnaseq/work-'"${GITHUB_SHA}"' -with-tower"], "environment": [{"name": "TOWER_ACCESS_TOKEN", "value": "'"$TOWER_ACCESS_TOKEN"'"}]}'

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   run-awstest:
-    if: ${{ github.repository }} == 'nf-core/rnaseq'
+    if: github.repository == 'nf-core/rnaseq'
     name: Run AWS test
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,30 @@
 - Minor tweaks to software version commands
 - Add information about SILVA licensing when removing rRNA to `usage.md`
 - Fixed ansi colours for pipeline summary, added summary logs of alignment results
-- Fixes an issue where multiqc fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353)
-- Fixes missing parameter `-p` [#351](https://github.com/nf-core/rnaseq/issues/351)
+- Fixes an issue where MultiQC fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353)
+- Fixes missing Qualimap parameter `-p` [#351](https://github.com/nf-core/rnaseq/issues/351)
 - Fixes broken links [#357](https://github.com/nf-core/rnaseq/issues/357)
-- Fixes label name in fastQC process, Issue [#345]
+- Fixes label name in FastQC process [#345](https://github.com/nf-core/rnaseq/pull/345)
 - Make publishDir mode configurable [#391](https://github.com/nf-core/rnaseq/pull/391)
-- Add AWS tests github actions workflow for small tests
+- Add AWS tests GitHub actions workflow for small tests
 
 #### Updated Packages
 
-- Salmon 0.14.2 -> 1.1.0
-- multiqc 1.7 -> 1.8
-- remove pinning of matplotlib version
+- Salmon `0.14.2` -> `1.1.0`
+- MultiQC `1.7` -> `1.8`
+- Remove pinning of MatPlotLib version
 
 #### Added / Removed Packages
 
-- Added pigz 2.3.4 for parallelized trim-galore support
-- Added rsem 1.3.3 for gene/transcript quantification
+- Added `pigz` `2.3.4` for parallelized trim-galore support
+- Added `rsem` `1.3.3` for gene/transcript quantification
 
-## Version 1.4.2
+## [Version 1.4.2](https://github.com/nf-core/rnaseq/releases/tag/1.4.2) - 2019-10-18
 
-- Minor version release for keeping Git History in sync
+- Minor version release for keeping git history in sync
 - No changes with respect to 1.4.1 on pipeline level
 
-## Version 1.4.1
+## [Version 1.4.1](https://github.com/nf-core/rnaseq/releases/tag/1.4.1) - 2019-10-17
 
 Major novel changes include:
 
@@ -42,7 +42,7 @@ Major novel changes include:
 - Fixed parameter warnings [#316](https://github.com/nf-core/rnaseq/issues/316) and [318](https://github.com/nf-core/rnaseq/issues/318)
 - Fixed [#307](https://github.com/nf-core/rnaseq/issues/307) - Confusing Info Printout about GFF and GTF
 
-## Version 1.4
+## [Version 1.4](https://github.com/nf-core/rnaseq/releases/tag/1.4) - 2019-10-15
 
 Major novel changes include:
 


### PR DESCRIPTION
Prevents AWS tests from running on forks of the pipeline that have pushes to `master` (eg. [here](https://github.com/ewels/nf-core-rnaseq/runs/730211172?check_suite_focus=true)).

Also made the AWS batch command multi-line to be a bit easier to read.

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
