### PR TITLE
Reinstate oncomplete error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1302](https://github.com/nf-core/rnaseq/pull/1302) - Add missing files from Tximport processing
 - [PR #1304](https://github.com/nf-core/rnaseq/pull/1304) - Remove redundant gene TPM outputs
 - [PR #1317](https://github.com/nf-core/rnaseq/pull/1317) - Strip problematic ifEmpty()
+- [PR #1319](https://github.com/nf-core/rnaseq/pull/1319) - Reinstate oncomplete error messages
 
 ### Parameters
 

--- a/main.nf
+++ b/main.nf
@@ -124,6 +124,9 @@ workflow NFCORE_RNASEQ {
     ch_versions = ch_versions.mix(RNASEQ.out.versions)
 
     emit:
+    trim_status    = RNASEQ.out.trim_status    // channel: [id, boolean]
+    map_status     = RNASEQ.out.map_status     // channel: [id, boolean]
+    strand_status  = RNASEQ.out.strand_status  // channel: [id, boolean]
     multiqc_report = RNASEQ.out.multiqc_report // channel: /path/to/multiqc_report.html
     versions       = ch_versions               // channel: [version1, version2, ...]
 }
@@ -167,7 +170,10 @@ workflow {
         params.outdir,
         params.monochrome_logs,
         params.hook_url,
-        NFCORE_RNASEQ.out.multiqc_report
+        NFCORE_RNASEQ.out.multiqc_report,
+        NFCORE_RNASEQ.out.trim_status,
+        NFCORE_RNASEQ.out.map_status,
+        NFCORE_RNASEQ.out.strand_status
     )
 }
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -14,7 +14,6 @@ include { UTILS_NFVALIDATION_PLUGIN } from '../../nf-core/utils_nfvalidation_plu
 include { paramsSummaryMap          } from 'plugin/nf-validation'
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline'
 include { completionEmail           } from '../../nf-core/utils_nfcore_pipeline'
-include { completionSummary         } from '../../nf-core/utils_nfcore_pipeline'
 include { dashedLine                } from '../../nf-core/utils_nfcore_pipeline'
 include { nfCoreLogo                } from '../../nf-core/utils_nfcore_pipeline'
 include { imNotification            } from '../../nf-core/utils_nfcore_pipeline'

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -611,7 +611,7 @@ def rnaseqSummary(monochrome_logs=true, pass_mapped_reads=[:], pass_trimmed_read
             color = colors.yellow
             status += ['with errored process(es)']
         }
-        if (fail_mapped_count > 0 || fail_trimmed_count > 0 || fail_strand_count > 0) {
+        if (fail_mapped_count > 0 || fail_trimmed_count > 0) {
             color = colors.yellow
             status += ['with skipped sampl(es)']
         }

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
@@ -18,6 +18,9 @@ nextflow_workflow {
                 input[5] = true // monochrome_logs (boolean)
                 input[6] = null // hook_url (string)
                 input[7] = "${outputDir}/multiqc_report.html" // multiqc_report (string)
+                input[8] = Channel.of(['test_sample', true])
+                input[9] = Channel.of(['test_sample', true])
+                input[10] = Channel.of(['test_sample', true])
                 """
             }
         }

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -742,7 +742,7 @@ workflow RNASEQ {
                     meta, strand_log ->
                         def inferred_strand = getInferexperimentStrandedness(strand_log, 30)
                         return [ meta, inferred_strand ]
-                 }
+                }
 
             // Save status for workflow summary
             ch_strand_status = ch_inferexperiment_strand


### PR DESCRIPTION
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

rnaseq has lost its workflow completion error messages, which I quite liked, due to a change in architecture. This PR puts those checks back in a manner consistent with that new structure.

This restoration also includes a fix to reflect the fact that samples are not actually skipped with strandedness failures.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
