### PR TITLE
Bugfix salmon summarizedexperiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
-- [[#940](https://github.com/nf-core/rnaseq/issues/940)] - Bugfix in `salmon_summarizedexperiment.r` to ensure `rbind` doesn't fail when `rowdata` has no `tx` column. See ([[#941](https://github.com/nf-core/rnaseq/pull/941)]) for details.
 - [[#934](https://github.com/nf-core/rnaseq/pull/934)] - Union of `ext.args` and `params.extra_star_align_args` prevents parameter clashes in the STAR module
+- [[#940](https://github.com/nf-core/rnaseq/issues/940)] - Bugfix in `salmon_summarizedexperiment.r` to ensure `rbind` doesn't fail when `rowdata` has no `tx` column. See ([[#941](https://github.com/nf-core/rnaseq/pull/941)]) for details.
 
 ## [[3.10.1](https://github.com/nf-core/rnaseq/releases/tag/3.10.1)] - 2023-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements & fixes
 
+- [[#940](https://github.com/nf-core/rnaseq/issues/940)] - Bugfix in `salmon_summarizedexperiment.r` to ensure `rbind` doesn't fail when `rowdata` has no `tx` column. See ([[#941](https://github.com/nf-core/rnaseq/pull/941)]) for details.
 - [[#934](https://github.com/nf-core/rnaseq/pull/934)] - Union of `ext.args` and `params.extra_star_align_args` prevents parameter clashes in the STAR module
 
 ## [[3.10.1](https://github.com/nf-core/rnaseq/releases/tag/3.10.1)] - 2023-01-05

--- a/bin/salmon_summarizedexperiment.r
+++ b/bin/salmon_summarizedexperiment.r
@@ -4,56 +4,65 @@ library(SummarizedExperiment)
 
 ## Create SummarizedExperiment (se) object from Salmon counts
 
-args = commandArgs(trailingOnly=TRUE)
+args <- commandArgs(trailingOnly = TRUE)
 if (length(args) < 2) {
-    stop("Usage: salmon_se.r <coldata> <counts> <tpm>", call.=FALSE)
+    stop("Usage: salmon_se.r <coldata> <counts> <tpm>", call. = FALSE)
 }
 
-coldata = args[1]
-counts_fn = args[2]
-tpm_fn = args[3]
+coldata <- args[1]
+counts_fn <- args[2]
+tpm_fn <- args[3]
 
-tx2gene = "salmon_tx2gene.tsv"
-info = file.info(tx2gene)
+tx2gene <- "salmon_tx2gene.tsv"
+info <- file.info(tx2gene)
 if (info$size == 0) {
-    tx2gene = NULL
+    tx2gene <- NULL
 } else {
-    rowdata = read.csv(tx2gene, sep="\t", header = FALSE)
-    colnames(rowdata) = c("tx", "gene_id", "gene_name")
-    tx2gene = rowdata[,1:2]
+    rowdata <- read.csv(tx2gene, sep = "\t", header = FALSE)
+    colnames(rowdata) <- c("tx", "gene_id", "gene_name")
+    tx2gene <- rowdata[, 1:2]
 }
 
-counts = read.csv(counts_fn, row.names=1, sep="\t")
-counts = counts[,2:ncol(counts),drop=FALSE] # remove gene_name column
-tpm = read.csv(tpm_fn, row.names=1, sep="\t")
-tpm = tpm[,2:ncol(tpm),drop=FALSE] # remove gene_name column
+counts <- read.csv(counts_fn, row.names = 1, sep = "\t")
+counts <- counts[, 2:ncol(counts), drop = FALSE] # remove gene_name column
+tpm <- read.csv(tpm_fn, row.names = 1, sep = "\t")
+tpm <- tpm[, 2:ncol(tpm), drop = FALSE] # remove gene_name column
 
 if (length(intersect(rownames(counts), rowdata[["tx"]])) > length(intersect(rownames(counts), rowdata[["gene_id"]]))) {
-    by_what = "tx"
+    by_what <- "tx"
 } else {
-    by_what = "gene_id"
-    rowdata = unique(rowdata[,2:3])
+    by_what <- "gene_id"
+    rowdata <- unique(rowdata[, 2:3])
 }
 
 if (file.exists(coldata)) {
-    coldata = read.csv(coldata, sep="\t")
-    coldata = coldata[match(colnames(counts), coldata[,1]),]
-    coldata = cbind(files = fns, coldata)
+    coldata <- read.csv(coldata, sep = "\t")
+    coldata <- coldata[match(colnames(counts), coldata[, 1]), ]
+    coldata <- cbind(files = fns, coldata)
 } else {
     message("ColData not avaliable ", coldata)
-    coldata = data.frame(files = colnames(counts), names = colnames(counts))
+    coldata <- data.frame(files = colnames(counts), names = colnames(counts))
 }
 
-rownames(coldata) = coldata[["names"]]
-extra = setdiff(rownames(counts),  as.character(rowdata[[by_what]]))
+rownames(coldata) <- coldata[["names"]]
+extra <- setdiff(rownames(counts), as.character(rowdata[[by_what]]))
 if (length(extra) > 0) {
-    rowdata = rbind(rowdata, data.frame(tx=extra, gene_id=extra, gene_name=extra))
+    rowdata <- rbind(
+        rowdata,
+        data.frame(
+            tx = extra,
+            gene_id = extra,
+            gene_name = extra
+        )[, colnames(rowdata)]
+    )
 }
 
-rowdata = rowdata[match(rownames(counts), as.character(rowdata[[by_what]])),]
-rownames(rowdata) = rowdata[[by_what]]
-se = SummarizedExperiment(assays = list(counts = counts, abundance = tpm),
-                        colData = DataFrame(coldata),
-                        rowData = rowdata)
+rowdata <- rowdata[match(rownames(counts), as.character(rowdata[[by_what]])), ]
+rownames(rowdata) <- rowdata[[by_what]]
+se <- SummarizedExperiment(
+    assays = list(counts = counts, abundance = tpm),
+    colData = DataFrame(coldata),
+    rowData = rowdata
+)
 
 saveRDS(se, file = paste0(tools::file_path_sans_ext(counts_fn), ".rds"))


### PR DESCRIPTION
[On Slack](https://nfcore.slack.com/archives/CE8SSJV3N/p1675687582834249), _Sven b_ reported that running

```console
nextflow run nf-core/rnaseq --outdir out/ --input https://raw.githubusercontent.com/nf-core/test-datasets/rnaseq/samplesheet/v3.10/samplesheet_test.csv 
--skip_alignment --pseudo_aligner salmon -profile singularity 
--max_cpus 8 --max_memory 40.GB 
--transcript_fasta https://github.com/nf-core/test-datasets/raw/rnaseq/reference/transcriptome.fasta 
--fasta https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genome.fasta 
--gtf https://github.com/nf-core/test-datasets/raw/rnaseq/reference/genes.gtf.gz
```
results in an error at `NFCORE_RNASEQ:RNASEQ:QUANTIFY_SALMON:SALMON_SE_TRANSCRIPT (salmon_tx2gene.tsv)`:

```console
  Error in rbind(deparse.level, ...) : 
    numbers of columns of arguments do not match
Caused by:
  Process `NFCORE_RNASEQ:RNASEQ:QUANTIFY_SALMON:SALMON_SE_TRANSCRIPT (salmon_tx2gene.tsv)` terminated with an error exit status (1)

Command executed:

  salmon_summarizedexperiment.r \
      NULL \
      salmon.merged.transcript_counts.tsv \
      salmon.merged.transcript_tpm.tsv
```
The reason is, that there is an extra transcript _Gfp_transgene_gene_ in the reference:

```R
> extra
[1] "Gfp_transgene_gene"
```

Hence, this additional row 

```R
data.frame(tx=extra, gene_id=extra, gene_name=extra)
                  tx            gene_id          gene_name
1 Gfp_transgene_gene Gfp_transgene_gene Gfp_transgene_gene
```

shall be concatenated to `rowdata` 

```R
> head(rowdata)
            gene_id gene_name
YAL069W     YAL069W   YAL069W
YAL068W-A YAL068W-A YAL068W-A
YAL068C     YAL068C      PAU8
YAL067W-A YAL067W-A YAL067W-A
YAL067C     YAL067C      SEO1
YAL066W     YAL066W   YAL066W
```

which however only has two columns in this case. Because of the superficial `tx` column, the `rbind()` command fails.

By adding a selection `[, colnames(rowdata)]` to the code, it is ensured that only the matching columns will be used in the future: 

```R
rowdata = rbind(rowdata, data.frame(tx=extra, gene_id=extra, gene_name=extra)[,colnames(rowdata)])
```

This also works when there is no column named `tx` in `rowdata`.

Closes #940

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
