### PR TITLE
New GitHub Actions CI push to dockerhub fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run workflow tests
     runs-on: ubuntu-latest
     # Only run on push if this is the nf-core dev branch (merged PRs)
-    if: ${{ github.event != 'push' || (github.event == 'push' && github.repository == 'nf-core/rnaseq') }}
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     env:
       NXF_VER: ${{ matrix.nxf_ver }}
       NXF_ANSI_LOG: false
@@ -62,7 +62,7 @@ jobs:
     # Only run if the tests passed
     needs: test
     # Only run for the nf-core repo, for releases and merged PRs
-    if: ${{ github.repository == 'nf-core/rnaseq' && (github.event == 'release' || github.event == 'push') }}
+    if: ${{ github.repository == 'nf-core/rnaseq' && (github.event_name == 'release' || github.event_name == 'push') }}
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
@@ -74,14 +74,14 @@ jobs:
         run: docker build --no-cache . -t nfcore/rnaseq:latest
 
       - name: Push Docker image to DockerHub (dev)
-        if: ${{ github.event == 'push' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker tag nfcore/rnaseq:latest nfcore/rnaseq:dev
           docker push nfcore/rnaseq:dev
 
       - name: Push Docker image to DockerHub (release)
-        if: ${{ github.event == 'release' }}
+        if: ${{ github.event_name == 'release' }}
         run: |
           echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           docker push nfcore/rnaseq:latest


### PR DESCRIPTION
Fixes error where a new image was not being built and pushed to Docker Hub after merge to dev (or release) - `github.event_name` instead of `github.event`

See #423 and #425 for context.