### PR TITLE
Add StringTie prepDE.py module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+* Added StringTie `prepDE.py` module to generate gene/transcript level counts
+
 ### Parameters
+
+| Old parameter               | New parameter                  |
+|-----------------------------|--------------------------------|
+|                             | `--skip_stringtie_prepde`      |
+
+> **NB:** Parameter has been __updated__ if both old and new parameter information is present.
+> **NB:** Parameter has been __added__ if just the new parameter information is present.
+> **NB:** Parameter has been __removed__ if parameter information isn't present.
 
 ## [[3.3](https://github.com/nf-core/rnaseq/releases/tag/3.3)] - 2021-07-29
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -175,6 +175,9 @@ params {
             args            = '-v'
             publish_dir     = "${params.aligner}/stringtie"
         }
+        'stringtie_prepde' {
+            publish_dir     = "${params.aligner}/stringtie"
+        }
         'subread_featurecounts' {
             args            = '-B -C'
             publish_dir     = "${params.aligner}/featurecounts"

--- a/docs/output.md
+++ b/docs/output.md
@@ -279,6 +279,8 @@ Unless you are using [UMIs](https://emea.illumina.com/science/sequencing-method-
     * `*.coverage.gtf`: GTF file containing transcripts that are fully covered by reads.
     * `*.transcripts.gtf`: GTF file containing all of the assembled transcipts from StringTie.
     * `*.gene_abundance.txt`: Text file containing gene aboundances and FPKM values.
+    * `*.transcript_count_matrix.csv`: CSV file containing raw counts for all annotated transcipts derived from StringTie results.
+    * `*.gene_count_matrix.csv`: CSV file containing raw counts for all annotated genes derived from StringTie results.
 * `<ALIGNER>/stringtie/<SAMPLE>.ballgown/`: Ballgown output directory.
 
 </details>

--- a/lib/WorkflowRnaseq.groovy
+++ b/lib/WorkflowRnaseq.groovy
@@ -117,6 +117,21 @@ class WorkflowRnaseq {
     }
 
     //
+    // Function that parses read length from FastQC html report
+    //
+    public static Integer getFastqcReadLength(report) {
+        def read_length = 76
+        def pattern = /Sequence length<\/td><td>(.*?)</
+        report.eachLine { line ->
+            def matcher = line =~ pattern
+            if (matcher) {
+                read_length = matcher[0][1].tokenize('-')[0].toInteger()
+            }
+        }
+        return read_length
+    }
+
+    //
     // Function that parses and returns the alignment rate from the STAR log output
     //
     public static ArrayList getStarPercentMapped(params, align_log) {

--- a/modules/local/stringtie_prepde.nf
+++ b/modules/local/stringtie_prepde.nf
@@ -36,6 +36,7 @@ process STRINGTIE_PREPDE {
         -i sample_lst.txt \\
         -g ${prefix}.gene_count_matrix.csv \\
         -t ${prefix}.transcript_count_matrix.csv \\
+        -l $meta.read_length \\
         $options.args
 
     echo \$(stringtie --version 2>&1) > ${software}.version.txt

--- a/modules/local/stringtie_prepde.nf
+++ b/modules/local/stringtie_prepde.nf
@@ -1,0 +1,43 @@
+// Import generic module functions
+include { initOptions; saveFiles; getSoftwareName } from './functions'
+
+params.options = [:]
+options        = initOptions(params.options)
+
+process STRINGTIE_PREPDE {
+    tag "$meta.id"
+    label 'process_low'
+    publishDir "${params.outdir}",
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
+
+    conda (params.enable_conda ? "bioconda::stringtie=2.1.7" : null)
+    if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
+        container "https://depot.galaxyproject.org/singularity/stringtie:2.1.7--h978d192_0"
+    } else {
+        container "quay.io/biocontainers/stringtie:2.1.7--h978d192_0"
+    }
+
+    input:
+    tuple val(meta), path(gtf)
+
+    output:
+    tuple val(meta), path("*.gene_count_matrix.csv")      , emit: counts_gene
+    tuple val(meta), path("*.transcript_count_matrix.csv"), emit: counts_transcript
+    path  "*.version.txt"                                 , emit: version
+
+    script:
+    def software = getSoftwareName(task.process)
+    def prefix   = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
+    """
+    echo "${meta.id} ${gtf}" > sample_lst.txt
+
+    prepDE.py \\
+        -i sample_lst.txt \\
+        -g ${prefix}.gene_count_matrix.csv \\
+        -t ${prefix}.transcript_count_matrix.csv \\
+        $options.args
+
+    echo \$(stringtie --version 2>&1) > ${software}.version.txt
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,6 +58,7 @@ params {
     save_unaligned             = false
     save_align_intermeds       = false
     skip_markduplicates        = false
+    skip_stringtie_prepde      = false
     skip_alignment             = false
 
     // QC

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -384,6 +384,11 @@
                     "fa_icon": "fas fa-fast-forward",
                     "description": "Skip picard MarkDuplicates step."
                 },
+                "skip_stringtie_prepde": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-fast-forward",
+                    "description": "Skip StringTie prepDE.py step."
+                },
                 "skip_alignment": {
                     "type": "boolean",
                     "fa_icon": "fas fa-fast-forward",

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -86,6 +86,7 @@ def deseq2_qc_salmon_options          = deseq2_qc_options.clone()
 deseq2_qc_salmon_options.publish_dir  = "salmon/deseq2_qc"
 
 include { BEDTOOLS_GENOMECOV                 } from '../modules/local/bedtools_genomecov'          addParams( options: modules['bedtools_genomecov']                     )
+include { STRINGTIE_PREPDE                   } from '../modules/local/stringtie_prepde'            addParams( options: modules['stringtie_prepde']                       )
 include { DESEQ2_QC as DESEQ2_QC_STAR_SALMON } from '../modules/local/deseq2_qc'                   addParams( options: deseq2_qc_options, multiqc_label: 'star_salmon'   )
 include { DESEQ2_QC as DESEQ2_QC_RSEM        } from '../modules/local/deseq2_qc'                   addParams( options: deseq2_qc_options, multiqc_label: 'star_rsem'     )
 include { DESEQ2_QC as DESEQ2_QC_SALMON      } from '../modules/local/deseq2_qc'                   addParams( options: deseq2_qc_salmon_options, multiqc_label: 'salmon' )
@@ -549,6 +550,12 @@ workflow RNASEQ {
             PREPARE_GENOME.out.gtf
         )
         ch_software_versions = ch_software_versions.mix(STRINGTIE.out.version.first().ifEmpty(null))
+
+        if (!params.skip_stringtie_prepde) {
+            STRINGTIE_PREPDE (
+                STRINGTIE.out.transcript_gtf
+            )
+        }
     }
 
     //


### PR DESCRIPTION
Added a local module to generate counts from StringTie results as explained in the [docs](http://ccb.jhu.edu/software/stringtie/index.shtml?t=manual#deseq). The counts will be generated separately for each sample because it is better this way for scaling purposes - especially those that run the pipeline on 100s-1000s samples.

I attempted to add another downstream module to merge the counts across samples but it appears like the ordering of the gene/transcript ids isn't always the same when generated via `prepDE.py`. I think it's best to read these files individually into R and `sort` them accordingly whilst creating a counts matrix.