### PR TITLE
Use standard process to auto-detect whether biotype entry exists in GTF file

### DIFF
--- a/lib/Workflow.groovy
+++ b/lib/Workflow.groovy
@@ -202,6 +202,16 @@ class Workflow {
                  "==================================================================================="
     }
 
+    // Print a warning if biotype attribute doesn't exist in GTF file
+    public static void biotypeInGtf(biotype, log) {
+        log.warn "=============================================================================\n" +
+                 "  Biotype attribute '${biotype}' not found in the last column of the GTF file!\n\n" +
+                 "  Biotype QC will be skipped to circumvent the issue below:\n" +
+                 "  https://github.com/nf-core/rnaseq/issues/460\n\n" +
+                 "  Amend '--featurecounts_group_type' to change this behaviour.\n" +
+                 "==================================================================================="
+    }
+
     // Exit pipeline if incorrect --genome key provided
     private static void genomeExists(params, log) {
         if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {

--- a/modules/local/attribute_in_gtf.nf
+++ b/modules/local/attribute_in_gtf.nf
@@ -16,10 +16,12 @@ process ATTRIBUTE_IN_GTF {
     val  attribute
 
     output:
-    env (ATTRIBUTE_EXISTS), emit: attribute_exists
+    env  (ATTRIBUTE_EXISTS), emit: exists
+    path ("*.txt")         , emit: txt
     
     script:
     """
     ATTRIBUTE_EXISTS=\$(awk -F "\t" '{ print \$9 }' $gtf | grep "$attribute " | wc -l | awk '{if(\$1 != 0) {print "true"} else print "false"}')
+    echo \$ATTRIBUTE_EXISTS > attribute_exists.txt
     """
 }

--- a/modules/local/attribute_in_gtf.nf
+++ b/modules/local/attribute_in_gtf.nf
@@ -2,33 +2,24 @@
  * Check if attribute is available in column 9 of GTF file
  */
 process ATTRIBUTE_IN_GTF {
+    tag "$gtf"
+    
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img"
+    } else {
+        container "biocontainers/biocontainers:v1.2.0_cv1"
+    }
 
     input:
-    val gtf
-    val attribute
+    path gtf
+    val  attribute
 
     output:
-    val attribute_in_gtf
+    env (ATTRIBUTE_EXISTS), emit: attribute_exists
     
-    exec:
-    def hits = 0
-    def gtf_file = file(gtf)
-    gtf_file.eachLine { line ->
-        def attributes = line.split('\t')[-1].split()
-        if (attributes.contains(attribute)) {
-            hits ++
-        }
-    }
-
-    attribute_in_gtf = false
-    if (hits) {
-        attribute_in_gtf = true
-    } else {
-        log.warn "=============================================================================\n" +
-                 "  Biotype attribute '${attribute}' not found in the last column of the GTF file!\n\n" +
-                 "  Biotype QC will be skipped to circumvent the issue below:\n" +
-                 "  https://github.com/nf-core/rnaseq/issues/460\n\n" +
-                 "  Amend '--featurecounts_group_type' to change this behaviour.\n" +
-                 "==================================================================================="
-    }
+    script:
+    """
+    ATTRIBUTE_EXISTS=\$(awk -F "\t" '{ print \$9 }' $gtf | grep "$attribute " | wc -l | awk '{if(\$1 != 0) {print "true"} else print "false"}')
+    """
 }

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -559,12 +559,13 @@ workflow RNASEQ {
 
         ATTRIBUTE_IN_GTF
             .out
+            .exists
             .map { it -> if (!it.toBoolean()) Workflow.biotypeInGtf(biotype, log) }
 
         // Prevent any samples from running if GTF file doesn't have a valid biotype
         ch_genome_bam
             .combine(PREPARE_GENOME.out.gtf)
-            .combine(ATTRIBUTE_IN_GTF.out)
+            .combine(ATTRIBUTE_IN_GTF.out.exists)
             .filter { it[-1].toBoolean() }
             .map { it[0..<it.size()-1] }
             .set { ch_featurecounts }

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -557,6 +557,10 @@ workflow RNASEQ {
             biotype
         )
 
+        ATTRIBUTE_IN_GTF
+            .out
+            .map { it -> if (!it.toBoolean()) Workflow.biotypeInGtf(biotype, log) }
+
         // Prevent any samples from running if GTF file doesn't have a valid biotype
         ch_genome_bam
             .combine(PREPARE_GENOME.out.gtf)


### PR DESCRIPTION
Bypass https://github.com/nextflow-io/nextflow/issues/2060 by using a standard `process` with `awk`  rather than a native Groovy process.

Tested my branch via Tower on AWS and the pipeline is now running as expected with `-profile test`.

![image](https://user-images.githubusercontent.com/23529759/115932130-3c587300-a484-11eb-803d-40cece7bd93b.png)
