### PR TITLE
Add '--no-sort-output' flag to TRANSCRIPTOME:UMITOOLS_DEDUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#944](https://github.com/nf-core/rnaseq/issues/944)] - Read clipping using clip_r1, clip_r2, three_prime_clip_r1, three_prime_clip_r2 disabled in 3.10
 - [[#956](https://github.com/nf-core/rnaseq/pull/956)] - Implement 'auto' as default strandedness argument in `fastq_dir_to_samplesheet.py` script
 - Remove HISAT2 from automated AWS full-sized tests
+- [[#958](https://github.com/nf-core/rnaseq/pull/958)] - Add '--no-sort-output' flag to TRANSCRIPTOME:UMITOOLS_DEDUP [as suggested by Lars Roed Ingerslev and Thomas Koefoed](https://nfcore.slack.com/archives/CE8SSJV3N/p1676885035327799)
 
 ### Software dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -652,6 +652,7 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
             withName: '.*:BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS_TRANSCRIPTOME:UMITOOLS_DEDUP' {
                 ext.args   = { [
                     meta.single_end                 ? '' : '--unpaired-reads=discard --chimeric-pairs=discard',
+                    params.save_align_intermeds     ? '' : '--no-sort-output',
                     params.umitools_grouping_method ? "--method='${params.umitools_grouping_method}'" : '',
                     params.umitools_umi_separator   ? "--umi-separator='${params.umitools_umi_separator}'" : '',
                 ].join(' ').trim() }


### PR DESCRIPTION
On Slack, [Lars Roed Ingerslev and Thomas Koefoed suggested](https://nfcore.slack.com/archives/CE8SSJV3N/p1676885035327799) adding a '--no-sort-output' flag to TRANSCRIPTOME:UMITOOLS_DEDUP as default extra argument to TRANSCRIPTOME:UMITOOLS_DEDUP, because the file is subsequently anyway name-sorted for quantification by Salmon.

This PR introduces those changes, but on the condition that no alignment intermediates are saved. In the latter case, the intermediate position sorted output of UMITOOLS_DEDUP is retained.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
