### PR TITLE
MultiQC: optimise configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixes label name in FastQC process [#345](https://github.com/nf-core/rnaseq/pull/345)
 - Make publishDir mode configurable [#391](https://github.com/nf-core/rnaseq/pull/391)
 - Add AWS tests GitHub actions workflow for small tests
+- Optimise MultiQC configuration for faster run-time on huge sample numbers
 
 #### Updated Packages
 

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -10,20 +10,109 @@ report_comment: >
     analysis pipeline. For information about how to interpret these results, please see the
     <a href="https://github.com/nf-core/rnaseq/blob/master/docs/output.md" target="_blank">documentation</a>.
 
+# Run only these modules
+run_modules:
+    - custom_content
+    - picard
+    - preseq
+    - rseqc
+    - featureCounts
+    - hisat2
+    - star
+    - cutadapt
+    - sortmerna
+    - fastqc
+    - qualimap
+    - salmon
+
+# Order of modules
 top_modules:
     - 'edgeR-sample-distances'
     - 'sample-similarity'
     - 'DupRadar'
     - 'biotype-counts'
 
+# Move custom-content sections to the bottom of the report
 report_section_order:
     software_versions:
         order: -1000
     nf-core-rnaseq-summary:
         order: -1100
 
+# Don't show % Dups in the General Stats table (we have this from Picard)
 table_columns_visible:
     FastQC:
         percent_duplicates: False
 
+# Generate flat versions of each plot and save
 export_plots: true
+
+# Customise the module search patterns to speed up execution time
+#  - Skip module sub-tools that we are not interested in
+#  - Replace file-content searching with filename pattern searching
+#  - Don't add anything that is the same as the MultiQC default
+# See https://multiqc.info/docs/#optimise-file-search-patterns for details
+sp:
+    preseq:
+        fn: '*.ccurve.txt'
+
+    rseqc/bam_stat:
+        fn: '*.bam_stat.txt'
+    rseqc/gene_body_coverage:
+        skip: true
+    rseqc/junction_annotation:
+        fn: '*.junction_annotation_log.txt'
+    rseqc/read_gc:
+        skip: true
+    rseqc/read_distribution:
+        fn: '*.read_distribution.txt'
+    rseqc/infer_experiment:
+        fn: '*infer_experiment.txt'
+
+    featurecounts:
+        fn: '*.summary'
+
+    hisat2:
+        fn: '*.hisat2_summary.txt'
+
+    cutadapt:
+        fn: '*trimming_report.txt'
+
+    sortmerna:
+        fn: '*_rRNA_report.txt'
+
+    salmon/meta:
+        fn: 'meta_info.json'
+
+    picard/markdups:
+        fn: '*.markDups_metrics.txt'
+    picard/alignment_metrics:
+        skip: true
+    picard/basedistributionbycycle:
+        skip: true
+    picard/gcbias:
+        skip: true
+    picard/hsmetrics:
+        skip: true
+    picard/insertsize:
+        skip: true
+    picard/oxogmetrics:
+        skip: true
+    picard/pcr_metrics:
+        skip: true
+    picard/quality_by_cycle:
+        skip: true
+    picard/quality_score_distribution:
+        skip: true
+    picard/quality_yield_metrics:
+        skip: true
+    picard/rnaseqmetrics:
+        skip: true
+    picard/rrbs_metrics:
+        skip: true
+    picard/sam_file_validation:
+        skip: true
+    picard/variant_calling_metrics:
+        skip: true
+    picard/wgs_metrics:
+        skip: true

--- a/main.nf
+++ b/main.nf
@@ -1663,6 +1663,7 @@ if (!params.skipAlignment) {
   hisat_stdout = Channel.from(false)
   alignment_logs = Channel.from(false)
   rseqc_results = Channel.from(false)
+  picard_results = Channel.from(false)
   qualimap_results = Channel.from(false)
   sample_correlation_results = Channel.from(false)
   featureCounts_logs = Channel.from(false)
@@ -1806,6 +1807,7 @@ process multiqc {
     file ('trimgalore/*') from trimgalore_results.collect().ifEmpty([])
     file ('alignment/*') from alignment_logs.collect().ifEmpty([])
     file ('rseqc/*') from rseqc_results.collect().ifEmpty([])
+    file ('picard/*') from picard_results.collect().ifEmpty([])
     file ('qualimap/*') from qualimap_results.collect().ifEmpty([])
     file ('preseq/*') from preseq_results.collect().ifEmpty([])
     file ('dupradar/*') from dupradar_results.collect().ifEmpty([])
@@ -1828,8 +1830,7 @@ process multiqc {
     rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
     custom_config_file = params.multiqc_config ? "--config $mqc_custom_config" : ''
     """
-    multiqc . -f $rtitle $rfilename $custom_config_file \\
-        -m custom_content -m picard -m preseq -m rseqc -m featureCounts -m hisat2 -m star -m cutadapt -m sortmerna -m fastqc -m qualimap -m salmon
+    multiqc . -f $rtitle $rfilename $custom_config_file
     """
 }
 


### PR DESCRIPTION
Optimised the MultiQC configuration.

* Added the Picard MarkDuplicate log files to the MultiQC input channels
* Moved the `-m` flags into the config file (`run_modules`)
* Customised search patterns:
  * Made it so that _only_ filename pattern matching is done (no content matching)
  * Added `skip: True` to all of the sub-module search patterns not being used (eg. all the Picard tools that are not MarkDuplicates)

Hopefully will speed up the MultiQC run-time a little. For smaller projects it'll only shave a second or two off. But for very large projects it could be worthwhile.

Tested locally with `-profile test,docker --aligner hisat2` and the reports looked identical. Except for the new Picard section.

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated
