### PR TITLE
Load nf-amazon plugin if downloading from AWS igenomes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Nextflow versions: check pipeline minimum and current latest
-        nxf_ver: ['20.11.0-edge']
+        nxf_ver: ['21.02.0-edge']
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     runs-on: ubuntu-latest
     env:
-      NXF_VER: '20.11.0-edge'
+      NXF_VER: '21.02.0-edge'
       NXF_ANSI_LOG: false
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     runs-on: ubuntu-latest
     env:
-      NXF_VER: '20.11.0-edge'
+      NXF_VER: '21.02.0-edge'
       NXF_ANSI_LOG: false
     strategy:
       matrix:
@@ -98,7 +98,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     runs-on: ubuntu-latest
     env:
-      NXF_VER: '20.11.0-edge'
+      NXF_VER: '21.02.0-edge'
       NXF_ANSI_LOG: false
     strategy:
       matrix:
@@ -123,7 +123,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     runs-on: ubuntu-latest
     env:
-      NXF_VER: '20.11.0-edge'
+      NXF_VER: '21.02.0-edge'
       NXF_ANSI_LOG: false
     strategy:
       matrix:
@@ -148,7 +148,7 @@ jobs:
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/rnaseq') }}
     runs-on: ubuntu-latest
     env:
-      NXF_VER: '20.11.0-edge'
+      NXF_VER: '21.02.0-edge'
       NXF_ANSI_LOG: false
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 * Make tximport output files using all the samples at the same time since working 1 by 1, will generate different numbers (see [#553](https://github.com/nf-core/rnaseq/issues/553), tximport documentation. First pointed by @j-andrews7.
+* Load nf-amazon plugin if AWS igenomes is used (see [#572](https://github.com/nf-core/rnaseq/pull/572)).
+* Updated Nextflow version to `v21.02.0-edge` (see [#572](https://github.com/nf-core/rnaseq/pull/572#issuecomment-781566422)).
 
 ## [[3.0](https://github.com/nf-core/rnaseq/releases/tag/3.0)] - 2020-12-15
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/rnaseq/results)
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.1400710-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.1400710)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A520.11.0--edge-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A521.02.0--edge-23aa62.svg?labelColor=000000)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -419,3 +419,7 @@ params {
     }
   }
 }
+
+plugins {
+  id 'nf-amazon'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -183,7 +183,7 @@ manifest {
   homePage        = 'https://github.com/nf-core/rnaseq'
   description     = 'Nextflow RNA-Seq analysis pipeline, part of the nf-core community.'
   mainScript      = 'main.nf'
-  nextflowVersion = '!>=20.11.0-edge'
+  nextflowVersion = '!>=21.02.0-edge'
   version         = '3.1dev'
 }
 


### PR DESCRIPTION
As described in issue [#571](https://github.com/nf-core/rnaseq/issues/571), the latest edge release of nextflow no longer supports AWS integration out of the box. Instead, the nf-amazon plugin needs to be loaded (previously, it has been loaded by default). (note that plugins are themselves a very new feature of nextflow: I don't think that they are yet included in a non-edge release).

In general, if the user is downloading data from AWS's s3 filesystem then I think they can be expected to load the appropriate plugin. However, using --genome <genome> to load a genome from AWS igenomes also requires this plugin to be loaded (as it is hosted on AWS's s3). For me at least, it was not immediately obvious that this was the case, and so it took me a little while to realise why my pipeline was downloading data from an s3 server (and thus crashing since this plugin wasn't loaded) when I was only using locally stored reads. In the interests of this pipeline requiring as little configuration / troubleshooting as possible from the user, I thought it might be useful to load this plugin by default if the igenomes config file is loaded, which this patch does. This should prevent crashing when loading data from AWS igenomes without the user having to manually load the required plugin.

## PR checklist

- [✓] This comment contains a description of changes (with reason).
- [✕] If you've fixed a bug or added code that should be tested, add tests! (unsure how to test this change) 
- [✕] Make sure your code lints (`nf-core lint .`). (sorry, couldn't get the linter to work)
- [✓] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [✕] `CHANGELOG.md` is updated.
