### PR TITLE
Fix file path composition

### DIFF
--- a/modules/local/sra_to_samplesheet.nf
+++ b/modules/local/sra_to_samplesheet.nf
@@ -40,7 +40,7 @@ process SRA_TO_SAMPLESHEET {
     pipeline_map << meta_map
 
     // Write to file
-    def file = file("${task.workDir}/${meta.id}.samplesheet.csv")
+    def file = task.workDir.resolve("${meta.id}.samplesheet.csv")
     file.write pipeline_map.keySet().collect{ '"' + it + '"'}.join(",") + '\n'
     file.append(pipeline_map.values().collect{ '"' + it + '"'}.join(",")) + '\n'
 }


### PR DESCRIPTION
Path names should be concatenated using the `resolve` API. The string interpolation should never be used with file paths, because it's not portable since it cause the loosing of the file protocol (due to the underlying java API). 

For example if the path is a S3 path eg. `file = "s3://bucket/foo/bar.txt"` the `"$file"` would return `/bucket/foo/bar.txt`.
