### PR TITLE
Improved ext.args consolidation for STAR and TRIMGALORE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1245](https://github.com/nf-core/rnaseq/pull/1245) - nf test quantify rsem
 - [PR #1246](https://github.com/nf-core/rnaseq/pull/1246) - nf-test quantify pseudoalignment
 - [PR #1247](https://github.com/nf-core/rnaseq/pull/1247) - nf-test prepare_genome
+- [PR #1248](https://github.com/nf-core/rnaseq/pull/1248) - Improved ext.args consolidation for STAR and TRIMGALORE extra_args parameters
 - [PR #1249](https://github.com/nf-core/rnaseq/pull/1249) - Include nf-tests for rsem_merge_counts module
 - [PR #1250](https://github.com/nf-core/rnaseq/pull/1250) - Remove all tags.yml files because the testing system has changed
 - [PR #1251](https://github.com/nf-core/rnaseq/pull/1251) - Replace deseq2qc paths

--- a/subworkflows/local/align_star/nextflow.config
+++ b/subworkflows/local/align_star/nextflow.config
@@ -2,29 +2,34 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
     process {
         withName: '.*:ALIGN_STAR:STAR_ALIGN|.*:ALIGN_STAR:STAR_ALIGN_IGENOMES' {
             ext.args   = {
-                def preset_args = [
-                    '--quantMode TranscriptomeSAM',
-                    '--twopassMode Basic',
-                    '--outSAMtype BAM Unsorted',
-                    '--readFilesCommand zcat',
-                    '--runRNGseed 0',
-                    '--outFilterMultimapNmax 20',
-                    '--alignSJDBoverhangMin 1',
-                    '--outSAMattributes NH HI AS NM MD',
-                    '--quantTranscriptomeBan Singleend',
-                    '--outSAMstrandField intronMotif',
-                    params.save_unaligned ? '--outReadsUnmapped Fastx' : ''
-                ]
+                    // Function to convert argument strings into a map
+                    def argsToMap(String args) {
+                        args.split("\\s(?=--)").collectEntries {
+                            def (key, value) = it.trim().split(/\s+/, 2)
+                            [(key): value]
+                        }
+                    }
 
-                def extra_args = params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)").unique() : []
+                    // Initialize the map with preconfigured values
+                    def preset_args_map = argsToMap("""
+                        --quantMode TranscriptomeSAM
+                        --twopassMode Basic
+                        --outSAMtype BAM Unsorted
+                        --readFilesCommand zcat
+                        --runRNGseed 0
+                        --outFilterMultimapNmax 20
+                        --alignSJDBoverhangMin 1
+                        --outSAMattributes NH HI AS NM MD
+                        --quantTranscriptomeBan Singleend
+                        --outSAMstrandField intronMotif
+                        ${params.save_unaligned ? '--outReadsUnmapped Fastx' : ''}
+                    """.trim())
 
-                extra_args.each { extra_arg ->
-                    def extra_arg_key = extra_arg.split(' ')[0]
-                    preset_args = preset_args.findAll { !it.startsWith(extra_arg_key) }
-                    preset_args.add(extra_arg)
-                }
+                    // Consolidate the extra arguments
+                    def final_args_map = preset_args_map + (params.extra_star_align_args ? argsToMap(params.extra_star_align_args) : [:])
 
-                preset_args.join(' ').trim()
+                    // Convert the map back to a list and then to a single string
+                    final_args_map.collect { key, value -> "${key} ${value}" }.join(' ').trim()
             }
 
             publishDir = [

--- a/subworkflows/local/align_star/nextflow.config
+++ b/subworkflows/local/align_star/nextflow.config
@@ -3,10 +3,10 @@ if (!params.skip_alignment && params.aligner == 'star_salmon') {
         withName: '.*:ALIGN_STAR:STAR_ALIGN|.*:ALIGN_STAR:STAR_ALIGN_IGENOMES' {
             ext.args   = {
                     // Function to convert argument strings into a map
-                    def argsToMap(String args) {
+                    def argsToMap = { String args ->
                         args.split("\\s(?=--)").collectEntries {
-                            def (key, value) = it.trim().split(/\s+/, 2)
-                            [(key): value]
+                            def parts = it.trim().split(/\s+/, 2)
+                            [(parts.first()): parts.last()]
                         }
                     }
 

--- a/subworkflows/local/align_star/nextflow.config
+++ b/subworkflows/local/align_star/nextflow.config
@@ -1,20 +1,32 @@
 if (!params.skip_alignment && params.aligner == 'star_salmon') {
     process {
         withName: '.*:ALIGN_STAR:STAR_ALIGN|.*:ALIGN_STAR:STAR_ALIGN_IGENOMES' {
-            ext.args   = { [
-                '--quantMode TranscriptomeSAM',
-                '--twopassMode Basic',
-                '--outSAMtype BAM Unsorted',
-                '--readFilesCommand zcat',
-                '--runRNGseed 0',
-                '--outFilterMultimapNmax 20',
-                '--alignSJDBoverhangMin 1',
-                '--outSAMattributes NH HI AS NM MD',
-                '--quantTranscriptomeBan Singleend',
-                '--outSAMstrandField intronMotif',
-                params.save_unaligned ? '--outReadsUnmapped Fastx' : '',
-                params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)") : ''
-            ].flatten().unique(false).join(' ').trim() }
+            ext.args   = {
+                def preset_args = [
+                    '--quantMode TranscriptomeSAM',
+                    '--twopassMode Basic',
+                    '--outSAMtype BAM Unsorted',
+                    '--readFilesCommand zcat',
+                    '--runRNGseed 0',
+                    '--outFilterMultimapNmax 20',
+                    '--alignSJDBoverhangMin 1',
+                    '--outSAMattributes NH HI AS NM MD',
+                    '--quantTranscriptomeBan Singleend',
+                    '--outSAMstrandField intronMotif',
+                    params.save_unaligned ? '--outReadsUnmapped Fastx' : ''
+                ]
+
+                def extra_args = params.extra_star_align_args ? params.extra_star_align_args.split("\\s(?=--)").unique() : []
+
+                extra_args.each { extra_arg ->
+                    def extra_arg_key = extra_arg.split(' ')[0]
+                    preset_args = preset_args.findAll { !it.startsWith(extra_arg_key) }
+                    preset_args.add(extra_arg)
+                }
+
+                preset_args.join(' ').trim()
+            }
+
             publishDir = [
                 [
                     path: { "${params.outdir}/${params.aligner}/log" },

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
@@ -13,16 +13,24 @@ if (!params.skip_trimming) {
         process {
             withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
                 ext.args   = {
-                    def preset_args = ["--fastqc_args '-t ${task.cpus}'"]
-                    def extra_args = params.extra_trimgalore_args ? params.extra_trimgalore_args.split("\\s(?=--)").unique() : []
-
-                    extra_args.each { extra_arg ->
-                        def extra_arg_key = extra_arg.split(' ')[0]
-                        preset_args = preset_args.findAll { !it.startsWith(extra_arg_key) }
-                        preset_args.add(extra_arg)
+                    // Function to convert argument strings into a map
+                    def argsToMap(String args) {
+                        args.split("\\s(?=--)").collectEntries {
+                            def (key, value) = it.trim().split(/\s+/, 2)
+                            [(key): value]
+                        }
                     }
 
-                    preset_args.join(' ').trim()
+                    // Initialize the map with preconfigured values
+                    def preset_args_map = argsToMap("""
+                    --fastqc_args '-t ${task.cpus}'
+                    """.trim())
+
+                    // Consolidate the extra arguments
+                    def final_args_map = preset_args_map + (params.extra_trimgalore_args ? argsToMap(params.extra_trimgalore_args) : [:])
+
+                    // Convert the map back to a list and then to a single string
+                    final_args_map.collect { key, value -> "${key} ${value}" }.join(' ').trim()
                 }
                 publishDir = [
                     [

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
@@ -13,10 +13,16 @@ if (!params.skip_trimming) {
         process {
             withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
                 ext.args   = {
-                    [
-                        "--fastqc_args '-t ${task.cpus}'",
-                        params.extra_trimgalore_args ? params.extra_trimgalore_args.split("\\s(?=--)") : ''
-                    ].flatten().unique(false).join(' ').trim()
+                    def preset_args = ["--fastqc_args '-t ${task.cpus}'"]
+                    def extra_args = params.extra_trimgalore_args ? params.extra_trimgalore_args.split("\\s(?=--)").unique() : []
+
+                    extra_args.each { extra_arg ->
+                        def extra_arg_key = extra_arg.split(' ')[0]
+                        preset_args = preset_args.findAll { !it.startsWith(extra_arg_key) }
+                        preset_args.add(extra_arg)
+                    }
+
+                    preset_args.join(' ').trim()
                 }
                 publishDir = [
                     [

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/nextflow.config
@@ -14,10 +14,10 @@ if (!params.skip_trimming) {
             withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
                 ext.args   = {
                     // Function to convert argument strings into a map
-                    def argsToMap(String args) {
+                    def argsToMap = { String args ->
                         args.split("\\s(?=--)").collectEntries {
-                            def (key, value) = it.trim().split(/\s+/, 2)
-                            [(key): value]
+                            def parts = it.trim().split(/\s+/, 2)
+                            [(parts.first()): parts.last()]
                         }
                     }
 


### PR DESCRIPTION
Occasionally, people were surprised that parameters provided to `extra_star_align_args` could still conflict with the default configuration (e.g. #1046). 

As a convenience parameter, I felt that it should never take precedence over the actual module configuration, because it seemed more error-prone to silently overwrite the module config with something that (as the parameter name suggests) is meant to be extra. Hence, I preferred that a custom module config should be used.

However, I said that I would be open to reconsider and since now also @tdanhorn and @CharlotteAnne [suggested that change](https://nfcore.slack.com/archives/CE8SSJV3N/p1709922560070949?thread_ts=1709918837.785829&cid=CE8SSJV3N), I gave in. This PR now improves the `extra_args` parameter consolidation so it can override presets from the config.

<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
