### PR TITLE
docs: Use actual process name

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -220,7 +220,8 @@ Whilst these default requirements will hopefully work for most people with most 
 
 ```nextflow
 process {
-  withName: star {
+  // Just the process name not RNASEQ:ALIGN_STAR:STAR_ALIGN
+  withName: STAR_ALIGN {
     memory = 32.GB
   }
 }


### PR DESCRIPTION
I was just trying to remember how to limit a process and now with all of the DSL2 magic, I just thought it would be nice to have this in the usage, and not have to go hunt through slack.