### PR TITLE
Increase contents of default.main.nf.test.snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1266](https://github.com/nf-core/rnaseq/pull/1266) - Delete unecessary tags from nf.test files for modules and subworkflows
 - [PR #1253](https://github.com/nf-core/rnaseq/pull/1253) - Use nf-test files as matrix to test over in CI/CD for efficiency
 - [PR #1278](https://github.com/nf-core/rnaseq/pull/1278) - Delocalise pseudo quant workflow
-- [PR ####](https://github.com/nf-core/rnaseq/pull/####) - Reorganise pipeline level tests into flat directory structure
+- [PR #1280](https://github.com/nf-core/rnaseq/pull/1280) - Reorganise pipeline level tests into flat directory structure
+- [PR #####](https://github.com/nf-core/rnaseq/pull/####) - Add output files to nf-test snapshot
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1253](https://github.com/nf-core/rnaseq/pull/1253) - Use nf-test files as matrix to test over in CI/CD for efficiency
 - [PR #1278](https://github.com/nf-core/rnaseq/pull/1278) - Delocalise pseudo quant workflow
 - [PR #1280](https://github.com/nf-core/rnaseq/pull/1280) - Reorganise pipeline level tests into flat directory structure
-- [PR #####](https://github.com/nf-core/rnaseq/pull/####) - Add output files to nf-test snapshot
+- [PR #1283](https://github.com/nf-core/rnaseq/pull/1283) - Add output files to nf-test snapshot
 
 ### Parameters
 

--- a/tests/default.main.nf.test
+++ b/tests/default.main.nf.test
@@ -26,8 +26,6 @@ nextflow_pipeline {
                         path("${params.outdir}/bbsplit/WT_REP1.stats.txt"),
                         path("${params.outdir}/bbsplit/WT_REP2.stats.txt"),
                         path("${params.outdir}/salmon/salmon.merged.transcript_counts.tsv"),
-                        path("${params.outdir}/salmon/salmon.merged.transcript_lengths.tsv"),
-                        path("${params.outdir}/salmon/salmon.merged.transcript_tpm.tsv"),
                         path("${params.outdir}/custom/out/genome_gfp.fasta"),
                         path("${params.outdir}/custom/out/genome_gfp.gtf"),
                         path("${params.outdir}/star_salmon/bigwig/RAP1_IAA_30M_REP1.forward.bigWig"),
@@ -39,12 +37,7 @@ nextflow_pipeline {
                         path("${params.outdir}/star_salmon/bigwig/WT_REP1.forward.bigWig"),
                         path("${params.outdir}/star_salmon/bigwig/WT_REP1.reverse.bigWig"),
                         path("${params.outdir}/star_salmon/bigwig/WT_REP2.forward.bigWig"),
-                        path("${params.outdir}/star_salmon/bigwig/WT_REP2.reverse.bigWig"),
-                        path("${params.outdir}/star_salmon/RAP1_IAA_30M_REP1.markdup.sorted.bam"),
-                        path("${params.outdir}/star_salmon/RAP1_UNINDUCED_REP1.markdup.sorted.bam"),
-                        path("${params.outdir}/star_salmon/RAP1_UNINDUCED_REP2.markdup.sorted.bam"),
-                        path("${params.outdir}/star_salmon/WT_REP1.markdup.sorted.bam"),
-                        path("${params.outdir}/star_salmon/WT_REP2.markdup.sorted.bam")
+                        path("${params.outdir}/star_salmon/bigwig/WT_REP2.reverse.bigWig")
                     ).match("output_files")
                 }
             )

--- a/tests/default.main.nf.test
+++ b/tests/default.main.nf.test
@@ -20,11 +20,6 @@ nextflow_pipeline {
                 { assert workflow.success },
                 { assert snapshot(UTILS.removeNextflowVersion("$outputDir/pipeline_info/nf_core_rnaseq_software_mqc_versions.yml")).match("software_versions") },
                 { assert snapshot(
-                        path("${params.outdir}/bbsplit/RAP1_IAA_30M_REP1.stats.txt"),
-                        path("${params.outdir}/bbsplit/RAP1_UNINDUCED_REP1.stats.txt"),
-                        path("${params.outdir}/bbsplit/RAP1_UNINDUCED_REP2.stats.txt"),
-                        path("${params.outdir}/bbsplit/WT_REP1.stats.txt"),
-                        path("${params.outdir}/bbsplit/WT_REP2.stats.txt"),
                         path("${params.outdir}/salmon/salmon.merged.transcript_counts.tsv"),
                         path("${params.outdir}/custom/out/genome_gfp.fasta"),
                         path("${params.outdir}/custom/out/genome_gfp.gtf"),

--- a/tests/default.main.nf.test
+++ b/tests/default.main.nf.test
@@ -14,10 +14,39 @@ nextflow_pipeline {
         }
 
         then {
-            assert workflow.success
+
 
             assertAll(
-                { assert snapshot(UTILS.removeNextflowVersion("$outputDir/pipeline_info/nf_core_rnaseq_software_mqc_versions.yml")).match("software_versions") }
+                { assert workflow.success },
+                { assert snapshot(UTILS.removeNextflowVersion("$outputDir/pipeline_info/nf_core_rnaseq_software_mqc_versions.yml")).match("software_versions") },
+                { assert snapshot(
+                        path("${params.outdir}/bbsplit/RAP1_IAA_30M_REP1.stats.txt"),
+                        path("${params.outdir}/bbsplit/RAP1_UNINDUCED_REP1.stats.txt"),
+                        path("${params.outdir}/bbsplit/RAP1_UNINDUCED_REP2.stats.txt"),
+                        path("${params.outdir}/bbsplit/WT_REP1.stats.txt"),
+                        path("${params.outdir}/bbsplit/WT_REP2.stats.txt"),
+                        path("${params.outdir}/salmon/salmon.merged.transcript_counts.tsv"),
+                        path("${params.outdir}/salmon/salmon.merged.transcript_lengths.tsv"),
+                        path("${params.outdir}/salmon/salmon.merged.transcript_tpm.tsv"),
+                        path("${params.outdir}/custom/out/genome_gfp.fasta"),
+                        path("${params.outdir}/custom/out/genome_gfp.gtf"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_IAA_30M_REP1.forward.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_IAA_30M_REP1.reverse.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_UNINDUCED_REP1.forward.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_UNINDUCED_REP1.reverse.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_UNINDUCED_REP2.forward.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/RAP1_UNINDUCED_REP2.reverse.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/WT_REP1.forward.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/WT_REP1.reverse.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/WT_REP2.forward.bigWig"),
+                        path("${params.outdir}/star_salmon/bigwig/WT_REP2.reverse.bigWig"),
+                        path("${params.outdir}/star_salmon/RAP1_IAA_30M_REP1.markdup.sorted.bam"),
+                        path("${params.outdir}/star_salmon/RAP1_UNINDUCED_REP1.markdup.sorted.bam"),
+                        path("${params.outdir}/star_salmon/RAP1_UNINDUCED_REP2.markdup.sorted.bam"),
+                        path("${params.outdir}/star_salmon/WT_REP1.markdup.sorted.bam"),
+                        path("${params.outdir}/star_salmon/WT_REP2.markdup.sorted.bam")
+                    ).match("output_files")
+                }
             )
         }
     }

--- a/tests/default.main.nf.test.snap
+++ b/tests/default.main.nf.test.snap
@@ -1,4 +1,38 @@
 {
+    "output_files": {
+        "content": [
+            "RAP1_IAA_30M_REP1.stats.txt:md5,a87292c6f7166096166a9015c2e63dac",
+            "RAP1_UNINDUCED_REP1.stats.txt:md5,781e49024150a8313779c574b58ad035",
+            "RAP1_UNINDUCED_REP2.stats.txt:md5,e455d0163bf2d988224b0c0092605213",
+            "WT_REP1.stats.txt:md5,6eab6936804c1157d5e1c61c0562d7de",
+            "WT_REP2.stats.txt:md5,002ddf6b828d34979652a40f05462843",
+            "salmon.merged.transcript_counts.tsv:md5,ff0f5be09ca7a322672c0074ba35da17",
+            "salmon.merged.transcript_lengths.tsv:md5,5d8b6275766ddceaf00bc704447f86ba",
+            "salmon.merged.transcript_tpm.tsv:md5,74c9bc32d53219e07b7d4e10e6c007b3",
+            "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
+            "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
+            "RAP1_IAA_30M_REP1.forward.bigWig:md5,0abafd7a9f9035469c003fd3dabd73e8",
+            "RAP1_IAA_30M_REP1.reverse.bigWig:md5,0f1e9ac71fc0b99785f06ecb860ef00e",
+            "RAP1_UNINDUCED_REP1.forward.bigWig:md5,09e8d65e21ac92e9a3b78afe3acdf28b",
+            "RAP1_UNINDUCED_REP1.reverse.bigWig:md5,8b002d23911f95f1c5b9965c2e7d0737",
+            "RAP1_UNINDUCED_REP2.forward.bigWig:md5,eede9cac23d47c4685dc13507e97bfb9",
+            "RAP1_UNINDUCED_REP2.reverse.bigWig:md5,a835e0ac51231016c52de94c18ebd466",
+            "WT_REP1.forward.bigWig:md5,92ad01ddd1dbb7f6d7e2eae23df58c7c",
+            "WT_REP1.reverse.bigWig:md5,dcac37ef5fff108afd0632388919dcf7",
+            "WT_REP2.forward.bigWig:md5,d10cbea27b82745b46077191d3ff2820",
+            "WT_REP2.reverse.bigWig:md5,2b3a15b511efdbc838574200ee2bec0c",
+            "RAP1_IAA_30M_REP1.markdup.sorted.bam:md5,21c43660bc4ad0c6bffa509dc275b336",
+            "RAP1_UNINDUCED_REP1.markdup.sorted.bam:md5,9ff074bb032c507eaab240b2de426721",
+            "RAP1_UNINDUCED_REP2.markdup.sorted.bam:md5,8be419214c011b5c46d36d0fe3160895",
+            "WT_REP1.markdup.sorted.bam:md5,c5b69c0480c4fa14fa54f3e3a7f49b23",
+            "WT_REP2.markdup.sorted.bam:md5,452ccf76f181d11795c54674f1e9e731"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-10T17:00:50.416385567"
+    },
     "software_versions": {
         "content": [
             "{BBMAP_BBSPLIT={bbmap=39.01}, BEDTOOLS_GENOMECOV_FW={bedtools=2.31.1}, CAT_FASTQ={cat=8.3}, CUSTOM_CATADDITIONALFASTA={python=3.9.5}, CUSTOM_GETCHROMSIZES={getchromsizes=1.16.1}, CUSTOM_TX2GENE={python=3.9.5}, DESEQ2_QC_PSEUDO={r-base=4.0.3, bioconductor-deseq2=1.28.0}, DESEQ2_QC_STAR_SALMON={r-base=4.0.3, bioconductor-deseq2=1.28.0}, DUPRADAR={bioconductor-dupradar=1.32.0}, FASTQC={fastqc=0.12.1}, FQ_SUBSAMPLE={fq=0.9.1 (2022-02-22)}, GTF2BED={perl=5.26.2}, GTF_FILTER={python=3.9.5}, GUNZIP_ADDITIONAL_FASTA={gunzip=1.1}, GUNZIP_GTF={gunzip=1.1}, MULTIQC_CUSTOM_BIOTYPE={python=3.9.5}, PICARD_MARKDUPLICATES={picard=3.1.1}, QUALIMAP_RNASEQ={qualimap=2.3}, RSEQC_BAMSTAT={rseqc=5.0.2}, RSEQC_INFEREXPERIMENT={rseqc=5.0.2}, RSEQC_INNERDISTANCE={rseqc=5.0.2}, RSEQC_JUNCTIONANNOTATION={rseqc=5.0.2}, RSEQC_JUNCTIONSATURATION={rseqc=5.0.2}, RSEQC_READDISTRIBUTION={rseqc=5.0.2}, RSEQC_READDUPLICATION={rseqc=5.0.2}, SALMON_QUANT={salmon=1.10.1}, SAMTOOLS_FLAGSTAT={samtools=1.19.2}, SAMTOOLS_IDXSTATS={samtools=1.19.2}, SAMTOOLS_INDEX={samtools=1.19.2}, SAMTOOLS_SORT={samtools=1.19.2}, SAMTOOLS_STATS={samtools=1.19.2}, SE_GENE={bioconductor-summarizedexperiment=1.32.0}, STAR_ALIGN={star=2.7.10a, samtools=1.18, gawk=5.1.0}, STAR_GENOMEGENERATE={star=2.7.10a, samtools=1.18, gawk=5.1.0}, STRINGTIE_STRINGTIE={stringtie=2.2.1}, SUBREAD_FEATURECOUNTS={subread=2.0.1}, TRIMGALORE={trimgalore=0.6.7, cutadapt=3.4}, TXIMETA_TXIMPORT={bioconductor-tximeta=1.20.1}, UCSC_BEDCLIP={ucsc=377}, UCSC_BEDGRAPHTOBIGWIG={ucsc=445}, UNTAR_SALMON_INDEX={untar=1.3}, Workflow={nf-core/rnaseq=v3.15.0dev}}"

--- a/tests/default.main.nf.test.snap
+++ b/tests/default.main.nf.test.snap
@@ -1,11 +1,6 @@
 {
     "output_files": {
         "content": [
-            "RAP1_IAA_30M_REP1.stats.txt:md5,a87292c6f7166096166a9015c2e63dac",
-            "RAP1_UNINDUCED_REP1.stats.txt:md5,781e49024150a8313779c574b58ad035",
-            "RAP1_UNINDUCED_REP2.stats.txt:md5,e455d0163bf2d988224b0c0092605213",
-            "WT_REP1.stats.txt:md5,6eab6936804c1157d5e1c61c0562d7de",
-            "WT_REP2.stats.txt:md5,f6df7d4d9a5b553209f31dec2a30f92b",
             "salmon.merged.transcript_counts.tsv:md5,ff0f5be09ca7a322672c0074ba35da17",
             "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
             "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
@@ -24,7 +19,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-04-11T13:15:25.54128645"
+        "timestamp": "2024-04-11T14:39:58.637279952"
     },
     "software_versions": {
         "content": [

--- a/tests/default.main.nf.test.snap
+++ b/tests/default.main.nf.test.snap
@@ -5,7 +5,7 @@
             "RAP1_UNINDUCED_REP1.stats.txt:md5,781e49024150a8313779c574b58ad035",
             "RAP1_UNINDUCED_REP2.stats.txt:md5,e455d0163bf2d988224b0c0092605213",
             "WT_REP1.stats.txt:md5,6eab6936804c1157d5e1c61c0562d7de",
-            "WT_REP2.stats.txt:md5,002ddf6b828d34979652a40f05462843",
+            "WT_REP2.stats.txt:md5,f6df7d4d9a5b553209f31dec2a30f92b",
             "salmon.merged.transcript_counts.tsv:md5,ff0f5be09ca7a322672c0074ba35da17",
             "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
             "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
@@ -24,7 +24,7 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-04-11T10:33:44.217825304"
+        "timestamp": "2024-04-11T13:15:25.54128645"
     },
     "software_versions": {
         "content": [

--- a/tests/default.main.nf.test.snap
+++ b/tests/default.main.nf.test.snap
@@ -7,8 +7,6 @@
             "WT_REP1.stats.txt:md5,6eab6936804c1157d5e1c61c0562d7de",
             "WT_REP2.stats.txt:md5,002ddf6b828d34979652a40f05462843",
             "salmon.merged.transcript_counts.tsv:md5,ff0f5be09ca7a322672c0074ba35da17",
-            "salmon.merged.transcript_lengths.tsv:md5,5d8b6275766ddceaf00bc704447f86ba",
-            "salmon.merged.transcript_tpm.tsv:md5,74c9bc32d53219e07b7d4e10e6c007b3",
             "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
             "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
             "RAP1_IAA_30M_REP1.forward.bigWig:md5,0abafd7a9f9035469c003fd3dabd73e8",
@@ -20,18 +18,13 @@
             "WT_REP1.forward.bigWig:md5,92ad01ddd1dbb7f6d7e2eae23df58c7c",
             "WT_REP1.reverse.bigWig:md5,dcac37ef5fff108afd0632388919dcf7",
             "WT_REP2.forward.bigWig:md5,d10cbea27b82745b46077191d3ff2820",
-            "WT_REP2.reverse.bigWig:md5,2b3a15b511efdbc838574200ee2bec0c",
-            "RAP1_IAA_30M_REP1.markdup.sorted.bam:md5,21c43660bc4ad0c6bffa509dc275b336",
-            "RAP1_UNINDUCED_REP1.markdup.sorted.bam:md5,9ff074bb032c507eaab240b2de426721",
-            "RAP1_UNINDUCED_REP2.markdup.sorted.bam:md5,8be419214c011b5c46d36d0fe3160895",
-            "WT_REP1.markdup.sorted.bam:md5,c5b69c0480c4fa14fa54f3e3a7f49b23",
-            "WT_REP2.markdup.sorted.bam:md5,452ccf76f181d11795c54674f1e9e731"
+            "WT_REP2.reverse.bigWig:md5,2b3a15b511efdbc838574200ee2bec0c"
         ],
         "meta": {
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-04-10T17:00:50.416385567"
+        "timestamp": "2024-04-11T10:33:44.217825304"
     },
     "software_versions": {
         "content": [


### PR DESCRIPTION
Changes:
 - Adds output files to nf-test snapshot
 - Used files that are important for downstream analysis to ensure that the snapshot is useful for testing
 - Should help stability of pipeline

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test tests/ --verbose --profile +docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
