### PR TITLE
Add slash to outdir for cloud tests to fix Azure validation…

### DIFF
--- a/.github/workflows/cloud_tests_small.yml
+++ b/.github/workflows/cloud_tests_small.yml
@@ -28,7 +28,7 @@ jobs:
           profiles: test
           parameters: |
             {
-                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}"
+                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}/"
             }
       - uses: actions/upload-artifact@v3
         with:
@@ -48,7 +48,7 @@ jobs:
           profiles: test
           parameters: |
             {
-                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}"
+                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}/"
             }
       - uses: actions/upload-artifact@v3
         with:
@@ -68,7 +68,7 @@ jobs:
           profiles: test
           parameters: |
             {
-                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}"
+                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}/"
             }
       - uses: actions/upload-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1151](https://github.com/nf-core/rnaseq/pull/1151) - fix to #1150: reinstate conditional
 - [PR #1152](https://github.com/nf-core/rnaseq/pull/1152) - Bump container versions for tools using Docker V1 manifest ([#1140](https://github.com/nf-core/rnaseq/issues/1140))
 - [PR #1154](https://github.com/nf-core/rnaseq/pull/1154) - Prerelease 3.14.0 fixes ([#1111](https://github.com/nf-core/rnaseq/issues/1111), [#1153](https://github.com/nf-core/rnaseq/issues/1153))
+- [PR #1157](https://github.com/nf-core/rnaseq/pull/1157) - Add slash to `--outdir` for cloud tests to fix Azure validation issue
 
 ### Parameters
 


### PR DESCRIPTION
To fix failing Azure tests as you can see [here](https://tower.nf/orgs/nf-core/workspaces/AWSmegatests/watch/41SRHZWS3jEMPX)

```
The workflow execution failed to start. Exit status: 1

Pulling nf-core/rnaseq ...
 downloaded from https://github.com/nf-core/rnaseq.git
Launching `https://github.com/nf-core/rnaseq` [azure_rnaseq_small] DSL2 - revision: a10f41afa2 [master]
Downloading plugin nf-validation@1.1.3
ERROR ~ ERROR: Validation of pipeline parameters failed!

 -- Check 'nf-41SRHZWS3jEMPX.log' file for details
[0;31mThe following invalid input values have been detected:

* --outdir: 'az://work/rnaseq/results-test-a10f41afa204538d5dcc89a5910c299d68f94f41' is not a directory, but a file (az://work/rnaseq/results-test-a10f41afa204538d5dcc89a5910c299d68f94f41)
[0m
```