### PR TITLE
Correct conditional for salmon indexing in preprocessing workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Special thanks to the following for their contributions to the release:
 
 - [Adam Talbot](https://github.com/adamrtalbot)
+- [David Carlson](https://github.com/davidecarlson)
 - [Edmund Miller](https://github.com/edmundmiller)
 - [Jonathan Manning](https://github.com/pinin4fjords)
 - [Laramie Lindsey](https://github.com/laramiellindsey)
@@ -107,6 +108,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 - [PR #1342](https://github.com/nf-core/rnaseq/pull/1342) - Factor out preprocessing
 - [PR #1345](https://github.com/nf-core/rnaseq/pull/1345) - Fix preprocessing call
 - [PR #1350](https://github.com/nf-core/rnaseq/pull/1350) - Reduce resource usage for sort process in bedtools/genomecov
+- [PR #1353](https://github.com/nf-core/rnaseq/pull/1353) - Correct conditional for salmon indexing in preprocessing workflow
 
 ### Parameters
 

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -126,6 +126,10 @@ workflow RNASEQ {
     // Run RNA-seq FASTQ preprocessing subworkflow
     //
 
+    // The subworkflow only has to do Salmon indexing if it discovers 'auto'
+    // samples, and if we haven't already made one elsewhere
+    salmon_index_available = params.salmon_index || (!params.skip_pseudo_alignment && params.pseudo_aligner == 'salmon')
+
     FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS (
         ch_fastq,
         ch_fasta,
@@ -139,7 +143,7 @@ workflow RNASEQ {
         params.skip_fastqc || params.skip_qc,
         params.skip_trimming,
         params.skip_umi_extract,
-        !params.salmon_index && params.pseudo_aligner == 'salmon' && !params.skip_pseudo_alignment,
+        !salmon_index_available,
         !params.sortmerna_index && params.remove_ribo_rna,
         params.trimmer,
         params.min_trimmed_reads,


### PR DESCRIPTION
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

As reported by @davidecarlson. In certain circumstances the workflow would complete prior to running Salmon for strandedness detection in preprocessing. I figured out that this was due to an emtpy ch_index channel for Salmon in that subworkflow, and it was empty due to errors in conditional logic at the workflow level

Specifically this occurred when:

1. An 'auto' was set in the sample sheet, necessitating a Salmon run and consequently a Salmon index
2. A Salmon index hadn't otherwise been created (e.g. where pseudo-aligner had been set to 'Salmon'). 

The fix is to correct the conditional logic such that ad-hoc index is requested correctly.

The subworkflow can't condition its structure on the possibility of an empty index channel, since that is not known until run time- hence the need for this explicit boolean based on input parameters.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
