### PR TITLE
Fix case-sensitivity issue while sorting bedGraph.

### DIFF
--- a/modules/local/process/bedtools_genomecov.nf
+++ b/modules/local/process/bedtools_genomecov.nf
@@ -36,14 +36,13 @@ process BEDTOOLS_GENOMECOV {
         strandedness = '-strand - -du'
     }
     """
-    export LC_COLLATE=C
     bedtools \\
         genomecov \\
         -ibam $bam \\
         -bg \\
         $strandedness \\
         -split \\
-        | sort -T '.' -k1,1 -k2,2n > ${prefix}.bedGraph
+        | bedtools sort > ${prefix}.bedGraph
 
     bedtools --version | sed -e "s/bedtools v//g" > ${software}.version.txt
     """

--- a/modules/local/process/bedtools_genomecov.nf
+++ b/modules/local/process/bedtools_genomecov.nf
@@ -36,6 +36,7 @@ process BEDTOOLS_GENOMECOV {
         strandedness = '-strand - -du'
     }
     """
+    export LC_COLLATE=C
     bedtools \\
         genomecov \\
         -ibam $bam \\


### PR DESCRIPTION
Fix case-sensitivity issue while sorting bedGraph. 

I got this error while running the dev version of the pipeline:
```
Error executing process > 'UCSC_BEDRAPHTOBIGWIG (KO6_27_Sh_R3)'                                                                                                                      
                                                                                                                                                                                     
Caused by:                                                                                                                                                                           
  Process `UCSC_BEDRAPHTOBIGWIG (KO6_27_Sh_R3)` terminated with an error exit status (255)                                                                                           
                                                                                                                                                                                     
Command executed:                                                                                                                                                                    
                                                                                                                                                                                     
  bedGraphToBigWig KO6_27_Sh_R3.bedGraph GRCh38.primary_assembly.genome.fa.sizes KO6_27_Sh_R3.bigWig                                                                                 
  echo 377 > ucsc.version.txt                                                                                                                                                        
                                                                                                                                                                                     
Command exit status:                                                                                                                                                                 
  255                                                                                                                                                                                
                                                                                                                                                                                     
Command output:                                                                                                                                                                      
  (empty)                                                                                                                                                                            
                                                                                                                                                                                     
Command error:                                                                                                                                                                       
  KO6_27_Sh_R3.bedGraph is not case-sensitive sorted at line 1637255.  Please use "sort -k1,1 -k2,2n" with LC_COLLATE=C,  or bedSort and try again.                                  
                                                                                                                                                                                     
Work dir:                                                                                                                                                                            
  /home/sturm/scratch/projects/2020/geley-rna-binding-proteins/work/a4/8c6d2169f59910a50bdcf1b4164809                                                                                
                                                                                                                                                                                     
Tip: view the complete command output by changing to the process work dir and entering the command `cat .command.out`                        
```

adding `LC_COLLATE=C` indeed resolved the issue. 


PR checklist
 - [x] PR is to `dev` rather than `master`
 - [x] This comment contains a description of changes (with reason)
 - [ ] ~If you've fixed a bug or added code that should be tested, add tests!~
 - [ ] ~If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)~
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] ~Documentation in `docs` is updated~
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
