### PR TITLE
python 3 scripts in bin could use a python3 shebang line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unpublished Version / DEV]
 
 ### Enhancements & fixes
+* Updated python3 script shebang line to specify python3
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unpublished Version / DEV]
 
 ### Enhancements & fixes
-* Updated python3 script shebang line to specify python3
+
+* Add `python3` shebang to appropriate scripts in `bin/` directory
 
 ### Parameters
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/bin/fasta2gtf.py
+++ b/bin/fasta2gtf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Read a custom fasta file and create a custom GTF containing each entry
 """

--- a/bin/fastq_dir_to_samplesheet.py
+++ b/bin/fastq_dir_to_samplesheet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Very minor change, but I use a copy of both of these scripts and ran into a python2/python3 conflict issue regarding f-strings when a pipeline is run locally using `module`. If the user has a copy of python2 loaded anywhere, it tries to run these scripts with python2 rather than 3, which runs into an `invalid syntax` error due to the f-strings.

I figured since there is no loss to specifying python3 in the shebang line it may as well be added on the off chance that someone is running these scripts outside a container.

I'm not too sure if the other py scripts in `bin` I didn't edit run fine on python2, so I didn't edit them.