### PR TITLE
don't throw error about csi indexing needed when csi indexing has been specified

### DIFF
--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -179,7 +179,7 @@ workflow RNASEQ {
     ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 
     // Check if contigs in genome fasta file > 512 Mbp
-    if (!params.skip_alignment) {
+    if (!params.skip_alignment && !params.bam_csi_index) {
         PREPARE_GENOME
             .out
             .fai


### PR DESCRIPTION
## PR checklist
- [x] This comment contains a description of changes (with reason).

digging into #855 more on our side, we found that the .nextflow.log contained the error:

> Aug-08 22:52:30.870 [Actor Thread 110] ERROR nextflow.Nextflow - =============================================================================
>   Contig longer than 512000000bp found in reference genome!
> 
>   pissa.Cameor.gnm1.chr5LG3: 579269071
> 
>   Provide the '--bam_csi_index' parameter to use a CSI instead of BAI index.
> 
>   Please see:
>   https://github.com/nf-core/rnaseq/issues/744

BUT, this was despite our having specified --bam_csi_index in the pipeline invocation. 
Making the little tweak in this PR seems to have made the pipeline run to completion using --bam_csi_index