### PR TITLE
Version issues with hisat2 align/build

### DIFF
--- a/modules/nf-core/modules/hisat2/align/main.nf
+++ b/modules/nf-core/modules/hisat2/align/main.nf
@@ -1,13 +1,13 @@
-def VERSION = '2.2.0' // Version information not provided by tool on CLI
+def VERSION = '2.2.1' // Version information not provided by tool on CLI
 
 process HISAT2_ALIGN {
     tag "$meta.id"
     label 'process_high'
 
-    conda (params.enable_conda ? "bioconda::hisat2=2.2.0 bioconda::samtools=1.15.1" : null)
+    conda (params.enable_conda ? "bioconda::hisat2=2.2.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:0e773bb207600fcb4d38202226eb20a33c7909b6-0' :
-        'quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:0e773bb207600fcb4d38202226eb20a33c7909b6-0' }"
+        'https://depot.galaxyproject.org/singularity/hisat2:2.2.1--h1b792b2_3' :
+        'quay.io/biocontainers/hisat2:2.2.1--h1b792b2_3' }"
 
     input:
     tuple val(meta), path(reads)


### PR DESCRIPTION
hisat2 align and hisat2 build modules have a different hisat2 versions in the singularity/conda containers. This generates the following warning:  "Warning: the current version of HISAT2 () is older than the version (2.2.1) used to build the index.
         Users are strongly recommended to update HISAT2 to the latest version."
I have updated hisat2 align to be the same version as build.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
