### PR TITLE
Fastq-subsample-index-fix

### DIFF
--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -247,6 +247,7 @@ workflow RNASEQ {
     PREPARE_GENOME.out.fasta
         .combine(ch_strand_fastq.auto_strand)
         .map { it.first() }
+        .first()
         .set { ch_genome_fasta }
 
     FASTQ_SUBSAMPLE_FQ_SALMON (
@@ -321,7 +322,7 @@ workflow RNASEQ {
 
     //
     // Get list of samples that failed trimming threshold for MultiQC report
-    //        
+    //
     ch_trim_read_count
         .map {
             meta, num_reads ->
@@ -332,7 +333,7 @@ workflow RNASEQ {
                 }
         }
         .collect()
-        .map { 
+        .map {
             tsv_data ->
                 def header = ["Sample", "Reads after trimming"]
                 WorkflowRnaseq.multiqcTsvFromList(tsv_data, header)
@@ -604,7 +605,7 @@ workflow RNASEQ {
         ch_pass_fail_mapped
             .fail
             .collect()
-            .map { 
+            .map {
                 tsv_data ->
                     def header = ["Sample", "STAR uniquely mapped reads (%)"]
                     WorkflowRnaseq.multiqcTsvFromList(tsv_data, header)
@@ -765,7 +766,7 @@ workflow RNASEQ {
             ch_versions = ch_versions.mix(BAM_RSEQC.out.versions)
 
             ch_inferexperiment_multiqc
-                .map { 
+                .map {
                     meta, strand_log ->
                         def inferred_strand = WorkflowRnaseq.getInferexperimentStrandedness(strand_log, 30)
                         pass_strand_check[meta.id] = true
@@ -775,7 +776,7 @@ workflow RNASEQ {
                         }
                 }
                 .collect()
-                .map { 
+                .map {
                     tsv_data ->
                         def header = [
                             "Sample",


### PR DESCRIPTION
Without this fix, we risk indexing the genome for each sample rather than just once for all samples.

Fixex https://github.com/nf-core/rnaseq/issues/1003

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
