### PR TITLE
patch bedtools/genomecov to use quay.io to solve issue with nf-core download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1386](https://github.com/nf-core/rnaseq/pull/1386) - Bump pipeline version to 3.16.0dev
 - [PR #1388](https://github.com/nf-core/rnaseq/pull/1388) - Adding Kraken2/Bracken on unaligned reads as an additional quality control step to detect sample contamination
 - [PR #1389](https://github.com/nf-core/rnaseq/pull/1389) - Update animated subway map
+- [PR #1393](https://github.com/nf-core/rnaseq/pull/1393) - Use quay.io for bedtools/genomecov to solve issue with nf-core download
 
 ### Parameters
 

--- a/modules.json
+++ b/modules.json
@@ -13,7 +13,8 @@
                     "bedtools/genomecov": {
                         "branch": "master",
                         "git_sha": "06c8865e36741e05ad32ef70ab3fac127486af48",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff"
                     },
                     "bracken/bracken": {
                         "branch": "master",

--- a/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
+++ b/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
@@ -2,14 +2,14 @@ Changes in module 'nf-core/bedtools/genomecov'
 Changes in 'bedtools/genomecov/main.nf':
 --- modules/nf-core/bedtools/genomecov/main.nf
 +++ modules/nf-core/bedtools/genomecov/main.nf
-@@ -3,9 +3,7 @@
-     label 'process_single'
+@@ -4,8 +4,8 @@
  
      conda "${moduleDir}/environment.yml"
--    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
 -        'oras://community.wave.seqera.io/library/bedtools_coreutils:ba273c06a3909a15':
 -        'community.wave.seqera.io/library/bedtools_coreutils:a623c13f66d5262b' }"
-+    container 'nf-core/bedtools_coreutils:a623c13f66d5262b'
++        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21':
++        'nf-core/bedtools_coreutils:a623c13f66d5262b' }"
  
      input:
      tuple val(meta), path(intervals), val(scale)

--- a/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
+++ b/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
@@ -1,0 +1,37 @@
+Changes in module 'nf-core/bedtools/genomecov'
+Changes in 'bedtools/genomecov/main.nf':
+--- modules/nf-core/bedtools/genomecov/main.nf
++++ modules/nf-core/bedtools/genomecov/main.nf
+@@ -3,9 +3,7 @@
+     label 'process_single'
+ 
+     conda "${moduleDir}/environment.yml"
+-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'oras://community.wave.seqera.io/library/bedtools_coreutils:ba273c06a3909a15':
+-        'community.wave.seqera.io/library/bedtools_coreutils:a623c13f66d5262b' }"
++    container 'nf-core/bedtools_coreutils:a623c13f66d5262b'
+ 
+     input:
+     tuple val(meta), path(intervals), val(scale)
+
+'modules/nf-core/bedtools/genomecov/meta.yml' is unchanged
+'modules/nf-core/bedtools/genomecov/environment.yml' is unchanged
+'modules/nf-core/bedtools/genomecov/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/bedtools/genomecov/tests/nextflow.config' is unchanged
+Changes in 'bedtools/genomecov/tests/main.nf.test':
+--- modules/nf-core/bedtools/genomecov/tests/main.nf.test
++++ modules/nf-core/bedtools/genomecov/tests/main.nf.test
+@@ -3,11 +3,6 @@
+     script "../main.nf"
+     process "BEDTOOLS_GENOMECOV"
+     config "./nextflow.config"
+-
+-    tag "modules"
+-    tag "modules_nfcore"
+-    tag "bedtools"
+-    tag "bedtools/genomecov"
+ 
+     test("sarscov2 - no scale") {
+         when {
+
+************************************************************

--- a/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
+++ b/modules/nf-core/bedtools/genomecov/bedtools-genomecov.diff
@@ -8,7 +8,7 @@ Changes in 'bedtools/genomecov/main.nf':
      container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
 -        'oras://community.wave.seqera.io/library/bedtools_coreutils:ba273c06a3909a15':
 -        'community.wave.seqera.io/library/bedtools_coreutils:a623c13f66d5262b' }"
-+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21':
++        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21/data':
 +        'nf-core/bedtools_coreutils:a623c13f66d5262b' }"
  
      input:

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -3,9 +3,7 @@ process BEDTOOLS_GENOMECOV {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'oras://community.wave.seqera.io/library/bedtools_coreutils:ba273c06a3909a15':
-        'community.wave.seqera.io/library/bedtools_coreutils:a623c13f66d5262b' }"
+    container 'nf-core/bedtools_coreutils:a623c13f66d5262b'
 
     input:
     tuple val(meta), path(intervals), val(scale)

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -3,7 +3,9 @@ process BEDTOOLS_GENOMECOV {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container 'nf-core/bedtools_coreutils:a623c13f66d5262b'
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21':
+        'nf-core/bedtools_coreutils:a623c13f66d5262b' }"
 
     input:
     tuple val(meta), path(intervals), val(scale)

--- a/modules/nf-core/bedtools/genomecov/main.nf
+++ b/modules/nf-core/bedtools/genomecov/main.nf
@@ -4,7 +4,7 @@ process BEDTOOLS_GENOMECOV {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21':
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/63/6397750e9730a3fbcc5b4c43f14bd141c64c723fd7dad80e47921a68a7c3cd21/data':
         'nf-core/bedtools_coreutils:a623c13f66d5262b' }"
 
     input:


### PR DESCRIPTION
- Use quay.io for bedtools/genomecov to solve issue with nf-core download
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
