### PR TITLE
README.md: Added ref to downstream analyses

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To see the results of an example test run with a full size dataset refer to the 
 For more details about the output files and reports, please refer to the
 [output documentation](https://nf-co.re/rnaseq/output).
 
-This pipeline assigns the RNA/cDNA reads to genes in the genome, counts the number of reads per gene and normalizes the data. It does not compare the samples or assign P values to individual genes. For downstream analyses, the output files can be analysed directly in statistics environments like [R](https://www.r-project.org/) or [Julia](https://julialang.org/), or be forwarded to another workflow of Nextflow to determine transcripts with [differential abundance](https://github.com/nf-core/differentialabundance/).
+This pipeline quantifies RNA-sequenced reads relative to genes/transcripts in the genome and normalizes the resulting data. It does not compare the samples statistically in order to assign significance in the form of FDR or P-values. For downstream analyses, the output files from this pipeline can be analysed directly in statistical environments like [R](https://www.r-project.org/), [Julia](https://julialang.org/) or via the [nf-core/differentialabundance](https://github.com/nf-core/differentialabundance/) pipeline.
 
 ## Online videos
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ To see the results of an example test run with a full size dataset refer to the 
 For more details about the output files and reports, please refer to the
 [output documentation](https://nf-co.re/rnaseq/output).
 
+This pipeline assigns the RNA/cDNA reads to genes in the genome, counts the number of reads per gene and normalizes the data. It does not compare the samples or assign P values to individual genes. For downstream analyses, the output files can be analysed directly in statistics environments like [R](https://www.r-project.org/) or [Julia](https://julialang.org/), or be forwarded to another workflow of Nextflow to determine transcripts with [differential abundance](https://github.com/nf-core/differentialabundance/).
+
 ## Online videos
 
 A short talk about the history, current status and functionality on offer in this pipeline was given by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) on [8th February 2022](https://nf-co.re/events/2022/bytesize-32-nf-core-rnaseq) as part of the nf-core/bytesize series.


### PR DESCRIPTION
At a first glance, an "RNA-seq workflow" suggests an inclusion of a differential analysis of expression since it offers samples to be grouped and also runs DESeq2 on the basis of that grouping, i.e. what would also be run to determine a differential abundance. The emphasis on QA makes perfect sense but is not strongly communicated.

I suggest to add this paragraph to avoid the possibility of a disappointment for your novice users who (like us, admittedly) may not be aware of that second dedicated workflow to exist.