### PR TITLE
Error in SALMON_SE_TRANSCRIPT process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+* Fix SALMON_SE_TRANSCRIPT process. It was removing the first sample in the matrix
 * Updated pipeline template to nf-core/tools `1.14`
 * Only FastQ files that require to be concatenated will be passed to `CAT_FASTQ` process
 * [[#449](https://github.com/nf-core/modules/pull/449)] - `--genomeSAindexNbases` will now be auto-calculated before building STAR indices

--- a/bin/salmon_tximport.r
+++ b/bin/salmon_tximport.r
@@ -66,7 +66,7 @@ if (!is.null(tx2gene)) {
 }
 
 build_table = function(se.obj, slot) {
-    cbind(rowData(se.obj), assays(se.obj)[[slot]])
+    cbind(rowData(se.obj)[,1:2], assays(se.obj)[[slot]])
 }
 
 if(exists("gse")){
@@ -78,8 +78,8 @@ if(exists("gse")){
     write.table(build_table(gse.s, "counts"), paste(c(prefix, "gene_counts_scaled.tsv"), collapse="."), sep="\t", quote=FALSE, row.names = FALSE)
 }
 
-write.table(assays(se)[["abundance"]], paste(c(prefix, "transcript_tpm.tsv"), collapse="."), sep="\t", quote=FALSE)
-write.table(assays(se)[["counts"]], paste(c(prefix, "transcript_counts.tsv"), collapse="."), sep="\t", quote=FALSE)
+write.table(build_table(se,"abundance"), paste(c(prefix, "transcript_tpm.tsv"), collapse="."), sep="\t", quote=FALSE)
+write.table(build_table(se, "counts"), paste(c(prefix, "transcript_counts.tsv"), collapse="."), sep="\t", quote=FALSE)
 
 # Print sessioninfo to standard out
 citation("tximeta")


### PR DESCRIPTION
The first sample was removed from the initial matrix giving an error when the samples in the run is 2 or less.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
 - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
