### PR TITLE
Fix for public_aws_ecr profile that didn't match modules sometimes

### DIFF
--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -12,43 +12,49 @@ docker.registry = 'public.ecr.aws'
 podman.registry = 'public.ecr.aws'
 
 process {
-    withName: '.*:CAT_FASTQ' {
+    withName: 'CAT_FASTQ' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:DESEQ2_QC' {
+    withName: 'SAMPLESHEET_CHECK|CAT_ADDITIONAL_FASTA|GTF_GENE_FILTER|MULTIQC_CUSTOM_BIOTYPE|SALMON_TX2GENE' {
+        container = 'quay.io/biocontainers/python:3.9--1'
+    }
+    withName: 'GTF2BED' {
+        container = 'quay.io/biocontainers/perl:5.26.2'
+    }
+    withName: 'DESEQ2_QC' {
         container = 'quay.io/biocontainers/mulled-v2-8849acf39a43cdd6c839a369a74c0adc823e2f91:ab110436faf952a33575c64dd74615a84011450b-0'
     }
-    withName: '.*:GUNZIP' {
+    withName: 'GUNZIP' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:HISAT2_ALIGN' {
+    withName: 'HISAT2_ALIGN' {
         container = 'quay.io/biocontainers/mulled-v2-a97e90b3b802d1da3d6958e0867610c718cb5eb1:2cdf6bf1e92acbeb9b2834b1c58754167173a410-0'
     }
-    withName: '.*:PREPROCESS_TRANSCRIPTS_FASTA_GENCODE' {
+    withName: 'PREPROCESS_TRANSCRIPTS_FASTA_GENCODE' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:RSEM_CALCULATEEXPRESSION' {
+    withName: 'RSEM_CALCULATEEXPRESSION' {
         container = 'quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0'
     }
-    withName: '.*:RSEM_MERGE_COUNTS' {
+    withName: 'RSEM_MERGE_COUNTS' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:RSEM_PREPAREREFERENCE' {
+    withName: 'RSEM_PREPAREREFERENCE' {
         container = 'quay.io/biocontainers/mulled-v2-cf0123ef83b3c38c13e3b0696a3f285d3f20f15b:64aad4a4e144878400649e71f42105311be7ed87-0'
     }
-    withName: '.*:STAR_ALIGN' {
+    withName: 'STAR_ALIGN' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0'
     }
-    withName: '.*:STAR_ALIGN_IGENOMES' {
+    withName: 'STAR_ALIGN_IGENOMES' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0'
     }
-    withName: '.*:STAR_GENOMEGENERATE' {
+    withName: 'STAR_GENOMEGENERATE' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0'
     }
-    withName: '.*:STAR_GENOMEGENERATE_IGENOMES' {
+    withName: 'STAR_GENOMEGENERATE_IGENOMES' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:59cdd445419f14abac76b31dd0d71217994cbcc9-0'
     }
-    withName: '.*:UNTAR' {
+    withName: 'UNTAR' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
 }


### PR DESCRIPTION
Fix for `public_aws_ecr` profile which sometimes did not match modules because globbing only works for the name the process is imported without an alias. When used globally you should use the original and not aliased name with no glob.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
