### PR TITLE
Fix CI markdownlint config location

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
       - name: Run Markdownlint
-        run: markdownlint ${GITHUB_WORKSPACE} -c ${GITHUB_WORKSPACE}/.markdownlint.yml
+        run: markdownlint .
 
       # If the above check failed, post a comment on the PR explaining the failure
       - name: Post PR comment
@@ -36,7 +36,7 @@ jobs:
                 * Everything else: [Install `npm`](https://www.npmjs.com/get-npm) then [install `markdownlint-cli`](https://www.npmjs.com/package/markdownlint-cli) (`npm install -g markdownlint-cli`)
             * Fix the markdown errors
                 * Automatically: `markdownlint . --config .github/markdownlint.yml --fix`
-                * Manually resolve anything left from `markdownlint . --config .github/markdownlint.yml`
+                * Manually resolve anything left from `markdownlint .`
 
             Once you push these changes the test should pass, and you can hide this comment :+1:
 


### PR DESCRIPTION
* Removed the `-c` argument from the lint test command, as that location is already default
* Updated the command in the comment that is posted when the test fails
* Replaced `${GITHUB_WORKSPACE}` with `.` as it should do the same thing and is easier to read.