### PR TITLE
Remove reference to unused "skip_sample_count" value in email templates

### DIFF
--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -34,25 +34,6 @@
         <p>The full error message was:</p>
         <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0">${errorReport}</pre>
       </div>
-      """ } else if(skip_sample_count > 0) { out << """
-      <div
-        style="
-          color: #856404;
-          background-color: #fff3cd;
-          border-color: #ffeeba;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        <h4 style="margin-top: 0; color: inherit">nf-core/rnaseq execution completed with warnings!</h4>
-        <p>
-          The pipeline finished successfully, but samples were skipped. Please check warnings at the top of the MultiQC report.
-        </p>
-        <p></p>
-      </div>
-
       """ } else { out << """
       <div
         style="

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -17,13 +17,6 @@ The full error message was:
 
 ${errorReport}
 """
-} else if (skip_sample_count > 0) {
-    out << """##################################################
-## nf-core/rnaseq execution completed with warnings ##
-##################################################
-The pipeline finished successfully, but samples were skipped.
-Please check warnings at the top of the MultiQC report.
-"""
 } else {
     out << "## nf-core/rnaseq execution completed successfully! ##"
 }


### PR DESCRIPTION
The email templates attempt to resolve a variable `skip_sample_count` but this variable is never created or referenced anywhere else in the workflow.

