### PR TITLE
FIX: Disable pipeline level conda tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,28 @@ jobs:
             profile: "conda"
           - isMaster: false
             profile: "singularity"
+          - profile: "conda"
+            nf_test_files: default.nf.test
+          - profile: "conda"
+            nf_test_files: featurecounts_group_type.nf.test
+          - profile: "conda"
+            nf_test_files: hisat2.nf.test
+          - profile: "conda"
+            nf_test_files: kallisto.nf.test
+          - profile: "conda"
+            nf_test_files: min_mapped_reads.nf.test
+          - profile: "conda"
+            nf_test_files: nextflow.config
+          - profile: "conda"
+            nf_test_files: remove_ribo_rna.nf.test
+          - profile: "conda"
+            nf_test_files: salmon.nf.test
+          - profile: "conda"
+            nf_test_files: skip_qc.nf.test
+          - profile: "conda"
+            nf_test_files: skip_trimming.nf.test
+          - profile: "conda"
+            nf_test_files: star_rsem.nf.test
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ Special thanks to the following for their contributions to the release:
 - [PR #1401](https://github.com/nf-core/rnaseq/pull/1401) - Template update for nf-core/tools v3.0.1
 - [PR #1405](https://github.com/nf-core/rnaseq/pull/1405) - Fix bad variable name in subworkflow
 - [PR #1406](https://github.com/nf-core/rnaseq/pull/1406) - Keep only one samplesheetToList
+- [PR #1409](https://github.com/nf-core/rnaseq/pull/1409) - Fix manifest DOI text
 - [PR #1410](https://github.com/nf-core/rnaseq/pull/1410) - Fix issues caused by empty versions from trimming subworkflows
 - [PR #1412](https://github.com/nf-core/rnaseq/pull/1412) - Reset versions back to 3.16.1 for patch release
+- [PR #1414](https://github.com/nf-core/rnaseq/pull/1414) - Disable pipeline level conda tests
 
 ### Parameters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1409](https://github.com/nf-core/rnaseq/pull/1409) - Fix manifest DOI text
 - [PR #1410](https://github.com/nf-core/rnaseq/pull/1410) - Fix issues caused by empty versions from trimming subworkflows
 - [PR #1412](https://github.com/nf-core/rnaseq/pull/1412) - Reset versions back to 3.16.1 for patch release
-- [PR #1414](https://github.com/nf-core/rnaseq/pull/1414) - Disable pipeline level conda tests
+- [PR #1415](https://github.com/nf-core/rnaseq/pull/1415) - Disable pipeline level conda tests
 
 ### Parameters
 


### PR DESCRIPTION
Done to resolve CI errors like:

```
    > Caused by:
    >   java.nio.channels.OverlappingFileLockException
```

caused by un-named Conda envs? @maxulysse maybe you can just clarify here for our future selves?