### PR TITLE
Move deseq2_qc multiqc label to args2

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -489,6 +489,7 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
                     "--count_col 3",
                     params.deseq2_vst ? '--vst TRUE' : ''
                 ].join(' ').trim()
+                ext.args2  = 'star_salmon'
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/deseq2_qc" },
                     mode: 'copy',
@@ -548,6 +549,7 @@ if (!params.skip_alignment && params.aligner == 'star_rsem') {
                     "--count_col 3",
                     params.deseq2_vst ? '--vst TRUE' : ''
                 ].join(' ').trim()
+                ext.args2  = 'star_rsem'
                 publishDir = [
                     path: { "${params.outdir}/${params.aligner}/deseq2_qc" },
                     mode: 'copy',
@@ -1018,6 +1020,7 @@ if (params.pseudo_aligner == 'salmon') {
                     "--count_col 3",
                     params.deseq2_vst ? '--vst TRUE' : ''
                 ].join(' ').trim()
+                ext.args2  = 'salmon'
                 publishDir = [
                     path: { "${params.outdir}/${params.pseudo_aligner}/deseq2_qc" },
                     mode: 'copy',

--- a/modules/local/deseq2_qc.nf
+++ b/modules/local/deseq2_qc.nf
@@ -1,5 +1,3 @@
-params.multiqc_label = ''
-
 process DESEQ2_QC {
     label "process_medium"
 
@@ -27,9 +25,10 @@ process DESEQ2_QC {
     path "versions.yml"         , emit: versions
 
     script:
-    def args = task.ext.args ?: ''
-    def label_lower = params.multiqc_label.toLowerCase()
-    def label_upper = params.multiqc_label.toUpperCase()
+    def args  = task.ext.args  ?: ''
+    def args2 = task.ext.args2 ?: ''
+    def label_lower = args2.toLowerCase()
+    def label_upper = args2.toUpperCase()
     """
     deseq2_qc.r \\
         --count_file $counts \\

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -83,9 +83,9 @@ ch_biotypes_header_multiqc   = file("$projectDir/assets/multiqc/biotypes_header.
 // MODULE: Loaded from modules/local/
 //
 include { BEDTOOLS_GENOMECOV                 } from '../modules/local/bedtools_genomecov'
-include { DESEQ2_QC as DESEQ2_QC_STAR_SALMON } from '../modules/local/deseq2_qc' addParams( multiqc_label: 'star_salmon' )
-include { DESEQ2_QC as DESEQ2_QC_RSEM        } from '../modules/local/deseq2_qc' addParams( multiqc_label: 'star_rsem'   )
-include { DESEQ2_QC as DESEQ2_QC_SALMON      } from '../modules/local/deseq2_qc' addParams( multiqc_label: 'salmon'      )
+include { DESEQ2_QC as DESEQ2_QC_STAR_SALMON } from '../modules/local/deseq2_qc'
+include { DESEQ2_QC as DESEQ2_QC_RSEM        } from '../modules/local/deseq2_qc'
+include { DESEQ2_QC as DESEQ2_QC_SALMON      } from '../modules/local/deseq2_qc'
 include { DUPRADAR                           } from '../modules/local/dupradar'
 include { MULTIQC                            } from '../modules/local/multiqc'
 include { MULTIQC_CUSTOM_BIOTYPE             } from '../modules/local/multiqc_custom_biotype'


### PR DESCRIPTION
Removes the addParams remaining in the rnaseq workflow.
args2 used to be consistent with other modules. 