### PR TITLE
Add linguist overrides for cleaner diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 *.config linguist-language=nextflow
+lib/NfcoreSchema.groovy linguist-generated
+lib/NfcoreTemplate.groovy linguist-generated
+lib/Utils.groovy linguist-generated
+modules/nf-core/* linguist-generated
+subworkflows/nf-core/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
 *.config linguist-language=nextflow
-lib/NfcoreSchema.groovy linguist-generated
-lib/NfcoreTemplate.groovy linguist-generated
-lib/Utils.groovy linguist-generated
 modules/nf-core/* linguist-generated
 subworkflows/nf-core/* linguist-generated

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,5 +1,6 @@
 lint:
   files_unchanged:
+    - .gitattributes
     - .markdownlint.yml
     - assets/email_template.html
     - assets/email_template.txt


### PR DESCRIPTION
This should auto-collapse nf-core modules, subworkflows, and static library files in all diffs.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
