### PR TITLE
CI: Build docker image if environment changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,36 @@ jobs:
         aligner: ["--aligner 'hisat2'", "--aligner 'star'", "--pseudo_aligner 'salmon'"]
         options: ['--skipQC', '--remove_rRNA', '--saveUnaligned', '--skipTrimming', '--star_index false']
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
+
+      - name: Has Docker / Conda changed?
+        uses: technote-space/get-diff-action@v1
+        with:
+          PREFIX_FILTER: |
+            Dockerfile
+            environment.yml
+
+      - name: Build new docker image
+        if: env.GIT_DIFF
+        run: docker build . -t nfcore/rnaseq:dev
+
       - name: Pull docker image
+        if: !env.GIT_DIFF
         run: |
           docker pull nfcore/rnaseq:dev
           docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
+
       - name: Basic workflow tests
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.aligner }} ${{ matrix.options }}
+
       - name: Basic workflow, gzipped input
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,14 @@ name: nf-core CI
 on: [push, pull_request]
 
 jobs:
-
-  setup:
-    name: Set up environment & Docker
+  test:
+    name: Run workflow tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['19.10.0', '']
+        aligner: ["--aligner 'hisat2'", "--aligner 'star'", "--pseudo_aligner 'salmon'"]
+        options: ['--skipQC', '--remove_rRNA', '--saveUnaligned', '--skipTrimming', '--star_index false']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -29,16 +33,6 @@ jobs:
           docker pull nfcore/rnaseq:dev
           docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
 
-  test:
-    name: Run workflow tests
-    needs: setup
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        nxf_ver: ['19.10.0', '']
-        aligner: ["--aligner 'hisat2'", "--aligner 'star'", "--pseudo_aligner 'salmon'"]
-        options: ['--skipQC', '--remove_rRNA', '--saveUnaligned', '--skipTrimming', '--star_index false']
-    steps:
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,30 @@ name: nf-core CI
 on: [push, pull_request]
 
 jobs:
+
+  setup:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Has Docker / Conda changed?
+      uses: technote-space/get-diff-action@v1
+      with:
+        PREFIX_FILTER: |
+          Dockerfile
+          environment.yml
+
+    - name: Build new docker image
+      if: env.GIT_DIFF
+      run: docker build . -t nfcore/rnaseq:dev
+
+    - name: Pull docker image
+      if: ! env.GIT_DIFF
+      run: |
+        docker pull nfcore/rnaseq:dev
+        docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
+
   test:
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -12,31 +35,12 @@ jobs:
         aligner: ["--aligner 'hisat2'", "--aligner 'star'", "--pseudo_aligner 'salmon'"]
         options: ['--skipQC', '--remove_rRNA', '--saveUnaligned', '--skipTrimming', '--star_index false']
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
 
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}
           wget -qO- get.nextflow.io | bash
           sudo mv nextflow /usr/local/bin/
-
-      - name: Has Docker / Conda changed?
-        uses: technote-space/get-diff-action@v1
-        with:
-          PREFIX_FILTER: |
-            Dockerfile
-            environment.yml
-
-      - name: Build new docker image
-        if: env.GIT_DIFF
-        run: docker build . -t nfcore/rnaseq:dev
-
-      - name: Pull docker image
-        if: !env.GIT_DIFF
-        run: |
-          docker pull nfcore/rnaseq:dev
-          docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
 
       - name: Basic workflow tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build new docker image
         if: env.GIT_DIFF
-        run: docker build . -t nfcore/rnaseq:dev
+        run: docker build --no-cache . -t nfcore/rnaseq:dev
 
       - name: Pull docker image
         if: ${{ !env.GIT_DIFF }}
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build new docker image
-        run: docker build . -t nfcore/rnaseq:dev
+        run: docker build --no-cache . -t nfcore/rnaseq:dev
 
       - name: Push Docker image to DockerHub (dev)
         if: ${{ github.event == 'push' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,31 @@ on: [push, pull_request]
 jobs:
 
   setup:
-    - name: Check out code
-      uses: actions/checkout@v2
+    name: Set up environment & Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
 
-    - name: Has Docker / Conda changed?
-      uses: technote-space/get-diff-action@v1
-      with:
-        PREFIX_FILTER: |
-          Dockerfile
-          environment.yml
+      - name: Check if Docker / Conda changed
+        uses: technote-space/get-diff-action@v1
+        with:
+          PREFIX_FILTER: |
+            Dockerfile
+            environment.yml
 
-    - name: Build new docker image
-      if: env.GIT_DIFF
-      run: docker build . -t nfcore/rnaseq:dev
+      - name: Build new docker image
+        if: env.GIT_DIFF
+        run: docker build . -t nfcore/rnaseq:dev
 
-    - name: Pull docker image
-      if: ! env.GIT_DIFF
-      run: |
-        docker pull nfcore/rnaseq:dev
-        docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
+      - name: Pull docker image
+        if: ! env.GIT_DIFF
+        run: |
+          docker pull nfcore/rnaseq:dev
+          docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
 
   test:
+    name: Run workflow tests
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -35,7 +39,6 @@ jobs:
         aligner: ["--aligner 'hisat2'", "--aligner 'star'", "--pseudo_aligner 'salmon'"]
         options: ['--skipQC', '--remove_rRNA', '--saveUnaligned', '--skipTrimming', '--star_index false']
     steps:
-
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: nf-core CI
-# This workflow is triggered on pushes and PRs to the repository.
+# This workflow is triggered on releases and pull-requests.
 # It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on:
   push:
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Run workflow tests
     runs-on: ubuntu-latest
+    # Only run on PRs / release / push to nf-core dev branch
+    if: ${{ github.event == 'pull_request' || github.event == 'release' || (github.event == 'push' && github.repository == 'nf-core/rnaseq' && github.branch == 'dev') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
@@ -23,9 +25,22 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
-      # Tag name needs to match process.container in pipeline code
+      - name: Check if Docker / Conda changed
+        uses: technote-space/get-diff-action@v1
+        with:
+          PREFIX_FILTER: |
+            Dockerfile
+            environment.yml
+
       - name: Build new docker image
+        if: env.GIT_DIFF
         run: docker build . -t nfcore/rnaseq:dev
+
+      - name: Pull docker image
+        if: ${{ !env.GIT_DIFF }}
+        run: |
+          docker pull nfcore/rnaseq:dev
+          docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
 
       - name: Install Nextflow
         run: |
@@ -40,13 +55,13 @@ jobs:
         run: nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}
 
       - name: Push Docker image to DockerHub (dev)
-        if: ${{ success() && github.repository == 'nf-core/rnaseq' && github.event == 'push' && github.branch == 'dev' }}
+        if: ${{ success() && github.event == 'push' && github.repository == 'nf-core/rnaseq' && github.branch == 'dev' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:dev
 
       - name: Push Docker image to DockerHub (release)
-        if: ${{ success() && github.repository == 'nf-core/rnaseq' && github.event == 'release' }}
+        if: ${{ success() && github.event == 'release' && github.repository == 'nf-core/rnaseq'  }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: nf-core CI
 # It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
 on:
   push:
+    branches:
+      - dev
   pull_request:
   release:
     types: [published]
@@ -12,7 +14,7 @@ jobs:
     name: Run workflow tests
     runs-on: ubuntu-latest
     # Only run on PRs / release / push to nf-core dev branch
-    if: ${{ github.event == 'pull_request' || github.event == 'release' || (github.event == 'push' && github.repository == 'nf-core/rnaseq' && github.branch == 'dev') }}
+    if: ${{ github.event == 'pull_request' || github.event == 'release' || (github.event == 'push' && github.repository == 'nf-core/rnaseq') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
@@ -55,7 +57,7 @@ jobs:
         run: nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}
 
       - name: Push Docker image to DockerHub (dev)
-        if: ${{ success() && github.event == 'push' && github.repository == 'nf-core/rnaseq' && github.branch == 'dev' }}
+        if: ${{ success() && github.event == 'push' && github.repository == 'nf-core/rnaseq' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     name: Run workflow tests
     runs-on: ubuntu-latest
-    # Only run on PRs / release / push to nf-core dev branch
-    if: ${{ github.event == 'pull_request' || github.event == 'release' || (github.event == 'push' && github.repository == 'nf-core/rnaseq') }}
+    # Only run on push if this is the nf-core dev branch (merged PRs)
+    if: ${{ github.event != 'push' || (github.event == 'push' && github.repository == 'nf-core/rnaseq') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,19 @@
 name: nf-core CI
 # This workflow is triggered on pushes and PRs to the repository.
 # It runs the pipeline with the minimal test dataset to check that it completes without any syntax errors
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   test:
     name: Run workflow tests
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
     strategy:
       matrix:
         nxf_ver: ['19.10.0', '']
@@ -16,22 +23,9 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
-      - name: Check if Docker / Conda changed
-        uses: technote-space/get-diff-action@v1
-        with:
-          PREFIX_FILTER: |
-            Dockerfile
-            environment.yml
-
+      # Tag name needs to match process.container in pipeline code
       - name: Build new docker image
-        if: env.GIT_DIFF
         run: docker build . -t nfcore/rnaseq:dev
-
-      - name: Pull docker image
-        if: ${{ !env.GIT_DIFF }}
-        run: |
-          docker pull nfcore/rnaseq:dev
-          docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev
 
       - name: Install Nextflow
         run: |
@@ -40,9 +34,21 @@ jobs:
           sudo mv nextflow /usr/local/bin/
 
       - name: Basic workflow tests
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.aligner }} ${{ matrix.options }}
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test,docker ${{ matrix.aligner }} ${{ matrix.options }}
 
       - name: Basic workflow, gzipped input
+        run: nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}
+
+      - name: Push Docker image to DockerHub (dev)
+        if: ${{ success() && github.repository == 'nf-core/rnaseq' && github.event == 'push' && github.branch == 'dev' }}
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker push nfcore/rnaseq:dev
+
+      - name: Push Docker image to DockerHub (release)
+        if: ${{ success() && github.repository == 'nf-core/rnaseq' && github.event == 'release' }}
+        run: |
+          echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+          docker push nfcore/rnaseq:${{ github.ref }}
+          docker tag nfcore/rnaseq:${{ github.ref }} nfcore/rnaseq:latest
+          docker push nfcore/rnaseq:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on push if this is the nf-core dev branch (merged PRs)
     if: ${{ github.event != 'push' || (github.event == 'push' && github.repository == 'nf-core/rnaseq') }}
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
     strategy:
       matrix:
         nxf_ver: ['19.10.0', '']
@@ -27,7 +24,7 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v2
 
-      - name: Check if Docker / Conda changed
+      - name: Check if Dockerfile or Conda environment changed
         uses: technote-space/get-diff-action@v1
         with:
           PREFIX_FILTER: |
@@ -56,14 +53,31 @@ jobs:
       - name: Basic workflow, gzipped input
         run: nextflow run ${GITHUB_WORKSPACE} -profile test_gz,docker ${{ matrix.aligner }} ${{ matrix.options }}
 
+  push_dockerhub:
+    name: Push new Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    # Only run if the tests passed
+    needs: test
+    # Only run for the nf-core repo, for releases and merged PRs
+    if: ${{ github.repository == 'nf-core/rnaseq' && (github.event == 'release' || github.event == 'push') }}
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Build new docker image
+        run: docker build . -t nfcore/rnaseq:dev
+
       - name: Push Docker image to DockerHub (dev)
-        if: ${{ success() && github.event == 'push' && github.repository == 'nf-core/rnaseq' }}
+        if: ${{ github.event == 'push' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:dev
 
       - name: Push Docker image to DockerHub (release)
-        if: ${{ success() && github.event == 'release' && github.repository == 'nf-core/rnaseq'  }}
+        if: ${{ github.event == 'release' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: docker build . -t nfcore/rnaseq:dev
 
       - name: Pull docker image
-        if: ! env.GIT_DIFF
+        if: ${{ !env.GIT_DIFF }}
         run: |
           docker pull nfcore/rnaseq:dev
           docker tag nfcore/rnaseq:dev nfcore/rnaseq:dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixes label name in FastQC process [#345](https://github.com/nf-core/rnaseq/pull/345)
 - Make publishDir mode configurable [#391](https://github.com/nf-core/rnaseq/pull/391)
 - Add AWS tests GitHub actions workflow for small tests
+- Build Docker image using GitHub Actions
 
 #### Updated Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,192 +4,193 @@
 
 ### Pipeline enhancements & fixes
 
-- Minor tweaks to software version commands
-- Add information about SILVA licensing when removing rRNA to `usage.md`
-- Fixed ansi colours for pipeline summary, added summary logs of alignment results
-- Fixes an issue where MultiQC fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353)
-- Fixes missing Qualimap parameter `-p` [#351](https://github.com/nf-core/rnaseq/issues/351)
-- Fixes broken links [#357](https://github.com/nf-core/rnaseq/issues/357)
-- Fixes label name in FastQC process [#345](https://github.com/nf-core/rnaseq/pull/345)
-- Make publishDir mode configurable [#391](https://github.com/nf-core/rnaseq/pull/391)
-- Add AWS tests GitHub actions workflow for small tests
-- Build Docker image using GitHub Actions
+* Minor tweaks to software version commands
+* Add information about SILVA licensing when removing rRNA to `usage.md`
+* Fixed ansi colours for pipeline summary, added summary logs of alignment results
+* Fixes an issue where MultiQC fails to run with `--skipbiotypeQC` option [#353](https://github.com/nf-core/rnaseq/issues/353)
+* Fixes missing Qualimap parameter `-p` [#351](https://github.com/nf-core/rnaseq/issues/351)
+* Fixes broken links [#357](https://github.com/nf-core/rnaseq/issues/357)
+* Fixes label name in FastQC process [#345](https://github.com/nf-core/rnaseq/pull/345)
+* Make publishDir mode configurable [#391](https://github.com/nf-core/rnaseq/pull/391)
+* Add AWS tests GitHub actions workflow for small tests
+* Build Docker image using GitHub Actions
+  * Pull-requests now rebuild the image if the software environment has been changed (so tests should pass)
+  * Builds are done on GitHub Actions and pushed to Docker Hub, which is much faster than waiting for Docker Hub to build
 
 #### Updated Packages
 
-- Salmon `0.14.2` -> `1.1.0`
-- MultiQC `1.7` -> `1.8`
-- Remove pinning of MatPlotLib version
+* Salmon `0.14.2` -> `1.1.0`
+* MultiQC `1.7` -> `1.8`
+* Remove pinning of MatPlotLib version
 
 #### Added / Removed Packages
 
-- Added `pigz` `2.3.4` for parallelized trim-galore support
-- Added `rsem` `1.3.3` for gene/transcript quantification
+* Added `pigz` `2.3.4` for parallelized trim-galore support
+* Added `rsem` `1.3.3` for gene/transcript quantification
 
-## [Version 1.4.2](https://github.com/nf-core/rnaseq/releases/tag/1.4.2) - 2019-10-18
+## [Version 1.4.2](https://github.com/nf-core/rnaseq/releases/tag/1.4.2) * 2019-10-18
 
-- Minor version release for keeping git history in sync
-- No changes with respect to 1.4.1 on pipeline level
+* Minor version release for keeping git history in sync
+* No changes with respect to 1.4.1 on pipeline level
 
-## [Version 1.4.1](https://github.com/nf-core/rnaseq/releases/tag/1.4.1) - 2019-10-17
+## [Version 1.4.1](https://github.com/nf-core/rnaseq/releases/tag/1.4.1) * 2019-10-17
 
 Major novel changes include:
 
-- Update `igenomes.config` with NCBI `GRCh38` and most recent UCSC genomes
-- Set `autoMounts = true` by default for `singularity` profile
+* Update `igenomes.config` with NCBI `GRCh38` and most recent UCSC genomes
+* Set `autoMounts = true` by default for `singularity` profile
 
 ### Pipeline enhancements & fixes
 
-- Fixed parameter warnings [#316](https://github.com/nf-core/rnaseq/issues/316) and [318](https://github.com/nf-core/rnaseq/issues/318)
-- Fixed [#307](https://github.com/nf-core/rnaseq/issues/307) - Confusing Info Printout about GFF and GTF
+* Fixed parameter warnings [#316](https://github.com/nf-core/rnaseq/issues/316) and [318](https://github.com/nf-core/rnaseq/issues/318)
+* Fixed [#307](https://github.com/nf-core/rnaseq/issues/307) * Confusing Info Printout about GFF and GTF
 
-## [Version 1.4](https://github.com/nf-core/rnaseq/releases/tag/1.4) - 2019-10-15
+## [Version 1.4](https://github.com/nf-core/rnaseq/releases/tag/1.4) * 2019-10-15
 
 Major novel changes include:
 
-- Support for Salmon as an alternative method to STAR and HISAT2
-- Several improvements in `featureCounts` handling of types other than `exon`. It is possible now to handle nuclearRNAseq data. Nuclear RNA has un-spliced RNA, and the whole transcript, including the introns, needs to be counted, e.g. by specifying `--fc_count_type transcript`.
-- Support for [outputting unaligned data](https://github.com/nf-core/rnaseq/issues/277) to results folders.
-- Added options to skip several steps
-
-  - Skip trimming using `--skipTrimming`
-  - Skip BiotypeQC using `--skipBiotypeQC`
-  - Skip Alignment using `--skipAlignment` to only use pseudo-alignment using Salmon
+* Support for Salmon as an alternative method to STAR and HISAT2
+* Several improvements in `featureCounts` handling of types other than `exon`. It is possible now to handle nuclearRNAseq data. Nuclear RNA has un-spliced RNA, and the whole transcript, including the introns, needs to be counted, e.g. by specifying `--fc_count_type transcript`.
+* Support for [outputting unaligned data](https://github.com/nf-core/rnaseq/issues/277) to results folders.
+* Added options to skip several steps
+  * Skip trimming using `--skipTrimming`
+  * Skip BiotypeQC using `--skipBiotypeQC`
+  * Skip Alignment using `--skipAlignment` to only use pseudo-alignment using Salmon
 
 ### Documentation updates
 
-- Adjust wording of skipped samples [in pipeline output](https://github.com/nf-core/rnaseq/issues/290)
-- Fixed link to guidelines [#203](https://github.com/nf-core/rnaseq/issues/203)
-- Add `Citation` and `Quick Start` section to `README.md`
-- Add in documentation of the `--gff` parameter
+* Adjust wording of skipped samples [in pipeline output](https://github.com/nf-core/rnaseq/issues/290)
+* Fixed link to guidelines [#203](https://github.com/nf-core/rnaseq/issues/203)
+* Add `Citation` and `Quick Start` section to `README.md`
+* Add in documentation of the `--gff` parameter
 
 ### Reporting Updates
 
-- Generate MultiQC plots in the results directory [#200](https://github.com/nf-core/rnaseq/issues/200)
-- Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
-- Get MultiQC to write out the software versions in a `.csv` file [#185](https://github.com/nf-core/rnaseq/issues/185)
-- Use `file` instead of `new File` to create `pipeline_report.{html,txt}` files, and properly create subfolders
+* Generate MultiQC plots in the results directory [#200](https://github.com/nf-core/rnaseq/issues/200)
+* Get MultiQC to save plots as [standalone files](https://github.com/nf-core/rnaseq/issues/183)
+* Get MultiQC to write out the software versions in a `.csv` file [#185](https://github.com/nf-core/rnaseq/issues/185)
+* Use `file` instead of `new File` to create `pipeline_report.{html,txt}` files, and properly create subfolders
 
 ### Pipeline enhancements & fixes
 
-- Restore `SummarizedExperimment` object creation in the salmon_merge process avoiding increasing memory with sample size.
-- Fix sample names in feature counts and dupRadar to remove suffixes added in other processes
-- Removed `genebody_coverage` process [#195](https://github.com/nf-core/rnaseq/issues/195)
-- Implemented Pearsons correlation instead of Euclidean distance [#146](https://github.com/nf-core/rnaseq/issues/146)
-- Add `--stringTieIgnoreGTF` parameter [#206](https://github.com/nf-core/rnaseq/issues/206)
-- Removed unused `stringtie` channels for `MultiQC`
-- Integrate changes in `nf-core/tools v1.6` template which resolved [#90](https://github.com/nf-core/rnaseq/issues/90)
-- Moved process `convertGFFtoGTF` before `makeSTARindex` [#215](https://github.com/nf-core/rnaseq/issues/215)
-- Change all boolean parameters from `snake_case` to `camelCase` and vice versa for value parameters
-- Add SM ReadGroup info for QualiMap compatibility[#238](https://github.com/nf-core/rnaseq/issues/238)
-- Obtain edgeR + dupRadar version information [#198](https://github.com/nf-core/rnaseq/issues/198) and [#112](https://github.com/nf-core/rnaseq/issues/112)
-- Add `--gencode` option for compatibility of Salmon and featureCounts biotypes with GENCODE gene annotations
-- Added functionality to accept compressed reference data in the pipeline
-- Check that gtf features are on chromosomes that exist in the genome fasta file [#274](https://github.com/nf-core/rnaseq/pull/274)
-- Maintain all gff features upon gtf conversion (keeps `gene_biotype` or `gene_type` to make `featureCounts` happy)
-- Add SortMeRNA as an optional step to allow rRNA removal [#280](https://github.com/nf-core/rnaseq/issues/280)
-- Minimal adjustment of memory and CPU constraints for clusters with locked memory / CPU relation
-- Cleaned up usage, `parameters.settings.json` and the `nextflow.config`
+* Restore `SummarizedExperimment` object creation in the salmon_merge process avoiding increasing memory with sample size.
+* Fix sample names in feature counts and dupRadar to remove suffixes added in other processes
+* Removed `genebody_coverage` process [#195](https://github.com/nf-core/rnaseq/issues/195)
+* Implemented Pearsons correlation instead of Euclidean distance [#146](https://github.com/nf-core/rnaseq/issues/146)
+* Add `--stringTieIgnoreGTF` parameter [#206](https://github.com/nf-core/rnaseq/issues/206)
+* Removed unused `stringtie` channels for `MultiQC`
+* Integrate changes in `nf-core/tools v1.6` template which resolved [#90](https://github.com/nf-core/rnaseq/issues/90)
+* Moved process `convertGFFtoGTF` before `makeSTARindex` [#215](https://github.com/nf-core/rnaseq/issues/215)
+* Change all boolean parameters from `snake_case` to `camelCase` and vice versa for value parameters
+* Add SM ReadGroup info for QualiMap compatibility[#238](https://github.com/nf-core/rnaseq/issues/238)
+* Obtain edgeR + dupRadar version information [#198](https://github.com/nf-core/rnaseq/issues/198) and [#112](https://github.com/nf-core/rnaseq/issues/112)
+* Add `--gencode` option for compatibility of Salmon and featureCounts biotypes with GENCODE gene annotations
+* Added functionality to accept compressed reference data in the pipeline
+* Check that gtf features are on chromosomes that exist in the genome fasta file [#274](https://github.com/nf-core/rnaseq/pull/274)
+* Maintain all gff features upon gtf conversion (keeps `gene_biotype` or `gene_type` to make `featureCounts` happy)
+* Add SortMeRNA as an optional step to allow rRNA removal [#280](https://github.com/nf-core/rnaseq/issues/280)
+* Minimal adjustment of memory and CPU constraints for clusters with locked memory / CPU relation
+* Cleaned up usage, `parameters.settings.json` and the `nextflow.config`
 
 ### Dependency Updates
 
-- Dependency list is now sorted appropriately
-- Force matplotlib=3.0.3
+* Dependency list is now sorted appropriately
+* Force matplotlib=3.0.3
 
 #### Updated Packages
 
-- Picard 2.20.0 -> 2.21.1
-- bioconductor-dupradar 1.12.1 -> 1.14.0
-- bioconductor-edger 3.24.3 -> 3.26.5
-- gffread 0.9.12 -> 0.11.4
-- trim-galore 0.6.1 -> 0.6.4
-- gffread 0.9.12 -> 0.11.4
-- rseqc 3.0.0 -> 3.0.1
-- R-Base 3.5 -> 3.6.1
+* Picard 2.20.0 -> 2.21.1
+* bioconductor-dupradar 1.12.1 -> 1.14.0
+* bioconductor-edger 3.24.3 -> 3.26.5
+* gffread 0.9.12 -> 0.11.4
+* trim-galore 0.6.1 -> 0.6.4
+* gffread 0.9.12 -> 0.11.4
+* rseqc 3.0.0 -> 3.0.1
+* R-Base 3.5 -> 3.6.1
 
 #### Added / Removed Packages
 
-- Dropped CSVtk in favor of Unix's simple `cut` and `paste` utilities
-- Added Salmon 0.14.2
-- Added TXIMeta 1.2.2
-- Added SummarizedExperiment 1.14.0
-- Added SortMeRNA 2.1b
-- Add tximport and summarizedexperiment dependency [#171](https://github.com/nf-core/rnaseq/issues/171)
-- Add Qualimap dependency [#202](https://github.com/nf-core/rnaseq/issues/202)
+* Dropped CSVtk in favor of Unix's simple `cut` and `paste` utilities
+* Added Salmon 0.14.2
+* Added TXIMeta 1.2.2
+* Added SummarizedExperiment 1.14.0
+* Added SortMeRNA 2.1b
+* Add tximport and summarizedexperiment dependency [#171](https://github.com/nf-core/rnaseq/issues/171)
+* Add Qualimap dependency [#202](https://github.com/nf-core/rnaseq/issues/202)
 
-## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) - 2019-03-26
+## [Version 1.3](https://github.com/nf-core/rnaseq/releases/tag/1.3) * 2019-03-26
 
 ### Pipeline Updates
 
-- Added configurable options to specify group attributes for featureCounts [#144](https://github.com/nf-core/rnaseq/issues/144)
-- Added support for RSeqC 3.0 [#148](https://github.com/nf-core/rnaseq/issues/148)
-- Added a `parameters.settings.json` file for use with the new `nf-core launch` helper tool.
-- Centralized all configuration profiles using [nf-core/configs](https://github.com/nf-core/configs)
-- Fixed all centralized configs [for offline usage](https://github.com/nf-core/rnaseq/issues/163)
-- Hide %dup in [multiqc report](https://github.com/nf-core/rnaseq/issues/150)
-- Add option for Trimming NextSeq data properly ([@jburos work](https://github.com/jburos))
+* Added configurable options to specify group attributes for featureCounts [#144](https://github.com/nf-core/rnaseq/issues/144)
+* Added support for RSeqC 3.0 [#148](https://github.com/nf-core/rnaseq/issues/148)
+* Added a `parameters.settings.json` file for use with the new `nf-core launch` helper tool.
+* Centralized all configuration profiles using [nf-core/configs](https://github.com/nf-core/configs)
+* Fixed all centralized configs [for offline usage](https://github.com/nf-core/rnaseq/issues/163)
+* Hide %dup in [multiqc report](https://github.com/nf-core/rnaseq/issues/150)
+* Add option for Trimming NextSeq data properly ([@jburos work](https://github.com/jburos))
 
 ### Bug fixes
 
-- Fixing HISAT2 Index Building for large reference genomes [#153](https://github.com/nf-core/rnaseq/issues/153)
-- Fixing HISAT2 BAM sorting using more memory than available on the system
-- Fixing MarkDuplicates memory consumption issues following [#179](https://github.com/nf-core/rnaseq/pull/179)
-- Use `file` instead of `new File` to create the `pipeline_report.{html,txt}` files to avoid creating local directories when outputting to AWS S3 folders
+* Fixing HISAT2 Index Building for large reference genomes [#153](https://github.com/nf-core/rnaseq/issues/153)
+* Fixing HISAT2 BAM sorting using more memory than available on the system
+* Fixing MarkDuplicates memory consumption issues following [#179](https://github.com/nf-core/rnaseq/pull/179)
+* Use `file` instead of `new File` to create the `pipeline_report.{html,txt}` files to avoid creating local directories when outputting to AWS S3 folders
 
 ### Dependency Updates
 
-- RSeQC 2.6.4 -> 3.0.0
-- Picard 2.18.15 -> 2.20.0
-- r-data.table 1.11.4 -> 1.12.2
-- bioconductor-edger 3.24.1 -> 3.24.3
-- r-markdown 0.8 -> 0.9
-- csvtk 0.15.0 -> 0.17.0
-- stringtie 1.3.4 -> 1.3.6
-- subread 1.6.2 -> 1.6.4
-- gffread 0.9.9 -> 0.9.12
-- multiqc 1.6 -> 1.7
-- deeptools 3.2.0 -> 3.2.1
-- trim-galore 0.5.0 -> 0.6.1
-- qualimap 2.2.2b
-- matplotlib 3.0.3
-- r-base 3.5.1
+* RSeQC 2.6.4 -> 3.0.0
+* Picard 2.18.15 -> 2.20.0
+* r-data.table 1.11.4 -> 1.12.2
+* bioconductor-edger 3.24.1 -> 3.24.3
+* r-markdown 0.8 -> 0.9
+* csvtk 0.15.0 -> 0.17.0
+* stringtie 1.3.4 -> 1.3.6
+* subread 1.6.2 -> 1.6.4
+* gffread 0.9.9 -> 0.9.12
+* multiqc 1.6 -> 1.7
+* deeptools 3.2.0 -> 3.2.1
+* trim-galore 0.5.0 -> 0.6.1
+* qualimap 2.2.2b
+* matplotlib 3.0.3
+* r-base 3.5.1
 
-## [Version 1.2](https://github.com/nf-core/rnaseq/releases/tag/1.2) - 2018-12-12
-
-### Pipeline updates
-
-- Removed some outdated documentation about non-existent features
-- Config refactoring and code cleaning
-- Added a `--fcExtraAttributes` option to specify more than ENSEMBL gene names in `featureCounts`
-- Remove legacy rseqc `strandRule` config code. [#119](https://github.com/nf-core/rnaseq/issues/119)
-- Added STRINGTIE ballgown output to results folder [#125](https://github.com/nf-core/rnaseq/issues/125)
-- HiSAT index build now requests `200GB` memory, enough to use the exons / splice junction option for building.
-  - Added documentation about the `--hisatBuildMemory` option.
-- BAM indices are stored and re-used between processes [#71](https://github.com/nf-core/rnaseq/issues/71)
-
-### Bug Fixes
-
-- Fixed conda bug which caused problems with environment resolution due to changes in bioconda [#113](https://github.com/nf-core/rnaseq/issues/113)
-- Fixed wrong gffread command line [#117](https://github.com/nf-core/rnaseq/issues/117)
-- Added `cpus = 1` to `workflow summary process` [#130](https://github.com/nf-core/rnaseq/issues/130)
-
-## [Version 1.1](https://github.com/nf-core/rnaseq/releases/tag/1.1) - 2018-10-05
+## [Version 1.2](https://github.com/nf-core/rnaseq/releases/tag/1.2) * 2018-12-12
 
 ### Pipeline updates
 
-- Wrote docs and made minor tweaks to the `--skip_qc` and associated options
-- Removed the depreciated `uppmax-modules` config profile
-- Updated the `hebbe` config profile to use the new `withName` syntax too
-- Use new `workflow.manifest` variables in the pipeline script
-- Updated minimum nextflow version to `0.32.0`
+* Removed some outdated documentation about non-existent features
+* Config refactoring and code cleaning
+* Added a `--fcExtraAttributes` option to specify more than ENSEMBL gene names in `featureCounts`
+* Remove legacy rseqc `strandRule` config code. [#119](https://github.com/nf-core/rnaseq/issues/119)
+* Added STRINGTIE ballgown output to results folder [#125](https://github.com/nf-core/rnaseq/issues/125)
+* HiSAT index build now requests `200GB` memory, enough to use the exons / splice junction option for building.
+  * Added documentation about the `--hisatBuildMemory` option.
+* BAM indices are stored and re-used between processes [#71](https://github.com/nf-core/rnaseq/issues/71)
 
 ### Bug Fixes
 
-- [#77](https://github.com/nf-core/rnaseq/issues/77): Added back `executor = 'local'` for the `workflow_summary_mqc`
-- [#95](https://github.com/nf-core/rnaseq/issues/95): Check if task.memory is false instead of null
-- [#97](https://github.com/nf-core/rnaseq/issues/97): Resolved edge-case where numeric sample IDs are parsed as numbers causing some samples to be incorrectly overwritten.
+* Fixed conda bug which caused problems with environment resolution due to changes in bioconda [#113](https://github.com/nf-core/rnaseq/issues/113)
+* Fixed wrong gffread command line [#117](https://github.com/nf-core/rnaseq/issues/117)
+* Added `cpus = 1` to `workflow summary process` [#130](https://github.com/nf-core/rnaseq/issues/130)
 
-## [Version 1.0](https://github.com/nf-core/rnaseq/releases/tag/1.0) - 2018-08-20
+## [Version 1.1](https://github.com/nf-core/rnaseq/releases/tag/1.1) * 2018-10-05
+
+### Pipeline updates
+
+* Wrote docs and made minor tweaks to the `--skip_qc` and associated options
+* Removed the depreciated `uppmax-modules` config profile
+* Updated the `hebbe` config profile to use the new `withName` syntax too
+* Use new `workflow.manifest` variables in the pipeline script
+* Updated minimum nextflow version to `0.32.0`
+
+### Bug Fixes
+
+* [#77](https://github.com/nf-core/rnaseq/issues/77): Added back `executor = 'local'` for the `workflow_summary_mqc`
+* [#95](https://github.com/nf-core/rnaseq/issues/95): Check if task.memory is false instead of null
+* [#97](https://github.com/nf-core/rnaseq/issues/97): Resolved edge-case where numeric sample IDs are parsed as numbers causing some samples to be incorrectly overwritten.
+
+## [Version 1.0](https://github.com/nf-core/rnaseq/releases/tag/1.0) * 2018-08-20
 
 This release marks the point where the pipeline was moved from [SciLifeLab/NGI-RNAseq](https://github.com/SciLifeLab/NGI-RNAseq)
 over to the new [nf-core](http://nf-co.re/) community, at [nf-core/rnaseq](https://github.com/nf-core/rnaseq).
@@ -201,30 +202,30 @@ There have been 157 commits by 16 different contributors covering 70 different f
 
 In summary, the main changes are:
 
-- Rebranding and renaming throughout the pipeline to nf-core
-- Updating many parts of the pipeline config and style to meet nf-core standards
-- Support for GFF files in addition to GTF files
-  - Just use `--gff` instead of `--gtf` when specifying a file path
-- New command line options to skip various quality control steps
-- More safety checks when launching a pipeline
-  - Several new sanity checks - for example, that the specified reference genome exists
-- Improved performance with memory usage (especially STAR and Picard)
-- New BigWig file outputs for plotting coverage across the genome
-- Refactored gene body coverage calculation, now much faster and using much less memory
-- Bugfixes in the MultiQC process to avoid edge cases where it wouldn't run
-- MultiQC report now automatically attached to the email sent when the pipeline completes
-- New testing method, with data on GitHub
-  - Now run pipeline with `-profile test` instead of using bash scripts
-- Rewritten continuous integration tests with Travis CI
-- New explicit support for Singularity containers
-- Improved MultiQC support for DupRadar and featureCounts
-  - Now works for all users instead of just NGI Stockholm
-- New configuration for use on AWS batch
-- Updated config syntax to support latest versions of Nextflow
-- Built-in support for a number of new local HPC systems
-  - CCGA, GIS, UCT HEX, updates to UPPMAX, CFC, BINAC, Hebbe, c3se
-- Slightly improved documentation (more updates to come)
-- Updated software packages
+* Rebranding and renaming throughout the pipeline to nf-core
+* Updating many parts of the pipeline config and style to meet nf-core standards
+* Support for GFF files in addition to GTF files
+  * Just use `--gff` instead of `--gtf` when specifying a file path
+* New command line options to skip various quality control steps
+* More safety checks when launching a pipeline
+  * Several new sanity checks * for example, that the specified reference genome exists
+* Improved performance with memory usage (especially STAR and Picard)
+* New BigWig file outputs for plotting coverage across the genome
+* Refactored gene body coverage calculation, now much faster and using much less memory
+* Bugfixes in the MultiQC process to avoid edge cases where it wouldn't run
+* MultiQC report now automatically attached to the email sent when the pipeline completes
+* New testing method, with data on GitHub
+  * Now run pipeline with `-profile test` instead of using bash scripts
+* Rewritten continuous integration tests with Travis CI
+* New explicit support for Singularity containers
+* Improved MultiQC support for DupRadar and featureCounts
+  * Now works for all users instead of just NGI Stockholm
+* New configuration for use on AWS batch
+* Updated config syntax to support latest versions of Nextflow
+* Built-in support for a number of new local HPC systems
+  * CCGA, GIS, UCT HEX, updates to UPPMAX, CFC, BINAC, Hebbe, c3se
+* Slightly improved documentation (more updates to come)
+* Updated software packages
 
 ...and many more minor tweaks.
 


### PR DESCRIPTION
WIP for new GitHub actions to build the docker image in the CI if the environment changes.

Building the docker image is fairly easy, it was getting the logic in place to only do it when we need to that was a little more fiddly. I got that working with the [`technote-space/get-diff-action@v1`](https://github.com/marketplace/actions/get-diff-action) action in the end.

If either `environment.yaml` or `Dockerfile` have been edited, then a new docker container is built using `docker build . -t nfcore/rnaseq:dev`.

If `environment.yaml` or `Dockerfile` have _not_ been edited, then the workflow just pulls the image with `docker pull nfcore/rnaseq:dev`

## Examples

* `push` actions run where the environment was not changed (`docker pull`):
    * https://github.com/ewels/nf-core-rnaseq/runs/730898163?check_suite_focus=true
* `pull_request` actions run where the environment was changed (`docker build`):
    * https://github.com/ewels/nf-core-rnaseq/pull/32/checks?check_run_id=730914424

## Caveats

The workflow runs on `push` and `pull_request`. The latter compares the `git diff` over the range of changes, but `push` just gets that one commit. So if you change the environment in one commit and then change something else in the second then the second `push` event will fail as it will pull the image because the environment files didn't change in that second, isolated commit. You can see this by looking at the latest actions `push` run on the demo PR branch above [here](https://github.com/ewels/nf-core-rnaseq/pull/32/checks?check_run_id=730903853). Pull-requests should work fine.

One way to get around this is to _always_ build the docker image for every single CI run. However, this is quite a bit slower. Using the above actions runs as an example, building the image took around 7-8 minutes. Pulling the image took about 1 minute. The entire run-time varies a bit according to the test, but the docker build takes about half of the total run time, so it's quite slow.

Another option is to always push to DockerHub with a new tag name corresponding to the branch name. Then use this in the pull. I think that this should work, though it will then require (a) every fork to have a corresponding Docker Hub repo set up and (b) will pollute with a _lot_ of Docker Hub tags.

## To-Do

- [x] Push to Docker Hub
- [ ] Update linting so that it doesn't fail
- [ ] Update `nf-core bump-versions` to edit the `docker build -t` tag


---

## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated