### PR TITLE
Allow setting clipping parameters (only _r1 if unpaired) - Issue 944

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [[#934](https://github.com/nf-core/rnaseq/pull/934)] - Union of `ext.args` and `params.extra_star_align_args` prevents parameter clashes in the STAR module
 - [[#940](https://github.com/nf-core/rnaseq/issues/940)] - Bugfix in `salmon_summarizedexperiment.r` to ensure `rbind` doesn't fail when `rowdata` has no `tx` column. See ([[#941](https://github.com/nf-core/rnaseq/pull/941)]) for details.
+- [[#944](https://github.com/nf-core/rnaseq/issues/944)] - Read clipping using clip_r1, clip_r2, three_prime_clip_r1, three_prime_clip_r2 disabled in 3.10
 
 ## [[3.10.1](https://github.com/nf-core/rnaseq/releases/tag/3.10.1)] - 2023-01-05
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -211,7 +211,11 @@ if (!params.skip_trimming) {
             ext.args   = {
                 [
                     "--fastqc_args '-t ${task.cpus}' ",
-                    params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : ''
+                    params.trim_nextseq > 0 ? "--nextseq ${params.trim_nextseq}" : '',
+                    params.clip_r1 > 0 ? "--clip_r1 ${params.clip_r1}" : '',
+                    params.clip_r2 > 0 && !meta.single_end ? "--clip_r2 ${params.clip_r2}" : '',
+                    params.three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${params.three_prime_clip_r1}" : '',
+                    params.three_prime_clip_r2 > 0  && !meta.single_end ? "--three_prime_clip_r2 ${params.three_prime_clip_r2}" : ''
                 ].join(' ').trim()
             }
             publishDir = [


### PR DESCRIPTION
Fix for https://github.com/nf-core/rnaseq/issues/944:
Setting clipping parameters did not work in 3.10.

## PR checklist

- [ X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [X ] Make sure your code lints (`nf-core lint`).
- [ X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ X] `CHANGELOG.md` is updated.
