### PR TITLE
Patch RSEM_PREPAREREFERENCE configuration

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -94,7 +94,7 @@ process {
         ]
     }
 
-    withName: RSEM_PREPAREREFERENCE {
+    withName: RSEM_PREPAREREFERENCE_GENOME {
         ext.args   = '--star'
         publishDir = [
             path: { "${params.outdir}/genome/index" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,7 @@ process {
 //
 
 process {
-    withName: 'GUNZIP_.*|RSEM_PREPAREREFERENCE_TRANSCRIPTS' {
+    withName: 'GUNZIP_.*|MAKE_TRANSCRIPTS_FASTA' {
         publishDir = [
             path: { "${params.outdir}/genome" },
             mode: 'copy',

--- a/conf/test.config
+++ b/conf/test.config
@@ -43,7 +43,7 @@ params {
 
 // When using RSEM, remove warning from STAR whilst building tiny indices
 process {
-    withName: 'RSEM_PREPAREREFERENCE' {
+    withName: 'RSEM_PREPAREREFERENCE_GENOME' {
         ext.args2 = "--genomeSAindexNbases 7"
     }
 }

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -21,7 +21,7 @@ include { HISAT2_EXTRACTSPLICESITES         } from '../../modules/nf-core/module
 include { HISAT2_BUILD                      } from '../../modules/nf-core/modules/hisat2/build/main'
 include { SALMON_INDEX                      } from '../../modules/nf-core/modules/salmon/index/main'
 include { RSEM_PREPAREREFERENCE as RSEM_PREPAREREFERENCE_GENOME      } from '../../modules/nf-core/modules/rsem/preparereference/main'
-include { RSEM_PREPAREREFERENCE as RSEM_PREPAREREFERENCE_TRANSCRIPTS } from '../../modules/nf-core/modules/rsem/preparereference/main'
+include { RSEM_PREPAREREFERENCE as MAKE_TRANSCRIPTS_FASTA } from '../../modules/nf-core/modules/rsem/preparereference/main'
 
 include { GTF2BED              } from '../../modules/local/gtf2bed'
 include { CAT_ADDITIONAL_FASTA } from '../../modules/local/cat_additional_fasta'
@@ -113,9 +113,9 @@ workflow PREPARE_GENOME {
         }
     } else {
         ch_filter_gtf = GTF_GENE_FILTER ( ch_fasta, ch_gtf ).gtf
-        ch_transcript_fasta = RSEM_PREPAREREFERENCE_TRANSCRIPTS ( ch_fasta, ch_filter_gtf ).transcript_fasta
+        ch_transcript_fasta = MAKE_TRANSCRIPTS_FASTA ( ch_fasta, ch_filter_gtf ).transcript_fasta
         ch_versions         = ch_versions.mix(GTF_GENE_FILTER.out.versions)
-        ch_versions         = ch_versions.mix(RSEM_PREPAREREFERENCE_TRANSCRIPTS.out.versions)
+        ch_versions         = ch_versions.mix(MAKE_TRANSCRIPTS_FASTA.out.versions)
     }
 
     //

--- a/subworkflows/local/prepare_genome.nf
+++ b/subworkflows/local/prepare_genome.nf
@@ -20,7 +20,7 @@ include { BBMAP_BBSPLIT                     } from '../../modules/nf-core/module
 include { HISAT2_EXTRACTSPLICESITES         } from '../../modules/nf-core/modules/hisat2/extractsplicesites/main'
 include { HISAT2_BUILD                      } from '../../modules/nf-core/modules/hisat2/build/main'
 include { SALMON_INDEX                      } from '../../modules/nf-core/modules/salmon/index/main'
-include { RSEM_PREPAREREFERENCE as RSEM_PREPAREREFERENCE             } from '../../modules/nf-core/modules/rsem/preparereference/main'
+include { RSEM_PREPAREREFERENCE as RSEM_PREPAREREFERENCE_GENOME      } from '../../modules/nf-core/modules/rsem/preparereference/main'
 include { RSEM_PREPAREREFERENCE as RSEM_PREPAREREFERENCE_TRANSCRIPTS } from '../../modules/nf-core/modules/rsem/preparereference/main'
 
 include { GTF2BED              } from '../../modules/local/gtf2bed'
@@ -182,8 +182,8 @@ workflow PREPARE_GENOME {
                 ch_rsem_index = file(params.rsem_index)
             }
         } else {
-            ch_rsem_index = RSEM_PREPAREREFERENCE ( ch_fasta, ch_gtf ).index
-            ch_versions   = ch_versions.mix(RSEM_PREPAREREFERENCE.out.versions)
+            ch_rsem_index = RSEM_PREPAREREFERENCE_GENOME ( ch_fasta, ch_gtf ).index
+            ch_versions   = ch_versions.mix(RSEM_PREPAREREFERENCE_GENOME.out.versions)
         }
     }
 


### PR DESCRIPTION
Patches RSEM_PREPAREREFERENCE configuration so it doesn't apply to RSEM_PREPAREREFERENCE_TRANSCRIPTS.

Related bug: https://github.com/nextflow-io/nextflow/issues/2490

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
