### PR TITLE
Add Slack badge to readme

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,7 @@ on:
     types: [published]
 
 jobs:
+
   Markdown:
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +20,7 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint
         run: markdownlint ${GITHUB_WORKSPACE} -c ${GITHUB_WORKSPACE}/.github/markdownlint.yml
+
   YAML:
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +32,7 @@ jobs:
         run: npm install -g yaml-lint
       - name: Run yaml-lint
         run: yamllint $(find ${GITHUB_WORKSPACE} -type f -name "*.yml")
+
   nf-core:
     runs-on: ubuntu-latest
     steps:
@@ -46,5 +49,24 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install nf-core
+
       - name: Run nf-core lint
         run: nf-core lint ${GITHUB_WORKSPACE}
+
+      # If linting failed or gave warnings, post a comment on the PR with the results
+      - name: Post PR comment
+        if: failure()
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Hi @${{ github.event.pull_request.user.login }},
+
+            It looks like this pull-request is has been made against the ${{github.event.pull_request.head.repo.full_name}} `master` branch.
+            The `master` branch on nf-core repositories should always contain code from the latest release.
+            Beacuse of this, PRs to `master` are only allowed if they come from the ${{github.event.pull_request.head.repo.full_name}} `dev` branch.
+
+            You do not need to close this PR, you can change the target branch to `dev` by clicking the _"Edit"_ button at the top of this page.
+
+            Thanks again for your contribution!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-repeats: false

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)
 [![Docker](https://img.shields.io/docker/automated/nfcore/rnaseq.svg)](https://hub.docker.com/r/nfcore/rnaseq/)
+[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23rnaseq-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/rnaseq)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/)
 [![Docker](https://img.shields.io/docker/automated/nfcore/rnaseq.svg)](https://hub.docker.com/r/nfcore/rnaseq/)
-[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23rnaseq-4A154B?style=plastic&logo=slack)](https://nfcore.slack.com/channels/rnaseq)
+[![Get help on Slack](http://img.shields.io/badge/slack-nf--core%20%23rnaseq-4A154B?logo=slack)](https://nfcore.slack.com/channels/rnaseq)
 
 ## Introduction
 


### PR DESCRIPTION
Added new badge to readme for Slack. Inspired by nf-core/ampliseq

See https://github.com/ewels/nf-core-rnaseq/tree/slack-readme-badge:

![image](https://user-images.githubusercontent.com/465550/83860945-43697c00-a720-11ea-99fb-229d6c3c1321.png)


## PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [x] `README.md` is updated
