### PR TITLE
Update warning about additional_fasta and gene BED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [[#1018](https://github.com/nf-core/rnaseq/issues/1018)] - Ability to skip both alignment and pseudo-alignment to only run pre-processing QC steps.
 - [PR #1016](https://github.com/nf-core/rnaseq/pull/1016) - Updated pipeline template to [nf-core/tools 2.8](https://github.com/nf-core/tools/releases/tag/2.8)
 - [PR #1025](https://github.com/nf-core/fetchngs/pull/1025) - Add `public_aws_ecr.config` to source mulled containers when using `public.ecr.aws` Docker Biocontainer registry
+- Updated error log for count values when supplying `--additional_fasta`
 
 ### Parameters
 

--- a/lib/WorkflowRnaseq.groovy
+++ b/lib/WorkflowRnaseq.groovy
@@ -405,6 +405,10 @@ class WorkflowRnaseq {
             "  Set '--additional_fasta <FASTA_FILE> --${index}_index false --save_reference' to\n" +
             "  re-build the index with transgenes included and the index will be saved in\n" +
             "  'results/genome/index/${index}/' for re-use with '--${index}_index'.\n\n" +
+            "  In addition, regions in '--additional_fasta' will not be included in count \n" +
+            "  values. If you wish to include this supply a '--gene_bed' file including \n" +
+            "  of interest or use '--gene_bed false to generate a new one containing all \n" +
+            "  of the '--additional_fasta' regions.\n\n" +
             "  Ignore this warning if you know that the index already contains transgenes.\n\n" +
             "  Please see:\n" +
             "  https://github.com/nf-core/rnaseq/issues/556\n" +


### PR DESCRIPTION
Based on #1001 

- Update warning based when using --additional_fasta and --gene_bed. 

Example of warning:

![image](https://github.com/nf-core/rnaseq/assets/12817534/3bb21573-c1d8-407d-a818-f77a21007167)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
