### PR TITLE
Fix reporting of versions with trailing zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Parameters
 
-## [[3.4](https://github.com/nf-core/rnaseq/releases/tag/3.3)] - 2021-10-05
+## [[3.4](https://github.com/nf-core/rnaseq/releases/tag/3.4)] - 2021-10-05
 
 ### Enhancements & fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+* Fix version reporting of versions with trailing zeros.
+
 ### Parameters
 
 ## [[3.4](https://github.com/nf-core/rnaseq/releases/tag/3.4)] - 2021-10-05

--- a/modules.json
+++ b/modules.json
@@ -10,7 +10,7 @@
                 "git_sha": "49da8642876ae4d91128168cd0db4f1c858d7792"
             },
             "custom/dumpsoftwareversions": {
-                "git_sha": "49da8642876ae4d91128168cd0db4f1c858d7792"
+                "git_sha": "84f2302920078b0cf7716b2a2e5fcc0be5c4531d"
             },
             "fastqc": {
                 "git_sha": "49da8642876ae4d91128168cd0db4f1c858d7792"

--- a/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/modules/custom/dumpsoftwareversions/main.nf
@@ -79,7 +79,7 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     }
 
     with open("$versions") as f:
-        workflow_versions = yaml.safe_load(f) | module_versions
+        workflow_versions = yaml.load(f, Loader=yaml.BaseLoader) | module_versions
 
     workflow_versions["Workflow"] = {
         "Nextflow": "$workflow.nextflow.version",


### PR DESCRIPTION
As shown in the image below and was discussed on slack, versions with trailing zeros were not being correctly reported, e.g. samtools version `1.10` was reported as `1.1`.

![image (1)](https://user-images.githubusercontent.com/6224346/136276151-28f1fdce-923c-4ca0-acd7-5e9f20df4bbc.png)

# PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] `CHANGELOG.md` is updated.
