### PR TITLE
Remove direct singularity pulls and --pull_docker_container parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[2.0](https://github.com/nf-core/rnaseq/releases/tag/2.0)] - 2020-11-12
+## [[2.0](https://github.com/nf-core/rnaseq/releases/tag/2.0)] - 2020-11-13
 
 ### Major enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `--multiqc_title` - MultiQC report title. Printed as page header, used for filename if not otherwise specified
 * `--public_data_ids` - File containing SRA/ENA/GEO identifiers one per line in order to download their associated FastQ files
 * `--publish_dir_mode` - Method used to save pipeline results to output directory
-* `--pull_docker_container` - Force the workflow to pull and use Docker containers if they have been provided
 * `--rsem_index` - Path to directory or tar.gz archive for pre-built RSEM index
 * `--rseqc_modules` - Specify the RSeQC modules to run
 * `--save_merged_fastq` - Save FastQ files after merging re-sequenced libraries in the results directory

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ On release, automated continuous integration tests run the pipeline on a [full-s
     ```
 
     > * Please check [nf-core/configs](https://github.com/nf-core/configs#documentation) to see if a custom config file to run nf-core pipelines already exists for your Institute. If so, you can simply use `-profile <institute>` in your command. This will enable either `docker` or `singularity` and set the appropriate execution settings for your local compute environment.
-    > * If you are using `singularity` then the pipeline will auto-detect this and attempt to pull the Singularity images directly as opposed to performing a conversion from Docker images. If you are persistently observing issues downloading Singularity images directly due to timeout or network issues then please use the `--pull_docker_container` parameter to pull and convert the Docker image instead. It is also highly recommended to use the [`NXF_SINGULARITY_CACHEDIR` or `singularity.cacheDir`](https://www.nextflow.io/docs/latest/singularity.html?#singularity-docker-hub) settings to store the images in a central location for future pipeline runs.
+    > * If you are using `singularity`, it is highly recommended to use the [`NXF_SINGULARITY_CACHEDIR` or `singularity.cacheDir`](https://www.nextflow.io/docs/latest/singularity.html?#singularity-docker-hub) settings to store the images in a central location for future pipeline runs.
 
 4. Start running your own analysis!
 

--- a/lib/Schema.groovy
+++ b/lib/Schema.groovy
@@ -117,6 +117,8 @@ class Schema {
         workflow_summary['runName']      = workflow.runName
         if (workflow.containerEngine) {
             workflow_summary['containerEngine'] = "$workflow.containerEngine"
+        }
+        if (workflow.container) {
             workflow_summary['container']       = "$workflow.container"
         }
         workflow_summary['launchDir']    = workflow.launchDir

--- a/modules/local/process/bedtools_genomecov.nf
+++ b/modules/local/process/bedtools_genomecov.nf
@@ -11,12 +11,8 @@ process BEDTOOLS_GENOMECOV {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bedtools=2.29.2" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bedtools:2.29.2--hc088bd4_0"
-    } else {
-        container "quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
-    }
+    conda     (params.enable_conda ? "bioconda::bedtools=2.29.2" : null)
+    container "quay.io/biocontainers/bedtools:2.29.2--hc088bd4_0"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/local/process/cat_additional_fasta.nf
+++ b/modules/local/process/cat_additional_fasta.nf
@@ -12,12 +12,8 @@ process CAT_ADDITIONAL_FASTA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'genome', publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     input:
     path fasta

--- a/modules/local/process/cat_fastq.nf
+++ b/modules/local/process/cat_fastq.nf
@@ -13,12 +13,8 @@ process CAT_FASTQ {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'merged_fastq', publish_id:meta.id) }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     tuple val(meta), path(reads)

--- a/modules/local/process/deseq2_qc.nf
+++ b/modules/local/process/deseq2_qc.nf
@@ -11,12 +11,8 @@ process DESEQ2_QC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::r-base=4.0.3 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.2 conda-forge::r-rcolorbrewer=1.1_2 conda-forge::r-pheatmap=1.0.12 bioconda::bioconductor-deseq2=1.28.0 bioconda::bioconductor-biocparallel=1.22.0 bioconda::bioconductor-tximport=1.16.0 bioconda::bioconductor-complexheatmap=2.4.2" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0"
-    }
+    conda     (params.enable_conda ? "conda-forge::r-base=4.0.3 conda-forge::r-optparse=1.6.6 conda-forge::r-ggplot2=3.3.2 conda-forge::r-rcolorbrewer=1.1_2 conda-forge::r-pheatmap=1.0.12 bioconda::bioconductor-deseq2=1.28.0 bioconda::bioconductor-biocparallel=1.22.0 bioconda::bioconductor-tximport=1.16.0 bioconda::bioconductor-complexheatmap=2.4.2" : null)
+    container "quay.io/biocontainers/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0"
     
     input:
     path counts

--- a/modules/local/process/dupradar.nf
+++ b/modules/local/process/dupradar.nf
@@ -11,12 +11,8 @@ process DUPRADAR {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bioconductor-dupradar=1.18.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bioconductor-dupradar:1.18.0--r40_1"
-    } else {
-        container "quay.io/biocontainers/bioconductor-dupradar:1.18.0--r40_1"
-    }
+    conda     (params.enable_conda ? "bioconda::bioconductor-dupradar=1.18.0" : null)
+    container "quay.io/biocontainers/bioconductor-dupradar:1.18.0--r40_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/local/process/featurecounts_merge_counts.nf
+++ b/modules/local/process/featurecounts_merge_counts.nf
@@ -9,12 +9,8 @@ process FEATURECOUNTS_MERGE_COUNTS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     path ('counts/*')

--- a/modules/local/process/get_chrom_sizes.nf
+++ b/modules/local/process/get_chrom_sizes.nf
@@ -12,12 +12,8 @@ process GET_CHROM_SIZES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:"genome", publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     path fasta

--- a/modules/local/process/get_software_versions.nf
+++ b/modules/local/process/get_software_versions.nf
@@ -11,12 +11,8 @@ process GET_SOFTWARE_VERSIONS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'pipeline_info', publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     cache false
 

--- a/modules/local/process/gffread.nf
+++ b/modules/local/process/gffread.nf
@@ -10,12 +10,8 @@ process GFFREAD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/gffread:0.12.1--h8b12597_0"
-    } else {
-        container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
-    }
+    conda     (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
+    container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
 
     input:
     path fasta

--- a/modules/local/process/gtf2bed.nf
+++ b/modules/local/process/gtf2bed.nf
@@ -13,12 +13,8 @@ process GTF2BED {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'genome', publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::perl=5.26.2" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/perl:5.26.2"
-    } else {
-        container "quay.io/biocontainers/perl:5.26.2"
-    }
+    conda     (params.enable_conda ? "conda-forge::perl=5.26.2" : null)
+    container "quay.io/biocontainers/perl:5.26.2"
 
     input:
     path gtf

--- a/modules/local/process/gtf_gene_filter.nf
+++ b/modules/local/process/gtf_gene_filter.nf
@@ -9,12 +9,8 @@ process GTF_GENE_FILTER {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'genome', publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     input:
     path fasta

--- a/modules/local/process/gunzip.nf
+++ b/modules/local/process/gunzip.nf
@@ -10,12 +10,8 @@ process GUNZIP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     path archive

--- a/modules/local/process/multiqc.nf
+++ b/modules/local/process/multiqc.nf
@@ -10,12 +10,8 @@ process MULTIQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::multiqc=1.9" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/multiqc:1.9--pyh9f0ad1d_0"
-    } else {
-        container "quay.io/biocontainers/multiqc:1.9--pyh9f0ad1d_0"
-    }
+    conda     (params.enable_conda ? "bioconda::multiqc=1.9" : null)
+    container "quay.io/biocontainers/multiqc:1.9--pyh9f0ad1d_0"
 
     input:
     path multiqc_config

--- a/modules/local/process/multiqc_custom_biotype.nf
+++ b/modules/local/process/multiqc_custom_biotype.nf
@@ -10,12 +10,8 @@ process MULTIQC_CUSTOM_BIOTYPE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     input:
     tuple val(meta), path(count)

--- a/modules/local/process/multiqc_custom_fail_mapped.nf
+++ b/modules/local/process/multiqc_custom_fail_mapped.nf
@@ -8,12 +8,8 @@ process MULTIQC_CUSTOM_FAIL_MAPPED {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     val fail_mapped

--- a/modules/local/process/multiqc_custom_strand_check.nf
+++ b/modules/local/process/multiqc_custom_strand_check.nf
@@ -8,12 +8,8 @@ process MULTIQC_CUSTOM_STRAND_CHECK {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     val fail_strand

--- a/modules/local/process/rsem_merge_counts.nf
+++ b/modules/local/process/rsem_merge_counts.nf
@@ -9,12 +9,8 @@ process RSEM_MERGE_COUNTS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     path ('genes/*')

--- a/modules/local/process/salmon_merge_counts.nf
+++ b/modules/local/process/salmon_merge_counts.nf
@@ -9,12 +9,8 @@ process SALMON_MERGE_COUNTS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     path ('genes_counts/*')

--- a/modules/local/process/salmon_summarizedexperiment.nf
+++ b/modules/local/process/salmon_summarizedexperiment.nf
@@ -10,12 +10,8 @@ process SALMON_SUMMARIZEDEXPERIMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::bioconductor-summarizedexperiment=1.18.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bioconductor-summarizedexperiment:1.18.1--r40_0"
-    } else {
-        container "quay.io/biocontainers/bioconductor-summarizedexperiment:1.18.1--r40_0"
-    }
+    conda     (params.enable_conda ? "bioconda::bioconductor-summarizedexperiment=1.18.1" : null)
+    container "quay.io/biocontainers/bioconductor-summarizedexperiment:1.18.1--r40_0"
 
     input:
     path counts

--- a/modules/local/process/salmon_tx2gene.nf
+++ b/modules/local/process/salmon_tx2gene.nf
@@ -10,12 +10,8 @@ process SALMON_TX2GENE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     input:
     path ("salmon/*")

--- a/modules/local/process/salmon_tximport.nf
+++ b/modules/local/process/salmon_tximport.nf
@@ -10,12 +10,8 @@ process SALMON_TXIMPORT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::bioconductor-tximeta=1.6.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/bioconductor-tximeta:1.6.3--r40_0"
-    } else {
-        container "quay.io/biocontainers/bioconductor-tximeta:1.6.3--r40_0"
-    }
+    conda     (params.enable_conda ? "bioconda::bioconductor-tximeta=1.6.3" : null)
+    container "quay.io/biocontainers/bioconductor-tximeta:1.6.3--r40_0"
     
     input:
     tuple val(meta), path("salmon/*")

--- a/modules/local/process/samplesheet_check.nf
+++ b/modules/local/process/samplesheet_check.nf
@@ -12,12 +12,8 @@ process SAMPLESHEET_CHECK {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:'pipeline_info', publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
 
     input:
     path samplesheet

--- a/modules/local/process/sra_fastq_ftp.nf
+++ b/modules/local/process/sra_fastq_ftp.nf
@@ -14,12 +14,8 @@ process SRA_FASTQ_FTP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     tuple val(meta), val(fastq)

--- a/modules/local/process/sra_ids_to_runinfo.nf
+++ b/modules/local/process/sra_ids_to_runinfo.nf
@@ -13,12 +13,8 @@ process SRA_IDS_TO_RUNINFO {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     val id

--- a/modules/local/process/sra_merge_samplesheet.nf
+++ b/modules/local/process/sra_merge_samplesheet.nf
@@ -11,12 +11,8 @@ process SRA_MERGE_SAMPLESHEET {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
 
     input:
     path ('samplesheets/*')

--- a/modules/local/process/sra_runinfo_to_ftp.nf
+++ b/modules/local/process/sra_runinfo_to_ftp.nf
@@ -11,12 +11,8 @@ process SRA_RUNINFO_TO_FTP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/python:3.8.3"
-    } else {
-        container "quay.io/biocontainers/python:3.8.3"
-    }
+    conda     (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "quay.io/biocontainers/python:3.8.3"
     
     input:
     path runinfo

--- a/modules/local/process/untar.nf
+++ b/modules/local/process/untar.nf
@@ -10,12 +10,8 @@ process UNTAR {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
-    } else {
-        container "biocontainers/biocontainers:v1.2.0_cv1"
-    }
+    conda     (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "biocontainers/biocontainers:v1.2.0_cv1"
     
     input:
     path archive

--- a/modules/nf-core/software/fastqc/main.nf
+++ b/modules/nf-core/software/fastqc/main.nf
@@ -11,12 +11,8 @@ process FASTQC {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0"
-    } else {
-        container "quay.io/biocontainers/fastqc:0.11.9--0"
-    }
+    conda     (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
+    container "quay.io/biocontainers/fastqc:0.11.9--0"
     
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/gffread/main.nf
+++ b/modules/nf-core/software/gffread/main.nf
@@ -10,12 +10,8 @@ process GFFREAD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/gffread:0.12.1--h8b12597_0"
-    } else {
-        container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
-    }
+    conda     (params.enable_conda ? "bioconda::gffread=0.12.1" : null)
+    container "quay.io/biocontainers/gffread:0.12.1--h8b12597_0"
 
     input:
     path gff

--- a/modules/nf-core/software/hisat2/align/main.nf
+++ b/modules/nf-core/software/hisat2/align/main.nf
@@ -13,12 +13,8 @@ process HISAT2_ALIGN {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2880dd9d8ad0a7b221d4eacda9a818e92983128d-0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/hisat2/build/main.nf
+++ b/modules/nf-core/software/hisat2/build/main.nf
@@ -12,12 +12,8 @@ process HISAT2_BUILD {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
-    } else {
-        container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
+    container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
 
     input:
     path fasta

--- a/modules/nf-core/software/hisat2/extractsplicesites/main.nf
+++ b/modules/nf-core/software/hisat2/extractsplicesites/main.nf
@@ -11,12 +11,8 @@ process HISAT2_EXTRACTSPLICESITES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/hisat2:2.2.0--py37hfa133b6_4"
-    } else {
-        container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
-    }
+    conda     (params.enable_conda ? "bioconda::hisat2=2.2.0" : null)
+    container "quay.io/biocontainers/hisat2:2.2.0--py37hfa133b6_4"
 
     input:
     path gtf

--- a/modules/nf-core/software/picard/markduplicates/main.nf
+++ b/modules/nf-core/software/picard/markduplicates/main.nf
@@ -11,12 +11,8 @@ process PICARD_MARKDUPLICATES {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::picard=2.23.8" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/picard:2.23.8--0"
-    } else {
-        container "quay.io/biocontainers/picard:2.23.8--0"
-    }
+    conda     (params.enable_conda ? "bioconda::picard=2.23.8" : null)
+    container "quay.io/biocontainers/picard:2.23.8--0"    
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/preseq/lcextrap/main.nf
+++ b/modules/nf-core/software/preseq/lcextrap/main.nf
@@ -12,12 +12,8 @@ process PRESEQ_LCEXTRAP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/preseq:2.0.3--hf53bd2b_3"
-    } else {
-        container "quay.io/biocontainers/preseq:2.0.3--hf53bd2b_3"
-    }
+    conda     (params.enable_conda ? "bioconda::preseq=2.0.3" : null)
+    container "quay.io/biocontainers/preseq:2.0.3--hf53bd2b_3"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/qualimap/rnaseq/main.nf
+++ b/modules/nf-core/software/qualimap/rnaseq/main.nf
@@ -11,12 +11,8 @@ process QUALIMAP_RNASEQ {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/qualimap:2.2.2d--1"
-    } else {
-        container "quay.io/biocontainers/qualimap:2.2.2d--1"
-    }
+    conda     (params.enable_conda ? "bioconda::qualimap=2.2.2d" : null)
+    container "quay.io/biocontainers/qualimap:2.2.2d--1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rsem/calculateexpression/main.nf
+++ b/modules/nf-core/software/rsem/calculateexpression/main.nf
@@ -11,12 +11,8 @@ process RSEM_CALCULATEEXPRESSION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    }
+    conda     (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
+    container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/rsem/preparereference/main.nf
+++ b/modules/nf-core/software/rsem/preparereference/main.nf
@@ -11,12 +11,8 @@ process RSEM_PREPAREREFERENCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    } else {
-        container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
-    }
+    conda     (params.enable_conda ? "bioconda::rsem=1.3.3 bioconda::star=2.7.6a" : null)
+    container "quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:606b713ec440e799d53a2b51a6e79dbfd28ecf3e-0"
 
     input:
     path fasta

--- a/modules/nf-core/software/rseqc/bamstat/main.nf
+++ b/modules/nf-core/software/rseqc/bamstat/main.nf
@@ -11,12 +11,8 @@ process RSEQC_BAMSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/inferexperiment/main.nf
+++ b/modules/nf-core/software/rseqc/inferexperiment/main.nf
@@ -11,12 +11,8 @@ process RSEQC_INFEREXPERIMENT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/innerdistance/main.nf
+++ b/modules/nf-core/software/rseqc/innerdistance/main.nf
@@ -11,12 +11,8 @@ process RSEQC_INNERDISTANCE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/junctionannotation/main.nf
+++ b/modules/nf-core/software/rseqc/junctionannotation/main.nf
@@ -11,12 +11,8 @@ process RSEQC_JUNCTIONANNOTATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/junctionsaturation/main.nf
+++ b/modules/nf-core/software/rseqc/junctionsaturation/main.nf
@@ -11,12 +11,8 @@ process RSEQC_JUNCTIONSATURATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/readdistribution/main.nf
+++ b/modules/nf-core/software/rseqc/readdistribution/main.nf
@@ -11,12 +11,8 @@ process RSEQC_READDISTRIBUTION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/rseqc/readduplication/main.nf
+++ b/modules/nf-core/software/rseqc/readduplication/main.nf
@@ -11,12 +11,8 @@ process RSEQC_READDUPLICATION {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/rseqc:3.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::rseqc=3.0.1" : null)
+    container "quay.io/biocontainers/rseqc:3.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/salmon/index/main.nf
+++ b/modules/nf-core/software/salmon/index/main.nf
@@ -11,12 +11,8 @@ process SALMON_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/salmon:1.3.0--hf69c8f4_0"
-    } else {
-        container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
-    }
+    conda     (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
+    container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
 
     input:
     path fasta

--- a/modules/nf-core/software/salmon/quant/main.nf
+++ b/modules/nf-core/software/salmon/quant/main.nf
@@ -11,12 +11,8 @@ process SALMON_QUANT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/salmon:1.3.0--hf69c8f4_0"
-    } else {
-        container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
-    }
+    conda     (params.enable_conda ? "bioconda::salmon=1.3.0" : null)
+    container "quay.io/biocontainers/salmon:1.3.0--hf69c8f4_0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/samtools/flagstat/main.nf
+++ b/modules/nf-core/software/samtools/flagstat/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_FLAGSTAT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/software/samtools/idxstats/main.nf
+++ b/modules/nf-core/software/samtools/idxstats/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_IDXSTATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/software/samtools/index/main.nf
+++ b/modules/nf-core/software/samtools/index/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_INDEX {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/samtools/sort/main.nf
+++ b/modules/nf-core/software/samtools/sort/main.nf
@@ -11,12 +11,8 @@ process SAMTOOLS_SORT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/samtools/stats/main.nf
+++ b/modules/nf-core/software/samtools/stats/main.nf
@@ -9,12 +9,8 @@ process SAMTOOLS_STATS {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::samtools=1.10" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/samtools:1.10--h9402c20_2"
-    } else {
-        container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
-    }
+    conda     (params.enable_conda ? "bioconda::samtools=1.10" : null)
+    container "quay.io/biocontainers/samtools:1.10--h9402c20_2"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/software/sortmerna/main.nf
+++ b/modules/nf-core/software/sortmerna/main.nf
@@ -11,12 +11,8 @@ process SORTMERNA {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/sortmerna:4.2.0--0"
-    } else {
-        container "quay.io/biocontainers/sortmerna:4.2.0--0"
-    }
+    conda     (params.enable_conda ? "bioconda::sortmerna=4.2.0" : null)
+    container "quay.io/biocontainers/sortmerna:4.2.0--0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/star/align/main.nf
+++ b/modules/nf-core/software/star/align/main.nf
@@ -12,12 +12,8 @@ process STAR_ALIGN {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/star:2.6.1d--0"
-    } else {
-        container "quay.io/biocontainers/star:2.6.1d--0"
-    }
+    conda     (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    container "quay.io/biocontainers/star:2.6.1d--0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/star/genomegenerate/main.nf
+++ b/modules/nf-core/software/star/genomegenerate/main.nf
@@ -12,12 +12,8 @@ process STAR_GENOMEGENERATE {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:'') }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::star=2.6.1d" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/star:2.6.1d--0"
-    } else {
-        container "quay.io/biocontainers/star:2.6.1d--0"
-    }
+    conda     (params.enable_conda ? "bioconda::star=2.6.1d" : null)
+    container "quay.io/biocontainers/star:2.6.1d--0"
 
     input:
     path fasta

--- a/modules/nf-core/software/stringtie/main.nf
+++ b/modules/nf-core/software/stringtie/main.nf
@@ -12,12 +12,8 @@ process STRINGTIE {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/stringtie:2.1.4--h7e0af3c_0"
-    } else {
-        container "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
-    }
+    conda     (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
+    container "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
 
     input:
     tuple val(meta), path(bam)

--- a/modules/nf-core/software/subread/featurecounts/main.nf
+++ b/modules/nf-core/software/subread/featurecounts/main.nf
@@ -12,12 +12,8 @@ process SUBREAD_FEATURECOUNTS {
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
     // Note: 2.7X indices incompatible with AWS iGenomes.
-    conda (params.enable_conda ? "bioconda::subread=2.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/subread:2.0.1--hed695b0_0"
-    } else {
-        container "quay.io/biocontainers/subread:2.0.1--hed695b0_0"
-    }
+    conda     (params.enable_conda ? "bioconda::subread=2.0.1" : null)
+    container "quay.io/biocontainers/subread:2.0.1--hed695b0_0"
 
     input:
     tuple val(meta), path(bams), path(annotation)

--- a/modules/nf-core/software/trimgalore/main.nf
+++ b/modules/nf-core/software/trimgalore/main.nf
@@ -11,12 +11,8 @@ process TRIMGALORE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/trim-galore:0.6.6--0"
-    } else {
-        container "quay.io/biocontainers/trim-galore:0.6.6--0"
-    }
+    conda     (params.enable_conda ? "bioconda::trim-galore=0.6.6" : null)
+    container "quay.io/biocontainers/trim-galore:0.6.6--0"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/software/ucsc/bedgraphtobigwig/main.nf
+++ b/modules/nf-core/software/ucsc/bedgraphtobigwig/main.nf
@@ -13,12 +13,8 @@ process UCSC_BEDRAPHTOBIGWIG {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/ucsc-bedgraphtobigwig:377--h446ed27_1"
-    } else {
-        container "quay.io/biocontainers/ucsc-bedgraphtobigwig:377--h446ed27_1"
-    }
+    conda     (params.enable_conda ? "bioconda::ucsc-bedgraphtobigwig=377" : null)
+    container "quay.io/biocontainers/ucsc-bedgraphtobigwig:377--h446ed27_1"
 
     input:
     tuple val(meta), path(bedgraph)

--- a/modules/nf-core/software/umitools/dedup/main.nf
+++ b/modules/nf-core/software/umitools/dedup/main.nf
@@ -11,12 +11,8 @@ process UMITOOLS_DEDUP {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/umi_tools:1.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
+    container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/software/umitools/extract/main.nf
+++ b/modules/nf-core/software/umitools/extract/main.nf
@@ -11,12 +11,8 @@ process UMITOOLS_EXTRACT {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), publish_id:meta.id) }
 
-    conda (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
-    if (workflow.containerEngine == 'singularity' && !params.pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/umi_tools:1.0.1--py37h516909a_1"
-    } else {
-        container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
-    }
+    conda     (params.enable_conda ? "bioconda::umi_tools=1.0.1" : null)
+    container "quay.io/biocontainers/umi_tools:1.0.1--py37h516909a_1"
 
     input:
     tuple val(meta), path(reads)

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,7 +81,6 @@ params {
 
   // Boilerplate options
   enable_conda               = false
-  pull_docker_container      = false
   clusterOptions             = ''
   outdir                     = './results'
   publish_dir_mode           = 'copy'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -612,13 +612,6 @@
                     "description": "Run this workflow with Conda. You can also use '-profile conda' instead of providing this parameter.",
                     "hidden": true,
                     "fa_icon": "fas fa-bacon"
-                },
-                "pull_docker_container": {
-                    "type": "boolean",
-                    "description": "Force the workflow to pull and use Docker containers if they have been provided.",
-                    "hidden": true,
-                    "fa_icon": "fas fa-toolbox",
-                    "help_text": "This may be useful for example if you are unable to pull Singularity containers to run the pipeline due to http/https proxy issues."
                 }
             }
         }


### PR DESCRIPTION
Please see description added [here](https://github.com/nf-core/modules/pull/76). The same changes have been made for local modules used in the pipeline too. The `--pull_docker_container` is no longer required and has been removed.