### PR TITLE
Remove tags from all nf-test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1324](https://github.com/nf-core/rnaseq/pull/1324) - Fix tags entries and rename pipeline level tests
 - [PR #1325](https://github.com/nf-core/rnaseq/pull/1325) - Minor fixes to strandedness settings and messaging
 - [PR #1326](https://github.com/nf-core/rnaseq/pull/1326) - Move Conda dependencies for local modules to individual environment file
+- [PR #1329](https://github.com/nf-core/rnaseq/pull/1329) - Remove tags from all nf-test files
 
 ### Parameters
 

--- a/modules/local/star_align_igenomes/tests/main.nf.test
+++ b/modules/local/star_align_igenomes/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process STAR_ALIGN_IGENOMES"
     script "../main.nf"
     process "STAR_ALIGN_IGENOMES"
-    tag "STAR_GENOMEGENERATE_IGENOMES"
 
     setup {
         run("STAR_GENOMEGENERATE_IGENOMES") {

--- a/modules/nf-core/custom/tx2gene/tests/main.nf.test
+++ b/modules/nf-core/custom/tx2gene/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process CUSTOM_TX2GENE"
     script "../main.nf"
     process "CUSTOM_TX2GENE"
-    tag "UNTAR"
 
     setup {
 

--- a/modules/nf-core/hisat2/align/tests/main.nf.test
+++ b/modules/nf-core/hisat2/align/tests/main.nf.test
@@ -3,8 +3,6 @@ nextflow_process {
     name "Test Process HISAT2_ALIGN"
     script "../main.nf"
     process "HISAT2_ALIGN"
-    tag "HISAT2_BUILD"
-    tag "HISAT2_EXTRACTSPLICESITES"
 
     test("Single-End") {
 

--- a/modules/nf-core/hisat2/build/tests/main.nf.test
+++ b/modules/nf-core/hisat2/build/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process HISAT2_BUILD"
     script "../main.nf"
     process "HISAT2_BUILD"
-    tag "HISAT2_EXTRACTSPLICESITES"
 
     test("Should run without failures") {
 

--- a/modules/nf-core/kallisto/quant/tests/main.nf.test
+++ b/modules/nf-core/kallisto/quant/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process KALLISTO_QUANT"
     script "../main.nf"
     process "KALLISTO_QUANT"
-    tag "KALLISTO_INDEX"
 
     setup {
             run("KALLISTO_INDEX") {

--- a/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
+++ b/modules/nf-core/rsem/calculateexpression/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process RSEM_CALCULATEEXPRESSION"
     script "../main.nf"
     process "RSEM_CALCULATEEXPRESSION"
-    tag "RSEM_PREPAREREFERENCE"
     config "./nextflow.config"
     
     test("homo_sapiens") {

--- a/modules/nf-core/salmon/quant/tests/main.nf.test
+++ b/modules/nf-core/salmon/quant/tests/main.nf.test
@@ -4,7 +4,6 @@ nextflow_process {
     script "../main.nf"
     process "SALMON_QUANT"
     config "./nextflow.config"
-    tag "SALMON_INDEX"
  
     setup {
         run("SALMON_INDEX") {

--- a/modules/nf-core/star/align/tests/main.nf.test
+++ b/modules/nf-core/star/align/tests/main.nf.test
@@ -3,7 +3,6 @@ nextflow_process {
     name "Test Process STAR_ALIGN"
     script "../main.nf"
     process "STAR_ALIGN"
-    tag "STAR_GENOMEGENERATE"
 
     setup {
         run("STAR_GENOMEGENERATE") {

--- a/modules/nf-core/summarizedexperiment/summarizedexperiment/tests/main.nf.test
+++ b/modules/nf-core/summarizedexperiment/summarizedexperiment/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_process {
     name "Test Process SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
     script "../main.nf"
     process "SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
-    tag "UNTAR"
-    tag "CUSTOM_TX2GENE"
-    tag "TXIMETA_TXIMPORT"
 
     setup {
 

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test
@@ -3,8 +3,6 @@ nextflow_process {
     name "Test Process TXIMETA_TXIMPORT"
     script "../main.nf"
     process "TXIMETA_TXIMPORT"
-    tag "UNTAR"
-    tag "CUSTOM_TX2GENE"
 
     test("saccharomyces_cerevisiae - kallisto - gtf") {
 

--- a/subworkflows/local/align_star/tests/main.nf.test
+++ b/subworkflows/local/align_star/tests/main.nf.test
@@ -4,11 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "ALIGN_STAR"
     config "./nextflow.config"
-    tag "STAR_GENOMEGENERATE"
-    tag "STAR_GENOMEGENERATE_IGENOMES"
-    tag "STAR_ALIGN"
-    tag "STAR_ALIGN_IGENOMES"
-    tag "BAM_SORT_STATS_SAMTOOLS"
 
     test("star - no igenomes") {
 

--- a/subworkflows/local/prepare_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test
@@ -4,23 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "PREPARE_GENOME"
     config "./nextflow.config"
-    tag "BBMAP_BBSPLIT"
-    tag "CUSTOM_CATADDITIONALFASTA"
-    tag "CUSTOM_GETCHROMSIZES"
-    tag "GFFREAD"
-    tag "GTF2BED"
-    tag "GTF_FILTER"
-    tag "GUNZIP"
-    tag "HISAT2_BUILD"
-    tag "HISAT2_EXTRACTSPLICESITES"
-    tag "KALLISTO_INDEX"
-    tag "PREPROCESS_TRANSCRIPTS_FASTA_GENCODE"
-    tag "RSEM_PREPAREREFERENCE"
-    tag "SALMON_INDEX"
-    tag "SORTMERNA"
-    tag "STAR_GENOMEGENERATE"
-    tag "STAR_GENOMEGENERATE_IGENOMES"
-    tag "UNTAR"
 
     test("default options") {
 

--- a/subworkflows/local/quantify_rsem/tests/main.nf.test
+++ b/subworkflows/local/quantify_rsem/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "QUANTIFY_RSEM"
     config "./nextflow.config"
-    tag "RSEM_PREPAREREFERENCE"
-    tag "RSEM_CALCULATEEXPRESSION"
-    tag "RSEM_MERGE_COUNTS"
-    tag "BAM_SORT_STATS_SAMTOOLS"
 
     test("homo_sapiens") {
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.function.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.function.nf.test
@@ -2,7 +2,6 @@ nextflow_function {
 
     name "Test Functions"
     script "../main.nf"
-    tag "UTILS_NFCORE_RNASEQ_PIPELINE"
 
     test("Test Function checkSamplesAfterGrouping success") {
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
@@ -3,7 +3,6 @@ nextflow_workflow {
     name "Test Workflow PIPELINE_COMPLETION"
     script "../main.nf"
     workflow "PIPELINE_COMPLETION"
-    tag "UTILS_NFCORE_RNASEQ_PIPELINE"
 
     test("test PIPELINE_COMPLETION successfully completes") {
 

--- a/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_dedup_stats_samtools_umitools/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_workflow {
     name "Test Workflow BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS"
     script "../main.nf"
     workflow "BAM_DEDUP_STATS_SAMTOOLS_UMITOOLS"
-    tag "UMITOOLS_DEDUP"
-    tag "SAMTOOLS_INDEX"
-    tag "BAM_STATS_SAMTOOLS"
 
     test("sarscov2_bam_bai") {
 

--- a/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_markduplicates_picard/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_workflow {
     name "Test Workflow BAM_MARKDUPLICATES_PICARD"
     script "../main.nf"
     workflow "BAM_MARKDUPLICATES_PICARD"
-    tag "PICARD_MARKDUPLICATES"
-    tag "SAMTOOLS_INDEX"
-    tag "BAM_STATS_SAMTOOLS"
 
     test("sarscov2 - bam") {
 

--- a/subworkflows/nf-core/bam_rseqc/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_rseqc/tests/main.nf.test
@@ -3,14 +3,6 @@ nextflow_workflow {
     name "Test Workflow BAM_RSEQC"
     script "../main.nf"
     workflow "BAM_RSEQC"
-    tag "RSEQC_BAMSTAT"
-    tag "RSEQC_INNERDISTANCE"
-    tag "RSEQC_INFEREXPERIMENT"
-    tag "RSEQC_JUNCTIONANNOTATION"
-    tag "RSEQC_JUNCTIONSATURATION"
-    tag "RSEQC_READDISTRIBUTION"
-    tag "RSEQC_READDUPLICATION"
-    tag "RSEQC_TIN"
 
     test("sarscov2 paired-end [bam]") {
 

--- a/subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_sort_stats_samtools/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_workflow {
     name "Test Workflow BAM_SORT_STATS_SAMTOOLS"
     script "../main.nf"
     workflow "BAM_SORT_STATS_SAMTOOLS"
-    tag "SAMTOOLS_SORT"
-    tag "SAMTOOLS_INDEX"
-    tag "BAM_STATS_SAMTOOLS"
 
     test("test_bam_sort_stats_samtools_single_end") {
 

--- a/subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
+++ b/subworkflows/nf-core/bam_stats_samtools/tests/main.nf.test
@@ -3,9 +3,6 @@ nextflow_workflow {
     name "Test Workflow BAM_STATS_SAMTOOLS"
     script "../main.nf"
     workflow "BAM_STATS_SAMTOOLS"
-    tag "SAMTOOLS_STATS"
-    tag "SAMTOOLS_IDXSTATS"
-    tag "SAMTOOLS_FLAGSTAT"
 
     test("test_bam_stats_samtools_single_end") {
 

--- a/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test
+++ b/subworkflows/nf-core/bedgraph_bedclip_bedgraphtobigwig/tests/main.nf.test
@@ -4,8 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "BEDGRAPH_BEDCLIP_BEDGRAPHTOBIGWIG"
     config "./nextflow.config"
-    tag "UCSC_BEDCLIP"
-    tag "UCSC_BEDGRAPHTOBIGWIG"
     
     test("sarscov2 [bedgraph] [genome_sizes]") {
 

--- a/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_align_hisat2/tests/main.nf.test
@@ -4,10 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "FASTQ_ALIGN_HISAT2"
     config "./nextflow.config"
-    tag "HISAT2_EXTRACTSPLICESITES"
-    tag "HISAT2_BUILD"
-    tag "HISAT2_ALIGN"
-    tag "BAM_SORT_STATS_SAMTOOLS"
 
     setup {
         run("HISAT2_EXTRACTSPLICESITES") {

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/tests/main.nf.test
@@ -4,9 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "FASTQ_FASTQC_UMITOOLS_FASTP"
     config './nextflow.config'
-    tag "FASTQC"
-    tag "UMITOOLS_EXTRACT"
-    tag "FASTP"
 
     test("sarscov2 paired-end [fastq]") {
 

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
@@ -4,9 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "FASTQ_FASTQC_UMITOOLS_TRIMGALORE"
     config './nextflow.config'
-    tag "FASTQC"
-    tag "UMITOOLS_EXTRACT"
-    tag "TRIMGALORE"
 
     test("test single end read with UMI") {
 

--- a/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_subsample_fq_salmon/tests/main.nf.test
@@ -4,9 +4,6 @@ nextflow_workflow {
     script "../main.nf"
     workflow "FASTQ_SUBSAMPLE_FQ_SALMON"
     config "./nextflow.config"
-    tag "SALMON_INDEX"
-    tag "FQ_SUBSAMPLE"
-    tag "SALMON_QUANT"
 
     test("homo_sapiens paired-end [fastq]") {
 

--- a/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test
+++ b/subworkflows/nf-core/quantify_pseudo_alignment/tests/main.nf.test
@@ -3,13 +3,6 @@ nextflow_workflow {
     name "Test Workflow QUANTIFY_PSEUDO_ALIGNMENT"
     script "../main.nf"
     workflow "QUANTIFY_PSEUDO_ALIGNMENT"
-    tag "SALMON_INDEX"
-    tag "KALLISTO_INDEX"
-    tag "SALMON_QUANT"
-    tag "KALLISTO_QUANT"
-    tag "CUSTOM_TX2GENE"
-    tag "TXIMETA_TXIMPORT"
-    tag "SUMMARIZEDEXPERIMENT_SUMMARIZEDEXPERIMENT"
 
     test("salmon") {
 

--- a/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.function.nf.test
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/tests/main.function.nf.test
@@ -4,7 +4,6 @@ nextflow_function {
     name "Test Functions"
     script "subworkflows/nf-core/utils_nextflow_pipeline/main.nf"
     config "subworkflows/nf-core/utils_nextflow_pipeline/tests/nextflow.config"
-    tag "UTILS_NEXTFLOW_PIPELINE"
     
     test("Test Function getWorkflowVersion") {
 

--- a/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/tests/main.function.nf.test
@@ -3,8 +3,7 @@ nextflow_function {
 
     name "Test Functions"
     script "../main.nf"
-    config "subworkflows/nf-core/utils_nfcore_pipeline/tests/nextflow.config"    
-    tag "UTILS_NFCORE_PIPELINE"
+    config "subworkflows/nf-core/utils_nfcore_pipeline/tests/nextflow.config"
 
     test("Test Function checkConfigProvided") {
 

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline with default settings"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: default") {
 

--- a/tests/featurecounts_group_type.nf.test
+++ b/tests/featurecounts_group_type.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline without a group type for featureCounts"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --featurecounts_group_type false") {
 

--- a/tests/kallisto.nf.test
+++ b/tests/kallisto.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline with Kallisto, skipping both QC and alignment"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --pseudo_aligner kallisto --skip_qc --skip_alignment") {
 

--- a/tests/min_mapped_reads.nf.test
+++ b/tests/min_mapped_reads.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline with a minimum mapped read threshold of 90"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --min_mapped_reads 90") {
 

--- a/tests/remove_ribo_rna.nf.test
+++ b/tests/remove_ribo_rna.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline with ribosomal RNA removal"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --remove_ribo_rna") {
 

--- a/tests/salmon.nf.test
+++ b/tests/salmon.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline with Salmon, skipping both QC and alignment"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --pseudo_aligner salmon --skip_qc --skip_alignment") {
 

--- a/tests/skip_qc.nf.test
+++ b/tests/skip_qc.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline by skipping QC options"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --skip_qc") {
 

--- a/tests/skip_trimming.nf.test
+++ b/tests/skip_trimming.nf.test
@@ -2,8 +2,6 @@ nextflow_pipeline {
 
     name "Test pipeline by skipping trimming options"
     script "../main.nf"
-    tag "RNASEQ"
-    tag "PIPELINE"
 
     test("Params: --skip_trimming") {
 


### PR DESCRIPTION
Based on @adamrtalbot comment here https://github.com/nf-core/rnaseq/pull/1324#discussion_r1647368614 we no longer need to explicitly use the `tag` entry within `*.nf.test` files to track the dependency tree between modules/subworkflows/workflows. The nf-test CI within rnaseq checks for dependencies based on files (see [adamrtalbot/detect-nf-test-changes](https://github.com/adamrtalbot/detect-nf-test-changes)) rather than tags. 

nf-test will add native functionality to check for changes in the next release via https://github.com/askimed/nf-test/pull/216. At this point we should be able to migrate to using this for both CI and local testing.