### PR TITLE
add fastqc thread options

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -14,7 +14,7 @@ process {
     memory = { check_max( 6.GB * task.attempt, 'memory' ) }
     time   = { check_max( 4.h  * task.attempt, 'time'   ) }
 
-    errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'finish' }
+    errorStrategy = { task.exitStatus in [140,143,137,104,134,139] ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -181,10 +181,12 @@ if (!(params.skip_fastqc || params.skip_qc)) {
 if (!params.skip_trimming) {
     process {
         withName: '.*:FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
-            ext.args   = [
-                '--fastqc',
-                params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : ''
-            ].join(' ').trim()
+            ext.args   = {
+                [
+                    "--fastqc_args '-t ${task.cpus}' ",
+                    params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : ''
+                ].join(' ').trim()
+            }
             publishDir = [
                 [
                     path: { "${params.outdir}/trimgalore/fastqc" },


### PR DESCRIPTION
Using the default settings I ran into the issue of the `fastqc` wrapper of `trim_galore` did not pass in the threads from the process into the fastqc substep. As a result with certain fastq files I was getting java-heap memory errors:

```
Exception in thread "Thread-1" java.lang.OutOfMemoryError: Java heap space
	at uk.ac.babraham.FastQC.Utilities.QualityCount.<init>(QualityCount.java:33)
	at uk.ac.babraham.FastQC.Modules.PerTileQualityScores.processSequence(PerTileQualityScores.java:259)
	at uk.ac.babraham.FastQC.Analysis.AnalysisRunner.run(AnalysisRunner.java:89)
	at java.lang.Thread.run(Thread.java:748)
```
which was addressed in this thread https://github.com/s-andrews/FastQC/issues/86 by adding more threads to fastqc

in this PR. I add the cpus used by the user for `TRIMGALORE` for the fastqc process as well. And by reading the docs of trim_galore https://github.com/FelixKrueger/TrimGalore/blob/master/Docs/Trim_Galore_User_Guide.md I found I could pass that along as an extra argument.

Since we always run fastqc (regardless of `skip_fastqc` btw) I thought we can always use the task.cpus for the subtask after trimming.
