### PR TITLE
Bump stringtie version to 2.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Note, since the pipeline is now using Nextflow DSL2, each process will be run wi
 |-------------|-------------|-------------|
 | `umi_tools` | 1.1.1       | 1.1.2       |
 | `samtools`  | 1.10        | 1.12        |
+| `stringtie` | 2.1.4       | 2.1.7       |
 
 > **NB:** Dependency has been __updated__ if both old and new version information is present.
 > **NB:** Dependency has been __added__ if just the new version information is present.

--- a/modules.json
+++ b/modules.json
@@ -91,7 +91,7 @@
                 "git_sha": "e937c7950af70930d1f34bb961403d9d2aa81c7d"
             },
             "stringtie/stringtie": {
-                "git_sha": "e937c7950af70930d1f34bb961403d9d2aa81c7d"
+                "git_sha": "217303f5c1a92effb8a97c29294ee9f2e19f697e"
             },
             "subread/featurecounts": {
                 "git_sha": "e937c7950af70930d1f34bb961403d9d2aa81c7d"

--- a/modules/nf-core/modules/stringtie/stringtie/main.nf
+++ b/modules/nf-core/modules/stringtie/stringtie/main.nf
@@ -11,11 +11,11 @@ process STRINGTIE {
         mode: params.publish_dir_mode,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
-    conda (params.enable_conda ? "bioconda::stringtie=2.1.4" : null)
+    conda (params.enable_conda ? "bioconda::stringtie=2.1.7" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/stringtie:2.1.4--h7e0af3c_0"
+        container "https://depot.galaxyproject.org/singularity/stringtie:2.1.7--h978d192_0"
     } else {
-        container "quay.io/biocontainers/stringtie:2.1.4--h7e0af3c_0"
+        container "quay.io/biocontainers/stringtie:2.1.7--h978d192_0"
     }
 
     input:
@@ -48,8 +48,9 @@ process STRINGTIE {
         -A ${prefix}.gene.abundance.txt \\
         -C ${prefix}.coverage.gtf \\
         -b ${prefix}.ballgown \\
+        -p $task.cpus \\
         $options.args
 
-    stringtie --version > ${software}.version.txt
+    echo \$(stringtie --version 2>&1) > ${software}.version.txt
     """
 }


### PR DESCRIPTION
Version of stringtie bumped to 2.1.7

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
