### PR TITLE
Make --outdir mandatory, tin.py opt-in and fix #750

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnas
     - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
     - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
 - [ ] Make sure your code lints (`nf-core lint`).
-- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
+- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.
 - [ ] `CHANGELOG.md` is updated.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run pipeline with test data
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --outdir ./results
 
   star_salmon:
     name: Test STAR Salmon with workflow parameters
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run pipeline with STAR and various parameters
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner star_salmon ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner star_salmon ${{ matrix.parameters }} --outdir ./results
 
   star_rsem:
     name: Test STAR RSEM with workflow parameters
@@ -98,7 +98,7 @@ jobs:
 
       - name: Run pipeline with RSEM STAR and various parameters
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner star_rsem ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner star_rsem ${{ matrix.parameters }} --outdir ./results
 
   hisat2:
     name: Test HISAT2 with workflow parameters
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run pipeline with HISAT2 and various parameters
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner hisat2 ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --aligner hisat2 ${{ matrix.parameters }} --outdir ./results
 
   salmon:
     name: Test Salmon with workflow parameters
@@ -142,4 +142,4 @@ jobs:
 
       - name: Run pipeline with Salmon and various parameters
         run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --pseudo_aligner salmon ${{ matrix.parameters }}
+          nextflow run ${GITHUB_WORKSPACE} -profile test,docker --pseudo_aligner salmon ${{ matrix.parameters }} --outdir ./results

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -4,6 +4,7 @@ lint:
     - assets/email_template.txt
     - lib/NfcoreTemplate.groovy
     - .github/ISSUE_TEMPLATE/bug_report.yml
+    - .github/PULL_REQUEST_TEMPLATE.md
     - .github/workflows/branch.yml
     - .github/workflows/linting_comment.yml
     - .github/workflows/linting.yml

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -17,4 +17,4 @@ update:
     rseqc/junctionsaturation: "e745e167c1020928ef20ea1397b6b4d230681b4d"
     rseqc/readdistribution: "e745e167c1020928ef20ea1397b6b4d230681b4d"
     rseqc/readduplication: "e745e167c1020928ef20ea1397b6b4d230681b4d"
-    rseqc/tin: "e745e167c1020928ef20ea1397b6b4d230681b4d"
+    rseqc/tin: "4dbc166a7c30e963511fb5c9870fbcaa158a53a9"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [[#754](https://github.com/nf-core/rnaseq/issues/754)] - DESeq2 QC issue linked to `--count_col` parameter
 * [[#755](https://github.com/nf-core/rnaseq/issues/755)] - Rename RSEM_PREPAREREFERENCE_TRANSCRIPTS process
 * [[#759](https://github.com/nf-core/rnaseq/issues/759)] - Empty lines in samplesheet.csv cause a crash
+* [[#769](https://github.com/nf-core/rnaseq/issues/769)] - Do not run RSeQC tin.py by default
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | Old parameter                 | New parameter                         |
 |-------------------------------|---------------------------------------|
 |                               | `--publish_dir_mode`                  |
+|                               | `--umi_discard_read`                  |
 
 > **NB:** Parameter has been **updated** if both old and new parameter information is present.
 >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [[#734](https://github.com/nf-core/rnaseq/issues/734)] - Is a vulnerable picard still used ? log4j vulnerability
 * [[#744](https://github.com/nf-core/rnaseq/issues/744)] - Auto-detect and raise error if CSI is required for BAM indexing
+* [[#750](https://github.com/nf-core/rnaseq/issues/750)] - Optionally ignore R1 / R2 after UMI extraction process
 * [[#752](https://github.com/nf-core/rnaseq/issues/752)] - How to set publishing mode for all processes?
 * [[#753](https://github.com/nf-core/rnaseq/issues/753)] - Add warning when user provides `--transcript_fasta`
 * [[#754](https://github.com/nf-core/rnaseq/issues/754)] - DESeq2 QC issue linked to `--count_col` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+* [nf-core/tools#1415](https://github.com/nf-core/tools/issues/1415) - Make `--outdir` a mandatory parameter
 * [[#734](https://github.com/nf-core/rnaseq/issues/734)] - Is a vulnerable picard still used ? log4j vulnerability
 * [[#744](https://github.com/nf-core/rnaseq/issues/744)] - Auto-detect and raise error if CSI is required for BAM indexing
 * [[#750](https://github.com/nf-core/rnaseq/issues/750)] - Optionally ignore R1 / R2 after UMI extraction process

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The SRA download functionality has been removed from the pipeline (`>=3.2`) and 
 3. Download the pipeline and test it on a minimal dataset with a single command:
 
     ```console
-    nextflow run nf-core/rnaseq -profile test,YOURPROFILE
+    nextflow run nf-core/rnaseq -profile test,YOURPROFILE --outdir <OUTDIR>
     ```
 
     Note that some form of configuration will be needed so that Nextflow knows how to fetch the required software. This is usually done in the form of a config profile (`YOURPROFILE` in the example command above). You can chain multiple config profiles in a comma-separated string.
@@ -77,6 +77,7 @@ The SRA download functionality has been removed from the pipeline (`>=3.2`) and 
     ```console
     nextflow run nf-core/rnaseq \
         --input samplesheet.csv \
+        --outdir <OUTDIR> \
         --genome GRCh37 \
         -profile <docker/singularity/podman/conda/institute>
     ```

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -902,7 +902,7 @@ if (!params.skip_alignment && !params.skip_qc) {
                 }
             }
         }
-        
+
         if ('read_duplication' in rseqc_modules) {
             process {
                 withName: '.*:RSEQC:RSEQC_READDUPLICATION' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -825,159 +825,157 @@ if (!params.skip_alignment && !params.skip_qc) {
         }
     }
 
-    if (!params.skip_rseqc && params.rseqc_modules) {
-        if ('bam_stat' in rseqc_modules) {
-            process {
-                withName: '.*:RSEQC:RSEQC_BAMSTAT' {
-                    publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/bam_stat" },
+    if (!params.skip_rseqc && 'bam_stat' in rseqc_modules) {
+        process {
+            withName: '.*:RSEQC:RSEQC_BAMSTAT' {
+                publishDir = [
+                    path: { "${params.outdir}/${params.aligner}/rseqc/bam_stat" },
+                    mode: params.publish_dir_mode,
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'infer_experiment' in rseqc_modules) {
+        process {
+            withName: '.*:RSEQC:RSEQC_INFEREXPERIMENT' {
+                publishDir = [
+                    path: { "${params.outdir}/${params.aligner}/rseqc/infer_experiment" },
+                    mode: params.publish_dir_mode,
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'junction_annotation' in rseqc_modules) {
+        process {
+            withName: '.*:RSEQC:RSEQC_JUNCTIONANNOTATION' {
+                publishDir = [
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/pdf" },
                         mode: params.publish_dir_mode,
-                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                    ]
-                }
-            }
-        }
-
-        if ('infer_experiment' in rseqc_modules) {
-            process {
-                withName: '.*:RSEQC:RSEQC_INFEREXPERIMENT' {
-                    publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/infer_experiment" },
+                        pattern: '*.pdf'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/bed" },
                         mode: params.publish_dir_mode,
+                        pattern: '*.bed'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/xls" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.xls'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/log" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.log'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/rscript" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.r'
+                    ]
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'junction_saturation' in rseqc_modules) {
+        process {
+            withName: '.*:RSEQC:RSEQC_JUNCTIONSATURATION' {
+                publishDir = [
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/pdf" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.pdf'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/rscript" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.r'
+                    ]
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'read_duplication' in rseqc_modules) {
+        process {
+            withName: '.*:RSEQC:RSEQC_READDUPLICATION' {
+                publishDir = [
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/pdf" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.pdf'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/xls" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.xls'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/rscript" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.r'
+                    ]
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'read_distribution' in rseqc_modules && !params.bam_csi_index) {
+        process {
+            withName: '.*:RSEQC:RSEQC_READDISTRIBUTION' {
+                publishDir = [
+                    path: { "${params.outdir}/${params.aligner}/rseqc/read_distribution" },
+                    mode: params.publish_dir_mode,
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                ]
+            }
+        }
+    }
+
+    if (!params.skip_rseqc && 'inner_distance' in rseqc_modules && !params.bam_csi_index) {
+        process {
+            withName: '.*:RSEQC:RSEQC_INNERDISTANCE' {
+                publishDir = [
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/txt" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.txt',
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/pdf" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.pdf'
+                    ],
+                    [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/rscript" },
+                        mode: params.publish_dir_mode,
+                        pattern: '*.r'
                     ]
-                }
+                ]
             }
         }
+    }
 
-        if ('junction_annotation' in rseqc_modules) {
-            process {
-                withName: '.*:RSEQC:RSEQC_JUNCTIONANNOTATION' {
-                    publishDir = [
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/pdf" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.pdf'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/bed" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.bed'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/xls" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.xls'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/log" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.log'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/rscript" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.r'
-                        ]
-                    ]
-                }
+    if (!params.skip_rseqc && 'tin' in rseqc_modules && !params.bam_csi_index) {
+        process {
+            withName: '.*:RSEQC:RSEQC_TIN' {
+                publishDir = [
+                    path: { "${params.outdir}/${params.aligner}/rseqc/tin" },
+                    mode: params.publish_dir_mode,
+                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                ]
             }
         }
+    }
 
-        if ('junction_saturation' in rseqc_modules) {
-            process {
-                withName: '.*:RSEQC:RSEQC_JUNCTIONSATURATION' {
-                    publishDir = [
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/pdf" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.pdf'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/rscript" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.r'
-                        ]
-                    ]
-                }
-            }
-        }
-
-        if ('read_duplication' in rseqc_modules) {
-            process {
-                withName: '.*:RSEQC:RSEQC_READDUPLICATION' {
-                    publishDir = [
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/pdf" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.pdf'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/xls" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.xls'
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/rscript" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.r'
-                        ]
-                    ]
-                }
-            }
-        }
-
-        if (!params.bam_csi_index) {
-            if ('read_distribution' in rseqc_modules) {
-                process {
-                    withName: '.*:RSEQC:RSEQC_READDISTRIBUTION' {
-                        publishDir = [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/read_distribution" },
-                            mode: params.publish_dir_mode,
-                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                        ]
-                    }
-                }
-            }
-
-            if ('inner_distance' in rseqc_modules) {
-                process {
-                    withName: '.*:RSEQC:RSEQC_INNERDISTANCE' {
-                        publishDir = [
-                            [
-                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/txt" },
-                                mode: params.publish_dir_mode,
-                                pattern: '*.txt',
-                                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                            ],
-                            [
-                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/pdf" },
-                                mode: params.publish_dir_mode,
-                                pattern: '*.pdf'
-                            ],
-                            [
-                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/rscript" },
-                                mode: params.publish_dir_mode,
-                                pattern: '*.r'
-                            ]
-                        ]
-                    }
-                }
-            }
-
-            if ('tin' in rseqc_modules) {
-                process {
-                    withName: '.*:RSEQC:RSEQC_TIN' {
-                        publishDir = [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/tin" },
-                            mode: params.publish_dir_mode,
-                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                        ]
-                    }
-                }
-            }
-        }
-
+    if (!params.skip_rseqc && rseqc_modules) {
         process {
             withName: 'MULTIQC_TSV_STRAND_CHECK' {
                 publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -3,12 +3,14 @@
     Config file for defining DSL2 per module options and publishing paths
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Available keys to override module options:
-        ext.args            = Additional arguments appended to command in module.
-        ext.args2           = Second set of arguments appended to command in module (multi-tool modules).
-        ext.args3           = Third set of arguments appended to command in module (multi-tool modules).
-        ext.prefix          = File name prefix for output files.
+        ext.args   = Additional arguments appended to command in module.
+        ext.args2  = Second set of arguments appended to command in module (multi-tool modules).
+        ext.args3  = Third set of arguments appended to command in module (multi-tool modules).
+        ext.prefix = File name prefix for output files.
 ----------------------------------------------------------------------------------------
 */
+
+def rseqc_modules = params.rseqc_modules ? params.rseqc_modules.split(',').collect{ it.trim().toLowerCase() } : []
 
 //
 // General configuration options
@@ -824,127 +826,159 @@ if (!params.skip_alignment && !params.skip_qc) {
     }
 
     if (!params.skip_rseqc && params.rseqc_modules) {
-        process {
-            withName: '.*:RSEQC:RSEQC_BAMSTAT' {
-                publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/rseqc/bam_stat" },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
-
-            withName: '.*:RSEQC:RSEQC_INFEREXPERIMENT' {
-                publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/rseqc/infer_experiment" },
-                    mode: params.publish_dir_mode,
-                    saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                ]
-            }
-
-            withName: '.*:RSEQC:RSEQC_JUNCTIONANNOTATION' {
-                publishDir = [
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/pdf" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.pdf'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/bed" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.bed'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/xls" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.xls'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/log" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.log'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/rscript" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.r'
-                    ]
-                ]
-            }
-
-            withName: '.*:RSEQC:RSEQC_JUNCTIONSATURATION' {
-                publishDir = [
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/pdf" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.pdf'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/rscript" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.r'
-                    ]
-                ]
-            }
-
-            withName: '.*:RSEQC:RSEQC_READDUPLICATION' {
-                publishDir = [
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/pdf" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.pdf'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/xls" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.xls'
-                    ],
-                    [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/rscript" },
-                        mode: params.publish_dir_mode,
-                        pattern: '*.r'
-                    ]
-                ]
-            }
-
-            if (!params.bam_csi_index) {
-                withName: '.*:RSEQC:RSEQC_READDISTRIBUTION' {
+        if ('bam_stat' in rseqc_modules) {
+            process {
+                withName: '.*:RSEQC:RSEQC_BAMSTAT' {
                     publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/read_distribution" },
+                        path: { "${params.outdir}/${params.aligner}/rseqc/bam_stat" },
                         mode: params.publish_dir_mode,
                         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
                     ]
                 }
+            }
+        }
 
-                withName: '.*:RSEQC:RSEQC_INNERDISTANCE' {
+        if ('infer_experiment' in rseqc_modules) {
+            process {
+                withName: '.*:RSEQC:RSEQC_INFEREXPERIMENT' {
+                    publishDir = [
+                        path: { "${params.outdir}/${params.aligner}/rseqc/infer_experiment" },
+                        mode: params.publish_dir_mode,
+                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                    ]
+                }
+            }
+        }
+
+        if ('junction_annotation' in rseqc_modules) {
+            process {
+                withName: '.*:RSEQC:RSEQC_JUNCTIONANNOTATION' {
                     publishDir = [
                         [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/txt" },
-                            mode: params.publish_dir_mode,
-                            pattern: '*.txt',
-                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-                        ],
-                        [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/pdf" },
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/pdf" },
                             mode: params.publish_dir_mode,
                             pattern: '*.pdf'
                         ],
                         [
-                            path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/rscript" },
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/bed" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.bed'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/xls" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.xls'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/log" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.log'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_annotation/rscript" },
                             mode: params.publish_dir_mode,
                             pattern: '*.r'
                         ]
                     ]
                 }
+            }
+        }
 
-                withName: '.*:RSEQC:RSEQC_TIN' {
+        if ('junction_saturation' in rseqc_modules) {
+            process {
+                withName: '.*:RSEQC:RSEQC_JUNCTIONSATURATION' {
                     publishDir = [
-                        path: { "${params.outdir}/${params.aligner}/rseqc/tin" },
-                        mode: params.publish_dir_mode,
-                        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/pdf" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.pdf'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/junction_saturation/rscript" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.r'
+                        ]
                     ]
                 }
             }
+        }
+        
+        if ('read_duplication' in rseqc_modules) {
+            process {
+                withName: '.*:RSEQC:RSEQC_READDUPLICATION' {
+                    publishDir = [
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/pdf" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.pdf'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/xls" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.xls'
+                        ],
+                        [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/read_duplication/rscript" },
+                            mode: params.publish_dir_mode,
+                            pattern: '*.r'
+                        ]
+                    ]
+                }
+            }
+        }
 
+        if (!params.bam_csi_index) {
+            if ('read_distribution' in rseqc_modules) {
+                process {
+                    withName: '.*:RSEQC:RSEQC_READDISTRIBUTION' {
+                        publishDir = [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/read_distribution" },
+                            mode: params.publish_dir_mode,
+                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                        ]
+                    }
+                }
+            }
+
+            if ('inner_distance' in rseqc_modules) {
+                process {
+                    withName: '.*:RSEQC:RSEQC_INNERDISTANCE' {
+                        publishDir = [
+                            [
+                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/txt" },
+                                mode: params.publish_dir_mode,
+                                pattern: '*.txt',
+                                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                            ],
+                            [
+                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/pdf" },
+                                mode: params.publish_dir_mode,
+                                pattern: '*.pdf'
+                            ],
+                            [
+                                path: { "${params.outdir}/${params.aligner}/rseqc/inner_distance/rscript" },
+                                mode: params.publish_dir_mode,
+                                pattern: '*.r'
+                            ]
+                        ]
+                    }
+                }
+            }
+
+            if ('tin' in rseqc_modules) {
+                process {
+                    withName: '.*:RSEQC:RSEQC_TIN' {
+                        publishDir = [
+                            path: { "${params.outdir}/${params.aligner}/rseqc/tin" },
+                            mode: params.publish_dir_mode,
+                            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                        ]
+                    }
+                }
+            }
+        }
+
+        process {
             withName: 'MULTIQC_TSV_STRAND_CHECK' {
                 publishDir = [
                     path: { "${params.outdir}/multiqc" },

--- a/conf/test.config
+++ b/conf/test.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run nf-core/rnaseq -profile test,<docker/singularity>
+        nextflow run nf-core/rnaseq -profile test,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a full size pipeline test.
 
     Use as follows:
-        nextflow run nf-core/rnaseq -profile test_full,<docker/singularity>
+        nextflow run nf-core/rnaseq -profile test_full,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/docs/output.md
+++ b/docs/output.md
@@ -502,7 +502,7 @@ RSeQC documentation: [bam_stat.py](http://rseqc.sourceforge.net/#bam-stat-py)
 
 </details>
 
-This script is designed to evaluate RNA integrity at the transcript level. TIN (transcript integrity number) is named in analogous to RIN (RNA integrity number). RIN (RNA integrity number) is the most widely used metric to evaluate RNA integrity at sample (or transcriptome) level. It is a very useful preventive measure to ensure good RNA quality and robust, reproducible RNA sequencing.
+This script is designed to evaluate RNA integrity at the transcript level. TIN (transcript integrity number) is named in analogous to RIN (RNA integrity number). RIN (RNA integrity number) is the most widely used metric to evaluate RNA integrity at sample (or transcriptome) level. It is a very useful preventive measure to ensure good RNA quality and robust, reproducible RNA sequencing. This process isn't run by default - please see [this issue](https://github.com/nf-core/rnaseq/issues/769).
 
 RSeQC documentation: [tin.py](http://rseqc.sourceforge.net/#tin-py)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ If you are using [GENCODE](https://www.gencodegenes.org/) reference genome files
 The typical command for running the pipeline is as follows:
 
 ```console
-nextflow run nf-core/rnaseq --input samplesheet.csv --genome GRCh37 -profile docker
+nextflow run nf-core/rnaseq --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile docker
 ```
 
 This will launch the pipeline with the `docker` configuration profile. See below for more information about profiles.

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -21,7 +21,7 @@ class WorkflowMain {
     // Print help to screen if required
     //
     public static String help(workflow, params, log) {
-        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --genome GRCh37 -profile docker"
+        def command = "nextflow run ${workflow.manifest.name} --input samplesheet.csv --outdir <OUTDIR> --genome GRCh37 -profile docker"
         def help_string = ''
         help_string += NfcoreTemplate.logo(workflow, params.monochrome_logs)
         help_string += NfcoreSchema.paramsHelp(workflow, params, command)

--- a/modules.json
+++ b/modules.json
@@ -70,7 +70,7 @@
                 "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
             },
             "rseqc/tin": {
-                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+                "git_sha": "4dbc166a7c30e963511fb5c9870fbcaa158a53a9"
             },
             "salmon/index": {
                 "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"

--- a/modules/nf-core/modules/rseqc/tin/main.nf
+++ b/modules/nf-core/modules/rseqc/tin/main.nf
@@ -1,6 +1,6 @@
 process RSEQC_TIN {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_high'
 
     conda (params.enable_conda ? "bioconda::rseqc=3.0.1 'conda-forge::r-base>=3.5'" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/nextflow.config
+++ b/nextflow.config
@@ -78,7 +78,7 @@ params {
     skip_deseq2_qc             = false
     skip_multiqc               = false
     deseq2_vst                 = false
-    rseqc_modules              = 'bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication,tin'
+    rseqc_modules              = 'bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication'
 
     // Boilerplate options
     outdir                     = './results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,7 +82,7 @@ params {
     rseqc_modules              = 'bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication'
 
     // Boilerplate options
-    outdir                     = './results'
+    outdir                     = null
     multiqc_config             = null
     multiqc_title              = null
     email                      = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,7 @@ params {
     with_umi                   = false
     umitools_extract_method    = 'string'
     umitools_bc_pattern        = null
+    umi_discard_read           = null
     save_umi_intermeds         = false
 
     // Trimming

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,6 +10,9 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
+            "required": [
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -23,8 +26,8 @@
                 },
                 "outdir": {
                     "type": "string",
-                    "description": "Path to the output directory where the results will be saved.",
-                    "default": "./results",
+                    "format": "directory-path",
+                    "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "email": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -422,7 +422,7 @@
             "properties": {
                 "rseqc_modules": {
                     "type": "string",
-                    "default": "bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication,tin",
+                    "default": "bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication",
                     "fa_icon": "fas fa-chart-pie",
                     "description": "Specify the RSeQC modules to run."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -76,7 +76,7 @@
                 "umi_discard_read": {
                     "type": "integer",
                     "fa_icon": "fas fa-barcode",
-                    "help_text": "After UMI barcode extraction discard either R1 or R2 by setting this parameter to 1 or 2, respectively.",
+                    "help_text": "After UMI barcode extraction discard either R1 or R2 by setting this parameter to 1 or 2, respectively."
                 },
                 "save_umi_intermeds": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -70,6 +70,11 @@
                     "help_text": "More details can be found in the [UMI-tools documentation](https://umi-tools.readthedocs.io/en/latest/reference/extract.html#extract-method).",
                     "description": "The UMI barcode pattern to use e.g. 'NNNNNN' indicates that the first 6 nucleotides of the read are from the UMI."
                 },
+                "umi_discard_read": {
+                    "type": "integer",
+                    "fa_icon": "fas fa-barcode",
+                    "help_text": "After UMI barcode extraction discard either R1 or R2 by setting this parameter to 1 or 2, respectively.",
+                },
                 "save_umi_intermeds": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",

--- a/subworkflows/nf-core/fastqc_umitools_trimgalore.nf
+++ b/subworkflows/nf-core/fastqc_umitools_trimgalore.nf
@@ -34,18 +34,13 @@ workflow FASTQC_UMITOOLS_TRIMGALORE {
 
         // Discard R1 / R2 if required
         if ([1,2].contains(umi_discard_read)) {
-            def keep_idx = 1
-            if (umi_discard_read == 2) {
-                keep_idx = 0
-            }
-
             UMITOOLS_EXTRACT
                 .out
                 .reads
                 .map { meta, reads ->
                     if (!meta.single_end) {
                         meta['single_end'] = true
-                        reads = reads[keep_idx]
+                        reads = reads[umi_discard_read % 2]
                     }
                     return [ meta, reads ]
                 }

--- a/subworkflows/nf-core/fastqc_umitools_trimgalore.nf
+++ b/subworkflows/nf-core/fastqc_umitools_trimgalore.nf
@@ -33,7 +33,7 @@ workflow FASTQC_UMITOOLS_TRIMGALORE {
         ch_versions = ch_versions.mix(UMITOOLS_EXTRACT.out.versions.first())
 
         // Discard R1 / R2 if required
-        if ([1,2].contains(umi_discard_read)) {
+        if (umi_discard_read in [1,2]) {
             UMITOOLS_EXTRACT
                 .out
                 .reads

--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -212,7 +212,8 @@ workflow RNASEQ {
         ch_cat_fastq,
         params.skip_fastqc || params.skip_qc,
         params.with_umi,
-        params.skip_trimming
+        params.skip_trimming,
+        params.umi_discard_read
     )
     ch_versions = ch_versions.mix(FASTQC_UMITOOLS_TRIMGALORE.out.versions)
 


### PR DESCRIPTION
* [nf-core/tools#1415](https://github.com/nf-core/tools/issues/1415) - Make `--outdir` a mandatory parameter
* [[#750](https://github.com/nf-core/rnaseq/issues/750)] - Optionally ignore R1 / R2 after UMI extraction process
* [[#769](https://github.com/nf-core/rnaseq/issues/769)] - Do not run RSeQC tin.py by default