### PR TITLE
Fix sample sheet schema validation reporting

### DIFF
--- a/lib/NfcoreSchema.groovy
+++ b/lib/NfcoreSchema.groovy
@@ -199,8 +199,9 @@ class NfcoreSchema {
             println ""
             println "=${colors.red}====   ERROR: Validation of '$param_name' file failed!   ============================="
             JSONObject exceptionJSON = e.toJSON()
+            println e.getMessage()
             e.getCausingExceptions().stream().map(ValidationException::getMessage).forEach(System.out::println)
-            println "=${colors.red}==================================================================================${colors.reset}"
+            println "===================================================================================${colors.reset}"
             println ""
             System.exit(1)
         }


### PR DESCRIPTION
* Don't stain the terminal red
* Print the top-level message in case causingExceptions is empty.
