### PR TITLE
delete args2 of untar modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 > **Warning**
 > Quantification isn't performed if using `--aligner hisat2` due to the lack of an appropriate option to calculate accurate expression estimates from HISAT2 derived genomic alignments. However, you can use this route if you have a preference for the alignment, QC and other types of downstream analysis compatible with the output of HISAT2.
-
+  
 ## Usage
 
 > **Note**

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -55,7 +55,7 @@ process {
     }
 
     withName: 'UNTAR_.*' {
-        ext.args2 = '--no-same-owner'
+        ext.args = '--no-same-owner'
     }
 
     withName: 'UNTAR_.*|STAR_GENOMEGENERATE|STAR_GENOMEGENERATE_IGENOMES|HISAT2_BUILD' {

--- a/modules/nf-core/untar/main.nf
+++ b/modules/nf-core/untar/main.nf
@@ -19,7 +19,6 @@ process UNTAR {
 
     script:
     def args  = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
     prefix    = task.ext.prefix ?: ( meta.id ? "${meta.id}" : archive.baseName.toString().replaceFirst(/\.tar$/, ""))
 
     """
@@ -33,14 +32,12 @@ process UNTAR {
             -xavf \\
             $args \\
             $archive \\
-            $args2
     else
         tar \\
             -C $prefix \\
             -xavf \\
             $args \\
             $archive \\
-            $args2
     fi
 
     cat <<-END_VERSIONS > versions.yml


### PR DESCRIPTION
Hi,
In the conf/modules.config file, the attribute ext.args2 for the UNTAR module is defined first, even though, according to the development standards, the ext.args attribute should be used firstly. Moreover, in modules/nf-core/untar, since task.ext.args has never been defined in the modules.config file, the line def args = task.ext.args ?: '' does not make sense. Therefore, I've removed the ext.args2 portion and standardized the use of ext.args, aligning it with the development standards.

Does this make sense? I'd like to submit a PR for this on the GitHub repo.
## PR checklist

- [ ✅] This comment contains a description of changes (with reason).

- [✅ ] Make sure your code lints (`nf-core lint`).

