### PR TITLE
Patch modules to fix #1103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Credits
 
+Special thanks to the following for their contributions to the release:
+
+- [Adam Talbot](https://github.com/adamrtalbot)
+- [Jonathan Manning](https://github.com/pinin4fjords)
+- [Mahesh Binzer-Panchal](https://github.com/mahesh-panchal)
+- [Matthias Zepper](https://github.com/MatthiasZepper)
+- [Maxime Garcia](https://github.com/maxulysse)
+- [Phil Ewels](https://github.com/ewels)
+- [Vlad Savelyev](https://github.com/vladsavelyev)
+
 ### Enhancements & fixes
 
-- [PR #1135](https://github.com/nf-core/rnaseq/pull/1135) - Update [action-tower-launch](https://github.com/marketplace/actions/action-tower-launch) to v2 which supports more variable handling.
-- [PR #1149](https://github.com/nf-core/rnaseq/pull/1149) - Patch modules to fix #1103
-
-### Software dependencies
-
-### Modules / Subworkflows
+- [PR #1135](https://github.com/nf-core/rnaseq/pull/1135) - Update [action-tower-launch](https://github.com/marketplace/actions/action-tower-launch) to v2 which supports more variable handling
+- [PR #1149](https://github.com/nf-core/rnaseq/pull/1149) - Fix and patch version commands for Fastp, FastQC and UMI-tools modules ([#1103](https://github.com/nf-core/rnaseq/issues/1103))
 
 ## [[3.13.2](https://github.com/nf-core/rnaseq/releases/tag/3.13.2)] - 2023-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements & fixes
 
 - [PR #1135](https://github.com/nf-core/rnaseq/pull/1135) - Update [action-tower-launch](https://github.com/marketplace/actions/action-tower-launch) to v2 which supports more variable handling.
+- [PR #1149](https://github.com/nf-core/rnaseq/pull/1149) - Patch modules to fix #1103
 
 ### Software dependencies
 

--- a/modules.json
+++ b/modules.json
@@ -28,12 +28,14 @@
                     "fastp": {
                         "branch": "master",
                         "git_sha": "d497a4868ace3302016ea8ed4b395072d5e833cd",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "modules"]
+                        "installed_by": ["fastq_fastqc_umitools_fastp", "modules"],
+                        "patch": "modules/nf-core/fastp/fastp.diff"
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "102cc9b709a6da9f7cee2373563ab1464fca9c0a",
-                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"]
+                        "installed_by": ["fastq_fastqc_umitools_trimgalore", "fastq_fastqc_umitools_fastp"],
+                        "patch": "modules/nf-core/fastqc/fastqc.diff"
                     },
                     "fq/subsample": {
                         "branch": "master",
@@ -222,12 +224,14 @@
                     "umitools/dedup": {
                         "branch": "master",
                         "git_sha": "7297204bf49273300a3dbfa4b7a4027c8683f1bd",
-                        "installed_by": ["bam_dedup_stats_samtools_umitools"]
+                        "installed_by": ["bam_dedup_stats_samtools_umitools"],
+                        "patch": "modules/nf-core/umitools/dedup/umitools-dedup.diff"
                     },
                     "umitools/extract": {
                         "branch": "master",
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
-                        "installed_by": ["fastq_fastqc_umitools_fastp", "fastq_fastqc_umitools_trimgalore"]
+                        "installed_by": ["fastq_fastqc_umitools_fastp", "fastq_fastqc_umitools_trimgalore"],
+                        "patch": "modules/nf-core/umitools/extract/umitools-extract.diff"
                     },
                     "untar": {
                         "branch": "master",

--- a/modules/nf-core/fastp/fastp.diff
+++ b/modules/nf-core/fastp/fastp.diff
@@ -1,0 +1,32 @@
+Changes in module 'nf-core/fastp'
+--- modules/nf-core/fastp/main.nf
++++ modules/nf-core/fastp/main.nf
+@@ -45,7 +45,7 @@
+             $adapter_list \\
+             $fail_fastq \\
+             $args \\
+-            2> ${prefix}.fastp.log \\
++            2> >(tee ${prefix}.fastp.log >&2) \\
+         | gzip -c > ${prefix}.fastp.fastq.gz
+ 
+         cat <<-END_VERSIONS > versions.yml
+@@ -66,7 +66,7 @@
+             $adapter_list \\
+             $fail_fastq \\
+             $args \\
+-            2> ${prefix}.fastp.log
++            2> >(tee ${prefix}.fastp.log >&2)
+ 
+         cat <<-END_VERSIONS > versions.yml
+         "${task.process}":
+@@ -91,7 +91,7 @@
+             --thread $task.cpus \\
+             --detect_adapter_for_pe \\
+             $args \\
+-            2> ${prefix}.fastp.log
++            2> >(tee ${prefix}.fastp.log >&2)
+ 
+         cat <<-END_VERSIONS > versions.yml
+         "${task.process}":
+
+************************************************************

--- a/modules/nf-core/fastp/main.nf
+++ b/modules/nf-core/fastp/main.nf
@@ -45,7 +45,7 @@ process FASTP {
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> ${prefix}.fastp.log \\
+            2> >(tee ${prefix}.fastp.log >&2) \\
         | gzip -c > ${prefix}.fastp.fastq.gz
 
         cat <<-END_VERSIONS > versions.yml
@@ -66,7 +66,7 @@ process FASTP {
             $adapter_list \\
             $fail_fastq \\
             $args \\
-            2> ${prefix}.fastp.log
+            2> >(tee ${prefix}.fastp.log >&2)
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -91,7 +91,7 @@ process FASTP {
             --thread $task.cpus \\
             --detect_adapter_for_pe \\
             $args \\
-            2> ${prefix}.fastp.log
+            2> >(tee ${prefix}.fastp.log >&2)
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/nf-core/fastqc/fastqc.diff
+++ b/modules/nf-core/fastqc/fastqc.diff
@@ -1,0 +1,23 @@
+Changes in module 'nf-core/fastqc'
+--- modules/nf-core/fastqc/main.nf
++++ modules/nf-core/fastqc/main.nf
+@@ -37,7 +37,7 @@
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
++        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
+     END_VERSIONS
+     """
+ 
+@@ -49,7 +49,7 @@
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
++        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
+     END_VERSIONS
+     """
+ }
+
+************************************************************

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -37,7 +37,7 @@ process FASTQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
     END_VERSIONS
     """
 
@@ -49,7 +49,7 @@ process FASTQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/umitools/dedup/main.nf
+++ b/modules/nf-core/umitools/dedup/main.nf
@@ -42,7 +42,7 @@ process UMITOOLS_DEDUP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
+        umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
     END_VERSIONS
     """
 
@@ -56,7 +56,7 @@ process UMITOOLS_DEDUP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
+        umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/umitools/dedup/umitools-dedup.diff
+++ b/modules/nf-core/umitools/dedup/umitools-dedup.diff
@@ -1,0 +1,23 @@
+Changes in module 'nf-core/umitools/dedup'
+--- modules/nf-core/umitools/dedup/main.nf
++++ modules/nf-core/umitools/dedup/main.nf
+@@ -42,7 +42,7 @@
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
++        umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
+     END_VERSIONS
+     """
+ 
+@@ -56,7 +56,7 @@
+ 
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+-        umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
++        umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
+     END_VERSIONS
+     """
+ }
+
+************************************************************

--- a/modules/nf-core/umitools/extract/main.nf
+++ b/modules/nf-core/umitools/extract/main.nf
@@ -33,7 +33,7 @@ process UMITOOLS_EXTRACT {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
+            umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
         END_VERSIONS
         """
     }  else {
@@ -49,7 +49,7 @@ process UMITOOLS_EXTRACT {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
+            umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
         END_VERSIONS
         """
     }

--- a/modules/nf-core/umitools/extract/umitools-extract.diff
+++ b/modules/nf-core/umitools/extract/umitools-extract.diff
@@ -1,0 +1,23 @@
+Changes in module 'nf-core/umitools/extract'
+--- modules/nf-core/umitools/extract/main.nf
++++ modules/nf-core/umitools/extract/main.nf
+@@ -33,7 +33,7 @@
+ 
+         cat <<-END_VERSIONS > versions.yml
+         "${task.process}":
+-            umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
++            umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
+         END_VERSIONS
+         """
+     }  else {
+@@ -49,7 +49,7 @@
+ 
+         cat <<-END_VERSIONS > versions.yml
+         "${task.process}":
+-            umitools: \$(umi_tools --version 2>&1 | sed 's/^.*UMI-tools version://; s/ *\$//')
++            umitools: \$( umi_tools --version | sed '/version:/!d; s/.*: //' )
+         END_VERSIONS
+         """
+     }
+
+************************************************************


### PR DESCRIPTION
Fixes tests in https://github.com/nf-core/rnaseq/pull/1148 which was a reversion of https://github.com/nf-core/rnaseq/pull/1138 

Idea is to temporarily patch fix this via `nf-core modules patch` and push all nf-test related changes to the nf-test branch.