### PR TITLE
Added resource parameters for UMITOOLS_DEDUP

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -424,6 +424,8 @@ if (!params.skip_alignment) {
                         )
                     ]
                 ]
+                cpus   = { check_max( 1, 'cpus'    ) }
+                memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
             }
 
             withName: '.*:BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_GENOME:SAMTOOLS_INDEX' {
@@ -657,6 +659,9 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
                     mode: params.publish_dir_mode,
                     pattern: '*.tsv'
                 ]
+                cpus   = { check_max( 1, 'cpus'    ) }
+                memory = { check_max( 36.GB * task.attempt, 'memory'  ) }
+                time   = { check_max( 20.h   * task.attempt, 'time'    ) }
             }
 
             withName: '.*:BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME:SAMTOOLS_INDEX' {


### PR DESCRIPTION


Changes:
Added resource parameters for UMITOOLS_DEDUP processes

Motivation:
Current version of UMI-tools has a very slow implementation of UMI deduplication of the transcriptome, which has been fixed on their Github, and will hopefully be released soon - see: https://github.com/CGATOxford/UMI-tools/pull/543. However, until then, the pipeline occasionally crashes due to runtime exceeding the standard settings, i.e.  >8 hours. Furthermore, the process is set as process_medium, taking up 6 CPU cores, even though it is only using one. By setting it to only use 1 thread, many more processes are able to run simultaneously, mitigating the effect of the very slow run-time. 

This is my first PR, so I hope the commit makes sense. I have not added this to the changelog since I was not sure how to reference this pull request. Let me know if I should do that!


