### PR TITLE
Fix #610 Save DESeq2 objects as both rds and rdata

### DIFF
--- a/bin/deseq2_qc.r
+++ b/bin/deseq2_qc.r
@@ -104,6 +104,7 @@ if (file.exists(DDSFile) == FALSE) {
     }
     assay(dds, vst_name) <- assay(rld)
     save(dds,file=DDSFile)
+    saveRDS(dds, file=sub("\\.dds\\.RData$", ".rds", DDSFile))
 } else {
     load(DDSFile)
     vst_name <- intersect(assayNames(dds), c("vst", "rlog"))


### PR DESCRIPTION
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

Save an additional rds object, that can be read in to R with a name of the user's choosing. Kept the previous as well, in case people are relying on that. 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
