### PR TITLE
Fix pipeline if only one sample is provided

### DIFF
--- a/bin/salmon_summarizedexperiment.r
+++ b/bin/salmon_summarizedexperiment.r
@@ -24,9 +24,9 @@ if (info$size == 0) {
 }
 
 counts = read.csv(counts_fn, row.names=1, sep="\t")
-counts = counts[,2:ncol(counts)] # remove gene_name column
+counts = counts[,2:ncol(counts),drop=FALSE] # remove gene_name column
 tpm = read.csv(tpm_fn, row.names=1, sep="\t")
-tpm = tpm[,2:ncol(tpm)] # remove gene_name column
+tpm = tpm[,2:ncol(tpm),drop=FALSE] # remove gene_name column
 
 if (length(intersect(rownames(counts), rowdata[["tx"]])) > length(intersect(rownames(counts), rowdata[["gene_id"]]))) {
     by_what = "tx"


### PR DESCRIPTION
This script will fail if only one sample is provided as R drops the matrix to a vector if not `drop=FALSE` is given.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - Not sure if this should be tested in the future through tests or not. Please let me know.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] `CHANGELOG.md` is updated.
    - I can do this if needed for this small change
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
    - as I'm a new contribute and this is a minor change should I do this?
