### PR TITLE
Add 'auto' option to fastq_dir_to_samplesheet.py and set as default argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#934](https://github.com/nf-core/rnaseq/pull/934)] - Union of `ext.args` and `params.extra_star_align_args` prevents parameter clashes in the STAR module
 - [[#940](https://github.com/nf-core/rnaseq/issues/940)] - Bugfix in `salmon_summarizedexperiment.r` to ensure `rbind` doesn't fail when `rowdata` has no `tx` column. See ([[#941](https://github.com/nf-core/rnaseq/pull/941)]) for details.
 - [[#944](https://github.com/nf-core/rnaseq/issues/944)] - Read clipping using clip_r1, clip_r2, three_prime_clip_r1, three_prime_clip_r2 disabled in 3.10
+- [[#956](https://github.com/nf-core/rnaseq/pull/956)] - Implement 'auto' as default strandedness argument in `fastq_dir_to_samplesheet.py` script
 
 ## [[3.10.1](https://github.com/nf-core/rnaseq/releases/tag/3.10.1)] - 2023-01-05
 

--- a/bin/fastq_dir_to_samplesheet.py
+++ b/bin/fastq_dir_to_samplesheet.py
@@ -18,8 +18,8 @@ def parse_args(args=None):
         "--strandedness",
         type=str,
         dest="STRANDEDNESS",
-        default="unstranded",
-        help="Value for 'strandedness' in samplesheet. Must be one of 'unstranded', 'forward', 'reverse'.",
+        default="auto",
+        help="Value for 'strandedness' in samplesheet. Must be one of 'unstranded', 'forward', 'reverse', 'auto'.",
     )
     parser.add_argument(
         "-r1",
@@ -80,7 +80,7 @@ def parse_args(args=None):
 def fastq_dir_to_samplesheet(
     fastq_dir,
     samplesheet_file,
-    strandedness="unstranded",
+    strandedness="auto",
     read1_extension="_R1_001.fastq.gz",
     read2_extension="_R2_001.fastq.gz",
     single_end=False,
@@ -154,8 +154,8 @@ def fastq_dir_to_samplesheet(
 def main(args=None):
     args = parse_args(args)
 
-    strandedness = "unstranded"
-    if args.STRANDEDNESS in ["unstranded", "forward", "reverse"]:
+    strandedness = "auto"
+    if args.STRANDEDNESS in ["unstranded", "forward", "reverse", "auto"]:
         strandedness = args.STRANDEDNESS
 
     fastq_dir_to_samplesheet(

--- a/bin/fastq_dir_to_samplesheet.py
+++ b/bin/fastq_dir_to_samplesheet.py
@@ -94,7 +94,9 @@ def fastq_dir_to_samplesheet(
         sample = os.path.basename(path).replace(extension, "")
         if sanitise_name:
             sample = sanitise_name_delimiter.join(
-                os.path.basename(path).split(sanitise_name_delimiter)[:sanitise_name_index]
+                os.path.basename(path).split(sanitise_name_delimiter)[
+                    :sanitise_name_index
+                ]
             )
         return sample
 
@@ -108,7 +110,9 @@ def fastq_dir_to_samplesheet(
         search_path = f"*{extension}"
         if recursive:
             search_path = f"**/*{extension}"
-        return sorted(glob.glob(os.path.join(fastq_dir, search_path), recursive=recursive))
+        return sorted(
+            glob.glob(os.path.join(fastq_dir, search_path), recursive=recursive)
+        )
 
     read_dict = {}
 
@@ -142,7 +146,9 @@ def fastq_dir_to_samplesheet(
                     sample_info = ",".join([sample, read_1, read_2, strandedness])
                     fout.write(f"{sample_info}\n")
     else:
-        error_str = "\nWARNING: No FastQ files found so samplesheet has not been created!\n\n"
+        error_str = (
+            "\nWARNING: No FastQ files found so samplesheet has not been created!\n\n"
+        )
         error_str += "Please check the values provided for the:\n"
         error_str += "  - Path to the directory containing the FastQ files\n"
         error_str += "  - '--read1_extension' parameter\n"


### PR DESCRIPTION
Updated the [fastq_dir_to_samplesheet.py](https://github.com/nf-core/rnaseq/blob/master/bin/fastq_dir_to_samplesheet.py) to add the 'auto' option to concur with [#729](https://github.com/nf-core/rnaseq/issues/729).   Also, set this to be the default argument when generating the spreadsheet.
