### PR TITLE
Fix schema for `hisat_build_memory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[3.1dev](https://github.com/nf-core/rnaseq/releases/tag/3.1)] - 2021-03-26
+## 3.1dev
 
 ### :warning: Major enhancements
 
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [[#569](https://github.com/nf-core/rnaseq/issues/569)] - nextflow edge release documentation for running 3.0
 * Load nf-amazon plugin if AWS igenomes is used (see [#572](https://github.com/nf-core/rnaseq/pull/572)).
 * Only FastQ files that require to be concatenated will be passed to `CAT_FASTQ` process.
+* [[#588](https://github.com/nf-core/rnaseq/pull/588)] - Fix schema for `hisat_build_memory` parameter.
 
 ## [[3.0](https://github.com/nf-core/rnaseq/releases/tag/3.0)] - 2020-12-15
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -186,10 +186,12 @@
                     "description": "Path to directory or tar.gz archive for pre-built Salmon index."
                 },
                 "hisat_build_memory": {
-                    "type": "integer",
-                    "default": 200,
+                    "type": "string",
+                    "default": "200.GB",
                     "fa_icon": "fas fa-memory",
-                    "description": "Memory passed to HISAT2 build process."
+                    "pattern": "^[\\d\\.]+\\s*.(K|M|G|T)?B$",
+                    "description": "Minimum memory required to use splice sites and exons in the HiSAT2 index build process.",
+                    "help_text": "HiSAT2 requies a huge amount of RAM to build a genome index for larger genomes, if including splice sites and exons (a Human genome might typically rqeuire 200GB). If you specify less than this threshold for the `HISAT2_BUILD` process then the splice sites and exons will be ignored, meaning that the process will require a lot less memory. If you are working with a small genome, set this parameter to a lower value to reduce the threshold for skipping this. If using a larger genome, consider changing the pipeline Nextflow config instead to supply more memory to the `HISAT2_BUILD` process."
                 },
                 "gencode": {
                     "type": "boolean",


### PR DESCRIPTION
The schema had a couple of issues for `params.hisat_build_memory`:

* It was set to an integer, meaning that memory could only be supplied in bytes
* The description was wrong

I updated it to be a string with a regex, using what we have in the latest pipeline template dev branch for `--max_memory`. I also wrote a new description text and help text. Hopefully this is clearer now.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
   - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
   - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
