### PR TITLE
Patch use of file append

### DIFF
--- a/modules/local/sra_to_samplesheet.nf
+++ b/modules/local/sra_to_samplesheet.nf
@@ -37,8 +37,8 @@ process SRA_TO_SAMPLESHEET {
     ]
     pipeline_map << meta_map
 
-    // create a sample sheet 
-    def csv = "sample,fastq_1,fastq_2,strandedness\n" + 
+    // create a sample sheet
+    def csv = "sample,fastq_1,fastq_2,strandedness\n" +
             "${pipeline_map.sample},${pipeline_map.fastq_1},${pipeline_map,fastq_2},'unstranded'\n"
 
     // Write to file

--- a/modules/local/sra_to_samplesheet.nf
+++ b/modules/local/sra_to_samplesheet.nf
@@ -37,8 +37,11 @@ process SRA_TO_SAMPLESHEET {
     ]
     pipeline_map << meta_map
 
+    // create a sample sheet 
+    def csv = "sample,fastq_1,fastq_2,strandedness\n" + 
+            "${pipeline_map.sample},${pipeline_map.fastq_1},${pipeline_map,fastq_2},'unstranded'\n"
+
     // Write to file
     def file = task.workDir.resolve("${meta.id}.samplesheet.csv")
-    file.write pipeline_map.keySet().collect{ '"' + it + '"'}.join(",") + '\n'
-    file.append(pipeline_map.values().collect{ '"' + it + '"'}.join(",")) + '\n'
+    file.text = csv
 }


### PR DESCRIPTION
The `SRA_TO_SAMPLESHEET` process is still problematic. It contains the use of `file.append` which is not supported by all storage. 

Especially attention should be taken when writing portable code for the cloud. Generally, the storage provided by these platforms provides limited I/O operations i.e. read, write but not append or random access. Therefore operations should be done all at once  
