### PR TITLE
Allow sample names without a replicate suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [[#515](https://github.com/nf-core/rnaseq/issues/515)] - Add decoy-aware indexing for salmon
 * [[#516](https://github.com/nf-core/rnaseq/issues/516)] - Unexpected error [InvocationTargetException]
 * [[#525](https://github.com/nf-core/rnaseq/issues/525)] - sra_ids_to_runinfo.py UnicodeEncodeError
+* [[#550](https://github.com/nf-core/rnaseq/issues/525)] - handle samplesheets with replicate=0
 
 ### Parameters
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -143,6 +143,8 @@ def check_samplesheet(file_in, file_out):
                     ## Write to file
                     for idx, sample_info in enumerate(sample_run_dict[sample][replicate]):
                         sample_id = "{}_R{}_T{}".format(sample,replicate,idx+1)
+                        if len(uniq_rep_ids) == 1:
+                            sample_id = "{}_T{}".format(sample,idx+1)
                         fout.write(','.join([sample_id] + sample_info) + '\n')
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,13 @@ You will need to create a samplesheet file with information about the samples in
 
 ### Multiple replicates
 
-The `group` identifier is the same when you have multiple replicates from the same experimental group, just increment the `replicate` identifier appropriately. The first replicate value for any given experimental group must be 1. Below is an example for a single experimental group in triplicate:
+The `group` identifier is the same when you have multiple replicates
+from the same experimental group, just increment the `replicate`
+identifier appropriately. The first replicate value for any given
+experimental group must be 0 or 1: any filenames corresponding to
+`replicate 0` samples will be derived purely from the `group` and not
+have a suffix identifying the replicate number appended. Below is an
+example for a single experimental group in triplicate:
 
 ```bash
 group,replicate,fastq_1,fastq_2,strandedness
@@ -22,6 +28,17 @@ control,1,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz,reve
 control,2,AEG588A2_S2_L002_R1_001.fastq.gz,AEG588A2_S2_L002_R2_001.fastq.gz,reverse
 control,3,AEG588A3_S3_L002_R1_001.fastq.gz,AEG588A3_S3_L002_R2_001.fastq.gz,reverse
 ```
+
+resulting in files prefixed `control_R1`...`control_R3`, in contrast to
+
+```bash
+group,replicate,fastq_1,fastq_2,strandedness
+AEG588A1,0,AEG588A1_S1_L002_R1_001.fastq.gz,AEG588A1_S1_L002_R2_001.fastq.gz,reverse
+AEG588A2,0,AEG588A2_S2_L002_R1_001.fastq.gz,AEG588A2_S2_L002_R2_001.fastq.gz,reverse
+AEG588A3,0,AEG588A3_S3_L002_R1_001.fastq.gz,AEG588A3_S3_L002_R2_001.fastq.gz,reverse
+```
+
+preserving the original filenames, without any `_R0` suffix.
 
 ### Multiple runs of the same library
 


### PR DESCRIPTION
closes #550 

Expands valid values allowed in the `replicate` column of the sample_sheet, so that if it's `0` the `_R0` will be omitted from the generated filenames. Extra logic to deal with missing individual replicate numbers, or the whole column being missing, has been implemented, but is switched off until a command-line argument can be assigned to allow switching between different behaviours.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
