### PR TITLE
deseq2_qc.r renumber groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [[#961](https://github.com/nf-core/rnaseq/issues/961)] - Add warnings to STDOUT for all skipped and failed strandedness check samples
 - [[#975](https://github.com/nf-core/rnaseq/issues/975)] - `SALMON_INDEX` runs when using `--aligner star_rsem` even if samples have explicit strandedness
 - Remove HISAT2 from automated AWS full-sized tests
+- [[#988](https://github.com/nf-core/rnaseq/issues/988)] - `DESEQ2_QC_STAR_SALMON` fails when sample names have many components
 
 ### Parameters
 

--- a/bin/deseq2_qc.r
+++ b/bin/deseq2_qc.r
@@ -77,10 +77,10 @@ decompose       <- n_components!=1 && all(sapply(name_components, length)==n_com
 coldata         <- data.frame(samples.vec, sample=samples.vec, row.names=1)
 if (decompose) {
     groupings        <- as.data.frame(lapply(1:n_components, function(i) sapply(name_components, "[[", i)))
-    names(groupings) <- paste0("Group", 1:n_components)
     n_distinct       <- sapply(groupings, function(grp) length(unique(grp)))
     groupings        <- groupings[n_distinct!=1 & n_distinct!=length(samples.vec)]
     if (ncol(groupings)!=0) {
+        names(groupings) <- paste0("Group", 1:ncol(groupings))
         coldata <- cbind(coldata, groupings)
     } else {
         decompose <- FALSE


### PR DESCRIPTION
This PR fixes #988. All that had to be done was to move one line of code a bit further down such that the columns of a data.frame are numbered starting with 1.

I also added a comment to the `CHANGELOG.md`. I'm not sure whether it's in the right place, though. Let me know if I am supposed to move it.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
