### PR TITLE
Oncomplete fix

### DIFF
--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -34,25 +34,6 @@
         <p>The full error message was:</p>
         <pre style="white-space: pre-wrap; overflow: visible; margin-bottom: 0">${errorReport}</pre>
       </div>
-      """ } else if(skip_sample_count > 0) { out << """
-      <div
-        style="
-          color: #856404;
-          background-color: #fff3cd;
-          border-color: #ffeeba;
-          padding: 15px;
-          margin-bottom: 20px;
-          border: 1px solid transparent;
-          border-radius: 4px;
-        "
-      >
-        <h4 style="margin-top: 0; color: inherit">nf-core/rnaseq execution completed with warnings!</h4>
-        <p>
-          The pipeline finished successfully, but samples were skipped. Please check warnings at the top of the MultiQC report.
-        </p>
-        <p></p>
-      </div>
-
       """ } else { out << """
       <div
         style="

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -17,13 +17,6 @@ The full error message was:
 
 ${errorReport}
 """
-} else if (skip_sample_count > 0) {
-    out << """##################################################
-## nf-core/rnaseq execution completed with warnings ##
-##################################################
-The pipeline finished successfully, but samples were skipped.
-Please check warnings at the top of the MultiQC report.
-"""
 } else {
     out << "## nf-core/rnaseq execution completed successfully! ##"
 }

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -116,10 +116,16 @@ workflow PIPELINE_COMPLETION {
             id, status -> pass_strand_check[id] = status
         }
 
+    // We need to ensure that the multiqc_report is a value channel (DataflowVariable).
+    // Queue channels will not be available in the workflow.onComplete block.
+    def multiqc_reports = multiqc_report.toList()
+
     //
     // Completion email and summary
     //
     workflow.onComplete {
+        assert multiqc_reports instanceof groovyx.gpars.dataflow.DataflowVariable : "Expected a value channel (DataflowVariable) for multiqc_reports inside workflow.onComplete block."
+
         if (email || email_on_fail) {
             completionEmail(
                 summary_params,
@@ -128,7 +134,7 @@ workflow PIPELINE_COMPLETION {
                 plaintext_email,
                 outdir,
                 monochrome_logs,
-                multiqc_report.toList()
+                multiqc_reports.getVal(),
             )
         }
 

--- a/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -248,32 +248,29 @@ def logColours(monochrome_logs=true) {
 //
 // Attach the multiqc report to email
 //
-def attachMultiqcReport(multiqc_report) {
-    def mqc_report = null
-    try {
-        if (workflow.success) {
-            mqc_report = multiqc_report.getVal()
-            if (mqc_report.getClass() == ArrayList && mqc_report.size() >= 1) {
-                if (mqc_report.size() > 1) {
+def getSingleReport(multiqc_reports) {
+    switch (multiqc_reports) {
+        case Path:
+            return multiqc_reports
+        case List:
+            switch (multiqc_reports.size()) {
+                case 0:
+                    log.warn("[${workflow.manifest.name}] No reports found from process 'MULTIQC'")
+                    return null
+                case 1:
+                    return multiqc_reports.first()
+                default:
                     log.warn("[${workflow.manifest.name}] Found multiple reports from process 'MULTIQC', will use only one")
-                }
-                mqc_report = mqc_report[0]
+                    return multiqc_reports.first()
             }
-        }
+        default:
+            return null
     }
-    catch (Exception all) {
-        if (multiqc_report) {
-            log.warn("[${workflow.manifest.name}] Could not attach MultiQC report to summary email")
-        }
-    }
-    return mqc_report
 }
-
 //
 // Construct and send completion email
 //
-def completionEmail(summary_params, email, email_on_fail, plaintext_email, outdir, monochrome_logs=true, multiqc_report=null) {
-
+def completionEmail(summary_params, email, email_on_fail, plaintext_email, outdir, monochrome_logs=true, multiqc_reports=[]) {
     // Set up the e-mail variables
     def subject = "[${workflow.manifest.name}] Successful: ${workflow.runName}"
     if (!workflow.success) {
@@ -320,7 +317,7 @@ def completionEmail(summary_params, email, email_on_fail, plaintext_email, outdi
     email_fields['summary']      = summary << misc_fields
 
     // On success try attach the multiqc report
-    def mqc_report = attachMultiqcReport(multiqc_report)
+    def mqc_report = getSingleReport(multiqc_reports)
 
     // Check if we are only sending emails on failure
     def email_address = email
@@ -351,7 +348,8 @@ def completionEmail(summary_params, email, email_on_fail, plaintext_email, outdi
     if (email_address) {
         try {
             if (plaintext_email) {
-new org.codehaus.groovy.GroovyException('Send plaintext e-mail, not HTML')            }
+                new org.codehaus.groovy.GroovyException('Send plaintext e-mail, not HTML')            
+            }
             // Try to send HTML e-mail using sendmail
             def sendmail_tf = new File(workflow.launchDir.toString(), ".sendmail_tmp.html")
             sendmail_tf.withWriter { w -> w << sendmail_html }


### PR DESCRIPTION
Note: This PR is not intended to be merged, it just serves as an executable example of the upstream changes in nf-core/tools and nf-core/modules.

The onComplete handler currently calls the toList() operator on a queue channel, but by the time the onComplete handler is called, the channels have all been emptied, and this operator will hang forever.

This fix moves the transformation of the queue channel into a value channel (which is safe to use inside the onComplete block) and also cleans up the `attachMultiqcReport` function.

The _actual_ PRs that need to be merged are:
- https://github.com/nf-core/tools/pull/3304
- https://github.com/nf-core/modules/pull/7129

