### PR TITLE
Delete unecessary tags from nf.test files for modules and subworkflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1250](https://github.com/nf-core/rnaseq/pull/1250) - Remove all tags.yml files because the testing system has changed
 - [PR #1251](https://github.com/nf-core/rnaseq/pull/1251) - Replace deseq2_qc paths
 - [PR #1265](https://github.com/nf-core/rnaseq/pull/1265) - Small updates noticed during code review
+- [PR #1266](https://github.com/nf-core/rnaseq/pull/1266) - Delete unecessary tags from nf.test files for modules and subworkflows
 
 ### Parameters
 

--- a/modules/local/gtf2bed/tests/main.nf.test
+++ b/modules/local/gtf2bed/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "GTF2BED"
 
-    tag "modules"
-    tag "modules_local"
-    tag "gtf2bed"
-
     test("sarscov2 - bam") {
 
         when {

--- a/modules/local/star_align_igenomes/tests/main.nf.test
+++ b/modules/local/star_align_igenomes/tests/main.nf.test
@@ -4,7 +4,7 @@ nextflow_process {
     script "../main.nf"
     process "STAR_ALIGN_IGENOMES"
     tag "STAR_ALIGN_IGENOMES"
-    tag "STAR_GENOMEGENERATE_IGENOMES_IGENOMES"
+    tag "STAR_GENOMEGENERATE_IGENOMES"
 
     setup {
         run("STAR_GENOMEGENERATE_IGENOMES") {

--- a/modules/local/star_genomegenerate_igenomes/tests/main.nf.test
+++ b/modules/local/star_genomegenerate_igenomes/tests/main.nf.test
@@ -4,8 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "STAR_GENOMEGENERATE_IGENOMES"
 
-    tag "STAR_GENOMEGENERATE_IGENOMES"
-
     test("fasta with gtf") {
 
         when {

--- a/modules/nf-core/bbmap/bbsplit/tests/main.nf.test
+++ b/modules/nf-core/bbmap/bbsplit/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process BBMAP_BBSPLIT"
     script "../main.nf"
     process "BBMAP_BBSPLIT"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "bbmap"
-    tag "bbmap/bbsplit"
 
     test("sarscov2_se_fastq_fasta_chr22_fasta") {
 

--- a/modules/nf-core/bedtools/genomecov/tests/main.nf.test
+++ b/modules/nf-core/bedtools/genomecov/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     process "BEDTOOLS_GENOMECOV"
     config "./nextflow.config"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "bedtools"
-    tag "bedtools/genomecov"
-
    test("sarscov2 - no scale") {
         when {
             process {

--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process CAT_FASTQ"
     script "../main.nf"
     process "CAT_FASTQ"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "cat"
-    tag "cat/fastq"
 
     test("test_cat_fastq_single_end") {
 

--- a/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test
+++ b/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "CUSTOM_CATADDITIONALFASTA"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "custom"
-    tag "custom/catadditionalfasta"
-
     test("sarscov2 - fastq - gtf") {
 
         when {

--- a/modules/nf-core/custom/getchromsizes/tests/main.nf.test
+++ b/modules/nf-core/custom/getchromsizes/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "CUSTOM_GETCHROMSIZES"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "custom"
-    tag "custom/getchromsizes"
-
     test("test_custom_getchromsizes") {
 
         when {

--- a/modules/nf-core/custom/tx2gene/tests/main.nf.test
+++ b/modules/nf-core/custom/tx2gene/tests/main.nf.test
@@ -3,12 +3,7 @@ nextflow_process {
     name "Test Process CUSTOM_TX2GENE"
     script "../main.nf"
     process "CUSTOM_TX2GENE"
-
-    tag "modules"
-    tag "modules_nfcore"
-    tag "custom"
-    tag "custom/tx2gene"
-    tag "untar"
+    tag "UNTAR"
 
     setup {
 

--- a/modules/nf-core/dupradar/tests/main.nf.test
+++ b/modules/nf-core/dupradar/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "DUPRADAR"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "dupradar"
-
     test("sarscov2 - bam - single_end") {
 
         config './nextflow.config'

--- a/modules/nf-core/fastp/tests/main.nf.test
+++ b/modules/nf-core/fastp/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_process {
     name "Test Process FASTP"
     script "../main.nf"
     process "FASTP"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "fastp"
 
     test("test_fastp_single_end") {
 

--- a/modules/nf-core/fastqc/tests/main.nf.test
+++ b/modules/nf-core/fastqc/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "FASTQC"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "fastqc"
-
     test("sarscov2 single-end [fastq]") {
 
         when {

--- a/modules/nf-core/fq/subsample/tests/main.nf.test
+++ b/modules/nf-core/fq/subsample/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "FQ_SUBSAMPLE"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "fq"
-    tag "fq/subsample"
-
     test("test_fq_subsample_no_args") {
         config "./nextflow_no_args.config"
         when {

--- a/modules/nf-core/gffread/tests/main.nf.test
+++ b/modules/nf-core/gffread/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "GFFREAD"
 
-    tag "gffread"
-    tag "modules_nfcore"
-    tag "modules"
-
     test("sarscov2-gff3-gtf") {
 
         config "./nextflow.config"

--- a/modules/nf-core/gunzip/tests/main.nf.test
+++ b/modules/nf-core/gunzip/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_process {
     name "Test Process GUNZIP"
     script "../main.nf"
     process "GUNZIP"
-    tag "gunzip"
-    tag "modules_nfcore"
-    tag "modules"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/hisat2/align/tests/main.nf.test
+++ b/modules/nf-core/hisat2/align/tests/main.nf.test
@@ -3,12 +3,8 @@ nextflow_process {
     name "Test Process HISAT2_ALIGN"
     script "../main.nf"
     process "HISAT2_ALIGN"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "hisat2"
-    tag "hisat2/align"
-    tag "hisat2/build"
-    tag "hisat2/extractsplicesites"
+    tag "HISAT2_BUILD"
+    tag "HISAT2_EXTRACTSPLICESITES"
 
     test("Single-End") {
 

--- a/modules/nf-core/hisat2/build/tests/main.nf.test
+++ b/modules/nf-core/hisat2/build/tests/main.nf.test
@@ -3,11 +3,7 @@ nextflow_process {
     name "Test Process HISAT2_BUILD"
     script "../main.nf"
     process "HISAT2_BUILD"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "hisat2"
-    tag "hisat2/build"
-    tag "hisat2/extractsplicesites"
+    tag "HISAT2_EXTRACTSPLICESITES"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
+++ b/modules/nf-core/hisat2/extractsplicesites/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process HISAT2_EXTRACTSPLICESITES"
     script "../main.nf"
     process "HISAT2_EXTRACTSPLICESITES"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "hisat2"
-    tag "hisat2/extractsplicesites"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/kallisto/index/tests/main.nf.test
+++ b/modules/nf-core/kallisto/index/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process KALLISTO_INDEX"
     script "../main.nf"
     process "KALLISTO_INDEX"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "kallisto"
-    tag "kallisto/index"
 
     test("sarscov2 transcriptome.fasta") {
 

--- a/modules/nf-core/kallisto/quant/tests/main.nf.test
+++ b/modules/nf-core/kallisto/quant/tests/main.nf.test
@@ -3,11 +3,7 @@ nextflow_process {
     name "Test Process KALLISTO_QUANT"
     script "../main.nf"
     process "KALLISTO_QUANT"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "kallisto"
-    tag "kallisto/quant"
-    tag "kallisto/index"
+    tag "KALLISTO_INDEX"
 
     setup {
             run("KALLISTO_INDEX") {

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "MULTIQC"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "multiqc"
-
     test("sarscov2 single-end [fastqc]") {
 
         when {

--- a/modules/nf-core/picard/markduplicates/tests/main.nf.test
+++ b/modules/nf-core/picard/markduplicates/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "PICARD_MARKDUPLICATES"
     config "./nextflow.config"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "picard"
-    tag "picard/markduplicates"
 
     test("sarscov2 [unsorted bam]") {
 

--- a/modules/nf-core/preseq/lcextrap/tests/main.nf.test
+++ b/modules/nf-core/preseq/lcextrap/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process PRESEQ_LCEXTRAP"
     script "../main.nf"
     process "PRESEQ_LCEXTRAP"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "preseq"
-    tag "preseq/lcextrap"
 
     test("sarscov2 - single_end") {
         when {

--- a/modules/nf-core/qualimap/rnaseq/tests/main.nf.test
+++ b/modules/nf-core/qualimap/rnaseq/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process QUALIMAP_RNASEQ"
     script "../main.nf"
     process "QUALIMAP_RNASEQ"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "qualimap"
-    tag "qualimap/rnaseq"
 
     test("homo_sapiens [bam]") {
 

--- a/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
+++ b/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
@@ -3,13 +3,9 @@ nextflow_process {
     name "Test Process RSEM_CALCULATEEXPRESSION"
     script "../main.nf"
     process "RSEM_CALCULATEEXPRESSION"
+    tag "RSEM_PREPAREREFERENCE"
     config "./nextflow.config"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rsem"
-    tag "rsem/calculateexpression"
-    tag "rsem/preparereference"
-
+    
     test("homo_sapiens") {
 
         setup {

--- a/modules/nf-core/rsem/preparereference/tests/main.nf.test
+++ b/modules/nf-core/rsem/preparereference/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process RSEM_PREPAREREFERENCE"
     script "../main.nf"
     process "RSEM_PREPAREREFERENCE"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rsem"
-    tag "rsem/preparereference"
 
     test("homo_sapiens") {
 

--- a/modules/nf-core/rseqc/bamstat/tests/main.nf.test
+++ b/modules/nf-core/rseqc/bamstat/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "RSEQC_BAMSTAT"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/bamstat"
-
     config "./nextflow.config"
 
     test("sarscov2 - [meta] - bam") {

--- a/modules/nf-core/rseqc/inferexperiment/tests/main.nf.test
+++ b/modules/nf-core/rseqc/inferexperiment/tests/main.nf.test
@@ -5,11 +5,6 @@ nextflow_process {
     process "RSEQC_INFEREXPERIMENT"
     config "./nextflow.config"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/inferexperiment"
-
     test("sarscov2 - [[meta] - bam] - bed") {
 
         when {

--- a/modules/nf-core/rseqc/innerdistance/tests/main.nf.test
+++ b/modules/nf-core/rseqc/innerdistance/tests/main.nf.test
@@ -5,11 +5,6 @@ nextflow_process {
     process "RSEQC_INNERDISTANCE"
     config "./nextflow.config"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/innerdistance"
-
     test("sarscov2 - [[meta] - bam] - bed") {
 
         when {

--- a/modules/nf-core/rseqc/junctionannotation/tests/main.nf.test
+++ b/modules/nf-core/rseqc/junctionannotation/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "RSEQC_JUNCTIONANNOTATION"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/junctionannotation"
-
     test("sarscov2 - paired end [bam]") {
 
         when {

--- a/modules/nf-core/rseqc/junctionsaturation/tests/main.nf.test
+++ b/modules/nf-core/rseqc/junctionsaturation/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "RSEQC_JUNCTIONSATURATION"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/junctionsaturation"
-
     test("sarscov2 paired-end [bam]") {
 
         when {

--- a/modules/nf-core/rseqc/readdistribution/tests/main.nf.test
+++ b/modules/nf-core/rseqc/readdistribution/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process RSEQC_READDISTRIBUTION"
     script "../main.nf"
     process "RSEQC_READDISTRIBUTION"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/readdistribution"
 
     test("sarscov2 paired-end [bam]") {
 

--- a/modules/nf-core/rseqc/readduplication/tests/main.nf.test
+++ b/modules/nf-core/rseqc/readduplication/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process RSEQC_READDUPLICATION"
     script "../main.nf"
     process "RSEQC_READDUPLICATION"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/readduplication"
 
     test("sarscov2 paired-end [bam]") {
 

--- a/modules/nf-core/rseqc/tin/tests/main.nf.test
+++ b/modules/nf-core/rseqc/tin/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process RSEQC_TIN"
     script "../main.nf"
     process "RSEQC_TIN"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "rseqc"
-    tag "rseqc/tin"
 
     test("sarscov2 paired-end [bam]") {
 

--- a/modules/nf-core/salmon/index/tests/main.nf.test
+++ b/modules/nf-core/salmon/index/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SALMON_INDEX"
     script "../main.nf"
     process "SALMON_INDEX"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "salmon"
-    tag "salmon/index"
 
     test("sarscov2") {
 

--- a/modules/nf-core/salmon/quant/tests/main.nf.test
+++ b/modules/nf-core/salmon/quant/tests/main.nf.test
@@ -3,12 +3,8 @@ nextflow_process {
     name "Test Process SALMON_QUANT"
     script "../main.nf"
     process "SALMON_QUANT"
+    tag "SALMON_INDEX"
     config "./nextflow.config"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "salmon"
-    tag "salmon/quant"
-    tag "salmon/index"
 
     setup {
         run("SALMON_INDEX") {

--- a/modules/nf-core/samtools/flagstat/tests/main.nf.test
+++ b/modules/nf-core/samtools/flagstat/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SAMTOOLS_FLAGSTAT"
     script "../main.nf"
     process "SAMTOOLS_FLAGSTAT"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "samtools"
-    tag "samtools/flagstat"
 
     test("BAM") {
 

--- a/modules/nf-core/samtools/idxstats/tests/main.nf.test
+++ b/modules/nf-core/samtools/idxstats/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SAMTOOLS_IDXSTATS"
     script "../main.nf"
     process "SAMTOOLS_IDXSTATS"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "samtools"
-    tag "samtools/idxstats"
 
     test("bam") {
 

--- a/modules/nf-core/samtools/index/tests/main.nf.test
+++ b/modules/nf-core/samtools/index/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SAMTOOLS_INDEX"
     script "../main.nf"
     process "SAMTOOLS_INDEX"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "samtools"
-    tag "samtools/index"
 
     test("bai") {
 

--- a/modules/nf-core/samtools/sort/tests/main.nf.test
+++ b/modules/nf-core/samtools/sort/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SAMTOOLS_SORT"
     script "../main.nf"
     process "SAMTOOLS_SORT"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "samtools"
-    tag "samtools/sort"
 
     test("bam") {
 

--- a/modules/nf-core/samtools/stats/tests/main.nf.test
+++ b/modules/nf-core/samtools/stats/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process SAMTOOLS_STATS"
     script "../main.nf"
     process "SAMTOOLS_STATS"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "samtools"
-    tag "samtools/stats"
 
     test("bam") {
 

--- a/modules/nf-core/sortmerna/tests/main.nf.test
+++ b/modules/nf-core/sortmerna/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_process {
     name "Test Process SORTMERNA"
     script "../main.nf"
     process "SORTMERNA"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "sortmerna"
 
     test("sarscov2 indexing only") {
  

--- a/modules/nf-core/star/align/tests/main.nf.test
+++ b/modules/nf-core/star/align/tests/main.nf.test
@@ -3,11 +3,7 @@ nextflow_process {
     name "Test Process STAR_ALIGN"
     script "../main.nf"
     process "STAR_ALIGN"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "star"
-    tag "star/align"
-    tag "star/genomegenerate"
+    tag "STAR_GENOMEGENERATE"
 
     setup {
         run("STAR_GENOMEGENERATE") {

--- a/modules/nf-core/star/genomegenerate/tests/main.nf.test
+++ b/modules/nf-core/star/genomegenerate/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process STAR_GENOMEGENERATE"
     script "../main.nf"
     process "STAR_GENOMEGENERATE"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "star"
-    tag "star/genomegenerate"
 
     test("fasta_gtf") {
 

--- a/modules/nf-core/stringtie/stringtie/tests/main.nf.test
+++ b/modules/nf-core/stringtie/stringtie/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process STRINGTIE_STRINGTIE"
     script "../main.nf"
     process "STRINGTIE_STRINGTIE"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "stringtie"
-    tag "stringtie/stringtie"
 
     test("sarscov2 [bam] - forward strandedness") {
 

--- a/modules/nf-core/subread/featurecounts/tests/main.nf.test
+++ b/modules/nf-core/subread/featurecounts/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "SUBREAD_FEATURECOUNTS"
     config "./nextflow.config"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "subread"
-    tag "subread/featurecounts"
 
     test("sarscov2 [bam] - forward") {
 

--- a/modules/nf-core/summarizedexperiment/summarizedexperiment/tests/main.nf.test
+++ b/modules/nf-core/summarizedexperiment/summarizedexperiment/tests/main.nf.test
@@ -3,15 +3,9 @@ nextflow_process {
     name "Test Process SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
     script "../main.nf"
     process "SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
-
-    tag "modules"
-    tag "modules_nfcore"
-    tag "custom/tx2gene"
-    tag "tximeta"
-    tag "tximeta/tximport"
-    tag "summarizedexperiment"
-    tag "summarizedexperiment/summarizedexperiment"
-    tag "untar"
+    tag "UNTAR"
+    tag "CUSTOM_TX2GENE"
+    tag "TXIMETA_TXIMPORT"
 
     setup {
 

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_process {
     name "Test Process TRIMGALORE"
     script "../main.nf"
     process "TRIMGALORE"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "trimgalore"
 
     test("test_trimgalore_single_end") {
 

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test
@@ -3,13 +3,8 @@ nextflow_process {
     name "Test Process TXIMETA_TXIMPORT"
     script "../main.nf"
     process "TXIMETA_TXIMPORT"
-
-    tag "modules"
-    tag "modules_nfcore"
-    tag "custom/tx2gene"
-    tag "tximeta"
-    tag "tximeta/tximport"
-    tag "untar"
+    tag "UNTAR"
+    tag "CUSTOM_TX2GENE"
 
     test("saccharomyces_cerevisiae - kallisto - gtf") {
 

--- a/modules/nf-core/ucsc/bedclip/tests/main.nf.test
+++ b/modules/nf-core/ucsc/bedclip/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process UCSC_BEDCLIP"
     script "../main.nf"
     process "UCSC_BEDCLIP"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "ucsc"
-    tag "ucsc/bedclip"
 
     test("sarscov2") {
         config "./nextflow.config"

--- a/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test
+++ b/modules/nf-core/ucsc/bedgraphtobigwig/tests/main.nf.test
@@ -3,10 +3,6 @@ nextflow_process {
     name "Test Process UCSC_BEDGRAPHTOBIGWIG"
     script "../main.nf"
     process "UCSC_BEDGRAPHTOBIGWIG"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "ucsc"
-    tag "ucsc/bedgraphtobigwig"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/umitools/dedup/tests/main.nf.test
+++ b/modules/nf-core/umitools/dedup/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "UMITOOLS_DEDUP"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "umitools"
-    tag "umitools/dedup"
-
     test("se - no stats") {
         config "./nextflow.config"
 

--- a/modules/nf-core/umitools/extract/tests/main.nf.test
+++ b/modules/nf-core/umitools/extract/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "UMITOOLS_EXTRACT"
     config "./nextflow.config"
-    tag "modules_nfcore"
-    tag "modules"
-    tag "umitools"
-    tag "umitools/extract"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/umitools/prepareforrsem/tests/main.nf.test
+++ b/modules/nf-core/umitools/prepareforrsem/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "UMITOOLS_PREPAREFORRSEM"
 
-    tag "modules"
-    tag "modules_nfcore"
-    tag "umitools"
-    tag "umitools/prepareforrsem"
-
     test("sarscov2 - bam") {
 
         when {

--- a/modules/nf-core/untar/tests/main.nf.test
+++ b/modules/nf-core/untar/tests/main.nf.test
@@ -3,9 +3,7 @@ nextflow_process {
     name "Test Process UNTAR"
     script "../main.nf"
     process "UNTAR"
-    tag "modules"
-    tag "modules_nfcore"
-    tag "untar"
+
     test("test_untar") {
 
         when {

--- a/subworkflows/local/align_star/tests/main.nf.test
+++ b/subworkflows/local/align_star/tests/main.nf.test
@@ -5,14 +5,10 @@ nextflow_workflow {
     workflow "ALIGN_STAR"
     config "./nextflow.config"
 
-    tag "ALIGN_STAR"
-
-    tag "star/align"
-    tag "star/genomegenerate"
-
-    tag "STAR_ALIGN_IGENOMES"
+    tag "STAR_GENOMEGENERATE"
     tag "STAR_GENOMEGENERATE_IGENOMES"
-
+    tag "STAR_ALIGN"
+    tag "STAR_ALIGN_IGENOMES"
     tag "BAM_SORT_STATS_SAMTOOLS"
 
     test("star - no igenomes") {

--- a/subworkflows/local/prepare_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test
@@ -5,8 +5,6 @@ nextflow_workflow {
     workflow "PREPARE_GENOME"
     config "./nextflow.config"
 
-    tag "PREPARE_GENOME"
-
     tag "BBMAP_BBSPLIT"
     tag "CUSTOM_CATADDITIONALFASTA"
     tag "CUSTOM_GETCHROMSIZES"
@@ -18,7 +16,6 @@ nextflow_workflow {
     tag "HISAT2_EXTRACTSPLICESITES"
     tag "KALLISTO_INDEX"
     tag "PREPROCESS_TRANSCRIPTS_FASTA_GENCODE"
-    tag "RSEM_PREPAREREFERENCE"
     tag "RSEM_PREPAREREFERENCE"
     tag "SALMON_INDEX"
     tag "SORTMERNA"

--- a/subworkflows/local/quantify_pseudo_alignment/tests/main.nf.test
+++ b/subworkflows/local/quantify_pseudo_alignment/tests/main.nf.test
@@ -4,11 +4,13 @@ nextflow_workflow {
     script "../main.nf"
     workflow "QUANTIFY_PSEUDO_ALIGNMENT"
 
-    tag 'SALMON_QUANT'
-    tag 'KALLISTO_QUANT'
-    tag 'CUSTOM_TX2GENE'
-    tag 'TXIMETA_TXIMPORT'
-    tag 'SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT'
+    tag "SALMON_INDEX"
+    tag "SALMON_QUANT"
+    tag "KALLISTO_INDEX"
+    tag "KALLISTO_QUANT"
+    tag "CUSTOM_TX2GENE"
+    tag "TXIMETA_TXIMPORT"
+    tag "SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
 
     test("salmon") {
 

--- a/subworkflows/local/quantify_rsem/tests/main.nf.test
+++ b/subworkflows/local/quantify_rsem/tests/main.nf.test
@@ -5,9 +5,10 @@ nextflow_workflow {
     workflow "QUANTIFY_RSEM"
     config "./nextflow.config"
 
-    tag 'RSEM_CALCULATEEXPRESSION'
-    tag 'RSEM_MERGE_COUNTS'
-    tag 'BAM_SORT_STATS_SAMTOOLS'
+    tag "RSEM_PREPAREREFERENCE"
+    tag "RSEM_CALCULATEEXPRESSION"
+    tag "RSEM_MERGE_COUNTS"
+    tag "BAM_SORT_STATS_SAMTOOLS"
 
     test("homo_sapiens") {
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.function.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.function.nf.test
@@ -2,6 +2,7 @@ nextflow_function {
 
     name "Test Functions"
     script "../main.nf"
+    tag "UTILS_NFCORE_RNASEQ_PIPELINE"
 
     test("Test Function checkSamplesAfterGrouping success") {
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
@@ -3,6 +3,7 @@ nextflow_workflow {
     name "Test Workflow PIPELINE_COMPLETION"
     script "../main.nf"
     workflow "PIPELINE_COMPLETION"
+    tag "UTILS_NFCORE_RNASEQ_PIPELINE"
 
     test("test PIPELINE_COMPLETION successfully completes") {
 

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
@@ -3,19 +3,10 @@ nextflow_workflow {
     name "Test Workflow BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS"
     script "../main.nf"
     workflow "BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/bam_dedup_stats_samtools_umitools"
-    tag "subworkflows/bam_stats_samtools"
-    tag "bam_dedup_stats_samtools_umitools"
-    tag "bam_stats_samtools"
-    tag "samtools"
-    tag "samtools/index"
-    tag "samtools/stats"
-    tag "samtools/idxstats"
-    tag "samtools/flagstat"
-    tag "umitools"
-    tag "umitools/dedup"
+    
+    tag "UMITOOLS_DEDUP"
+    tag "SAMTOOLS_INDEX"
+    tag "BAM_STATS_SAMTOOLS"
 
     test("sarscov2_bam_bai") {
 

--- a/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
@@ -4,19 +4,9 @@ nextflow_workflow {
     script "../main.nf"
     workflow "BAM_MARKDUPLICATES_PICARD"
 
-    tag "picard"
-    tag "picard/markduplicates"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "bam_markduplicates_picard"
-    tag "subworkflows/bam_markduplicates_picard"
-    tag "subworkflows/bam_stats_samtools"
-    tag "bam_stats_samtools"
-    tag "samtools"
-    tag "samtools/flagstat"
-    tag "samtools/idxstats"
-    tag "samtools/index"
-    tag "samtools/stats"
+    tag "PICARD_MARKDUPLICATES"
+    tag "SAMTOOLS_INDEX"
+    tag "BAM_STATS_SAMTOOLS"
 
     test("sarscov2 - bam") {
 

--- a/subworkflows/nf-core/bam_rseqc/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_rseqc/tests/main.nf.test
@@ -3,19 +3,15 @@ nextflow_workflow {
     name "Test Workflow BAM_RSEQC"
     script "../main.nf"
     workflow "BAM_RSEQC"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/bam_rseqc"
-    tag "bam_rseqc"
-    tag "rseqc"
-    tag "rseqc/bamstat"
-    tag "rseqc/inferexperiment"
-    tag "rseqc/innerdistance"
-    tag "rseqc/junctionannotation"
-    tag "rseqc/junctionsaturation"
-    tag "rseqc/readdistribution"
-    tag "rseqc/readduplication"
-    tag "rseqc/tin"
+
+    tag "RSEQC_BAMSTAT"
+    tag "RSEQC_INNERDISTANCE"
+    tag "RSEQC_INFEREXPERIMENT"
+    tag "RSEQC_JUNCTIONANNOTATION"
+    tag "RSEQC_JUNCTIONSATURATION"
+    tag "RSEQC_READDISTRIBUTION"
+    tag "RSEQC_READDUPLICATION"
+    tag "RSEQC_TIN"
 
     test("sarscov2 paired-end [bam]") {
 

--- a/subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
@@ -3,18 +3,10 @@ nextflow_workflow {
     name "Test Workflow BAM_SORT_STATS_SAMTOOLS"
     script "../main.nf"
     workflow "BAM_SORT_STATS_SAMTOOLS"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/bam_sort_stats_samtools"
-    tag "bam_sort_stats_samtools"
-    tag "subworkflows/bam_stats_samtools"
-    tag "bam_stats_samtools"
-    tag "samtools"
-    tag "samtools/index"
-    tag "samtools/sort"
-    tag "samtools/stats"
-    tag "samtools/idxstats"
-    tag "samtools/flagstat"
+    
+    tag "SAMTOOLS_SORT"
+    tag "SAMTOOLS_INDEX"
+    tag "BAM_STATS_SAMTOOLS"
 
     test("test_bam_sort_stats_samtools_single_end") {
 

--- a/subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
@@ -3,14 +3,10 @@ nextflow_workflow {
     name "Test Workflow BAM_STATS_SAMTOOLS"
     script "../main.nf"
     workflow "BAM_STATS_SAMTOOLS"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "bam_stats_samtools"
-    tag "subworkflows/bam_stats_samtools"
-    tag "samtools"
-    tag "samtools/flagstat"
-    tag "samtools/idxstats"
-    tag "samtools/stats"
+
+    tag "SAMTOOLS_STATS"
+    tag "SAMTOOLS_IDXSTATS"
+    tag "SAMTOOLS_FLAGSTAT"
 
     test("test_bam_stats_samtools_single_end") {
 

--- a/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test
+++ b/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test
@@ -4,14 +4,10 @@ nextflow_workflow {
     script "../main.nf"
     workflow "BEDGRAPH_BEDCLIP_BEDGRAPHTOBIGWIG"
     config "./nextflow.config"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/bedgraph_bedclip_bedgraphtobigwig"
-    tag "bedgraph_bedclip_bedgraphtobigwig"
-    tag "ucsc"
-    tag "ucsc/bedclip"
-    tag "ucsc/bedgraphtobigwig"
 
+    tag "UCSC_BEDCLIP"
+    tag "UCSC_BEDGRAPHTOBIGWIG"
+    
     test("sarscov2 [bedgraph] [genome_sizes]") {
 
         when {

--- a/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test
@@ -5,50 +5,40 @@ nextflow_workflow {
     workflow "FASTQ_ALIGN_HISAT2"
     config "./nextflow.config"
 
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/fastq_align_hisat2"
+    tag "HISAT2_EXTRACTSPLICESITES"
+    tag "HISAT2_BUILD"
+    tag "HISAT2_ALIGN"
+    tag "BAM_SORT_STATS_SAMTOOLS"
 
-    tag "hisat2/align"
-    tag "hisat2/build"
-    tag "hisat2/extractsplicesites"
-
-    tag "samtools/flagstat"
-    tag "samtools/idxstats"
-    tag "samtools/index"
-    tag "samtools/sort"
-    tag "samtools/stats"
-    tag "subworkflows/bam_sort_stats_samtools"
-
-        setup {
-            run("HISAT2_EXTRACTSPLICESITES") {
-                script "../../../../modules/nf-core/hisat2/extractsplicesites/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [id: 'test'],
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
-                    ])
-                    """
-                }
-            }
-            run("HISAT2_BUILD") {
-                script "../../../../modules/nf-core/hisat2/build/main.nf"
-                process {
-                    """
-                    input[0] = Channel.of([
-                        [id: 'test'],
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
-                    ])
-                    input[1] = Channel.of([
-                        [id: 'test'],
-                        file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
-                    ])
-                    input[2] = HISAT2_EXTRACTSPLICESITES.out.txt
-                    """
-                }
+    setup {
+        run("HISAT2_EXTRACTSPLICESITES") {
+            script "../../../../modules/nf-core/hisat2/extractsplicesites/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                ])
+                """
             }
         }
+        run("HISAT2_BUILD") {
+            script "../../../../modules/nf-core/hisat2/build/main.nf"
+            process {
+                """
+                input[0] = Channel.of([
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gtf", checkIfExists: true)
+                ])
+                input[2] = HISAT2_EXTRACTSPLICESITES.out.txt
+                """
+            }
+        }
+    }
 
     test("sarscov2 - bam - single_end") {
 

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
@@ -3,14 +3,10 @@ nextflow_workflow {
     name "Test Workflow FASTQ_FASTQC_UMITOOLS_FASTP"
     script "../main.nf"
     workflow "FASTQ_FASTQC_UMITOOLS_FASTP"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/fastq_fastqc_umitools_fastp"
-    tag "fastq_fastqc_umitools_fastp"
-    tag "fastqc"
-    tag "umitools/extract"
-    tag "fastp"
 
+    tag "FASTQC"
+    tag "UMITOOLS_EXTRACT"
+    tag "FASTP"
 
     test("sarscov2 paired-end [fastq]") {
 

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
@@ -5,13 +5,6 @@ nextflow_workflow {
     workflow "FASTQ_FASTQC_UMITOOLS_TRIMGALORE"
     config './nextflow.config'
 
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/fastq_fastqc_umitools_trimgalore"
-    tag "fastqc"
-    tag "umitools/extract"
-    tag "trimgalore"
-
     tag "FASTQC"
     tag "UMITOOLS_EXTRACT"
     tag "TRIMGALORE"

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
@@ -4,13 +4,10 @@ nextflow_workflow {
     script "../main.nf"
     workflow "FASTQ_SUBSAMPLE_FQ_SALMON"
     config "./nextflow.config"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "subworkflows/fastq_subsample_fq_salmon"
-    tag "fastq_subsample_fq_salmon"
-    tag "salmon/index"
-    tag "fq/subsample"
-    tag "salmon/quant"
+
+    tag "SALMON_INDEX"
+    tag "FQ_SUBSAMPLE"
+    tag "SALMON_QUANT"
 
     test("homo_sapiens paired-end [fastq]") {
 

--- a/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.function.nf.test
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.function.nf.test
@@ -4,10 +4,8 @@ nextflow_function {
     name "Test Functions"
     script "subworkflows/nf-core/utils_nextflow_pipeline/main.nf"
     config "subworkflows/nf-core/utils_nextflow_pipeline/tests/nextflow.config"
-    tag 'subworkflows'
-    tag 'utils_nextflow_pipeline'
-    tag 'subworkflows/utils_nextflow_pipeline'
-
+    tag "UTILS_NEXTFLOW_PIPELINE"
+    
     test("Test Function getWorkflowVersion") {
 
         function "getWorkflowVersion"

--- a/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.workflow.nf.test
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.workflow.nf.test
@@ -4,9 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     config "subworkflows/nf-core/utils_nextflow_pipeline/tests/nextflow.config"
     workflow "UTILS_NEXTFLOW_PIPELINE"
-    tag 'subworkflows'
-    tag 'utils_nextflow_pipeline'
-    tag 'subworkflows/utils_nextflow_pipeline'
 
     test("Should run no inputs") {
 

--- a/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
@@ -3,11 +3,8 @@ nextflow_function {
 
     name "Test Functions"
     script "../main.nf"
-    config "subworkflows/nf-core/utils_nfcore_pipeline/tests/nextflow.config"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "utils_nfcore_pipeline"
-    tag "subworkflows/utils_nfcore_pipeline"
+    config "subworkflows/nf-core/utils_nfcore_pipeline/tests/nextflow.config"    
+    tag "UTILS_NFCORE_PIPELINE"
 
     test("Test Function checkConfigProvided") {
 

--- a/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.workflow.nf.test
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.workflow.nf.test
@@ -4,10 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     config "subworkflows/nf-core/utils_nfcore_pipeline/tests/nextflow.config"
     workflow "UTILS_NFCORE_PIPELINE"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "utils_nfcore_pipeline"
-    tag "subworkflows/utils_nfcore_pipeline"
 
     test("Should run without failures") {
 

--- a/subworkflows/nf-core/utils_nfvalidation_plugin/tests/main.nf.test
+++ b/subworkflows/nf-core/utils_nfvalidation_plugin/tests/main.nf.test
@@ -3,12 +3,6 @@ nextflow_workflow {
     name "Test Workflow UTILS_NFVALIDATION_PLUGIN"
     script "../main.nf"
     workflow "UTILS_NFVALIDATION_PLUGIN"
-    tag "subworkflows"
-    tag "subworkflows_nfcore"
-    tag "plugin/nf-validation"
-    tag "'plugin/nf-validation'"
-    tag "utils_nfvalidation_plugin"
-    tag "subworkflows/utils_nfvalidation_plugin"
 
     test("Should run nothing") {
 


### PR DESCRIPTION
This PR cleans up nf-test files to remove excessive tags to mirror what we have done in nf-core/fetchngs v1.12.0. We need to update nf-core/modules and nf-core/tools to deal with this properly but the plan is that we shouldn't see a diff in the pipeline when this functionality has been added natively.