### PR TITLE
Be more flexible on attribute values in GTFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1141](https://github.com/nf-core/rnaseq/pull/1141) - Important! Template update for nf-core/tools v2.11
 - [PR #1149](https://github.com/nf-core/rnaseq/pull/1149) - Fix and patch version commands for Fastp, FastQC and UMI-tools modules ([#1103](https://github.com/nf-core/rnaseq/issues/1103))
 - [PR #1144](https://github.com/nf-core/rnaseq/pull/1144) - Interface to kmer size for pseudoaligners
-- [PR #1150](https://github.com/nf-core/rnaseq/pull/1150) - Be more flexible on attribute values in GTFs
+- [PR #1150](https://github.com/nf-core/rnaseq/pull/1150) - Be more flexible on attribute values in GTFs ([#1132](https://github.com/nf-core/rnaseq/issues/1132))
 
 ## [[3.13.2](https://github.com/nf-core/rnaseq/releases/tag/3.13.2)] - 2023-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1141](https://github.com/nf-core/rnaseq/pull/1141) - Important! Template update for nf-core/tools v2.11
 - [PR #1149](https://github.com/nf-core/rnaseq/pull/1149) - Fix and patch version commands for Fastp, FastQC and UMI-tools modules ([#1103](https://github.com/nf-core/rnaseq/issues/1103))
 - [PR #1144](https://github.com/nf-core/rnaseq/pull/1144) - Interface to kmer size for pseudoaligners
+- [PR #1150](https://github.com/nf-core/rnaseq/pull/1150) - Be more flexible on attribute values in GTFs
 
 ## [[3.13.2](https://github.com/nf-core/rnaseq/releases/tag/3.13.2)] - 2023-11-21
 

--- a/bin/tx2gene.py
+++ b/bin/tx2gene.py
@@ -54,7 +54,7 @@ def discover_transcript_attribute(gtf_file: str, transcripts: Set[str]) -> str:
 
     votes = Counter()
     with open(gtf_file) as inh:
-         # Read GTF file, skipping header lines
+        # Read GTF file, skipping header lines
         for line in filter(lambda x: not x.startswith("#"), inh):
             cols = line.split("\t")
 

--- a/bin/tx2gene.py
+++ b/bin/tx2gene.py
@@ -6,6 +6,7 @@ import logging
 import argparse
 import glob
 import os
+import re
 from collections import Counter, defaultdict, OrderedDict
 from collections.abc import Set
 from typing import Dict
@@ -50,14 +51,18 @@ def discover_transcript_attribute(gtf_file: str, transcripts: Set[str]) -> str:
     Returns:
     str: The attribute name that corresponds to transcripts in the GTF file.
     """
+
     votes = Counter()
     with open(gtf_file) as inh:
-        # Read GTF file, skipping header lines
+         # Read GTF file, skipping header lines
         for line in filter(lambda x: not x.startswith("#"), inh):
             cols = line.split("\t")
-            # Parse attribute column and update votes for each attribute found
-            attributes = dict(item.strip().split(" ", 1) for item in cols[8].split(";") if item.strip())
-            votes.update(key for key, value in attributes.items() if value.strip('"') in transcripts)
+
+            # Use regular expression to correctly split the attributes string
+            attributes_str = cols[8]
+            attributes = dict(re.findall(r'(\S+) "(.*?)(?<!\\)";', attributes_str))
+
+            votes.update(key for key, value in attributes.items())
 
     if not votes:
         # Log a warning if no matching attribute is found


### PR DESCRIPTION
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

Closes https://github.com/nf-core/rnaseq/issues/1132

In the above noted issue, parsing a GTF file failed due to semicolons in the attribute value. We can address this by being more flexible on field content while being stricter on the formatting of the attribute line itself.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
