### PR TITLE
Create patches for umi-tools

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -212,12 +212,14 @@
                     "umitools/dedup": {
                         "branch": "master",
                         "git_sha": "6d9c7e43404e20a97d2f6f88548456afe78282e6",
-                        "installed_by": ["bam_dedup_stats_samtools_umitools"]
+                        "installed_by": ["bam_dedup_stats_samtools_umitools"],
+                        "patch": "modules/nf-core/umitools/dedup/umitools-dedup.diff"
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "6d9c7e43404e20a97d2f6f88548456afe78282e6",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"]
+                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"],
+                        "patch": "modules/nf-core/umitools/extract/umitools-extract.diff"
                     },
                     "untar": {
                         "branch": "master",

--- a/modules/nf-core/umitools/dedup/umitools-dedup.diff
+++ b/modules/nf-core/umitools/dedup/umitools-dedup.diff
@@ -1,0 +1,13 @@
+Changes in module 'nf-core/umitools/dedup'
+--- modules/nf-core/umitools/dedup/main.nf
++++ modules/nf-core/umitools/dedup/main.nf
+@@ -1,6 +1,7 @@
+ process UMITOOLS_DEDUP {
+     tag "$meta.id"
+     label "process_single"
++    label "process_high_memory"
+ 
+     conda "bioconda::umi_tools=1.1.4"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+
+************************************************************

--- a/modules/nf-core/umitools/extract/umitools-extract.diff
+++ b/modules/nf-core/umitools/extract/umitools-extract.diff
@@ -1,0 +1,13 @@
+Changes in module 'nf-core/umitools/extract'
+--- modules/nf-core/umitools/extract/main.nf
++++ modules/nf-core/umitools/extract/main.nf
+@@ -1,6 +1,7 @@
+ process UMITOOLS_EXTRACT {
+     tag "$meta.id"
+     label "process_single"
++    label "process_long"
+ 
+     conda "bioconda::umi_tools=1.1.4"
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+
+************************************************************


### PR DESCRIPTION
This PR is a hotfix for the 3.11 release candidate to add additional process labels to umi_tools extract (`process long`) and umi_tools dedup (`process high_memory`) as a temporary solution to fix errors during pipeline execution until a more appropriate process label has been added to the modules.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
