### PR TITLE
Fix naming of GFFREAD outputs leading to null.gtf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 3.18.1 - 2024-03-24
+
+### Credits
+
+Special thanks to the following for their contributions to the release:
+
+- [Milos Micik](https://github.com/milos7250)
+
+### Enhancements & fixes
+
+- [PR #1524](https://github.com/nf-core/rnaseq/pull/1524) - Fix naming of GFFREAD outputs (`null.gtf`).
+
 # 3.18.0 - 2024-12-19
 
 ### Credits

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -92,7 +92,8 @@ workflow PREPARE_GENOME {
                 ch_gff      = GUNZIP_GFF ( [ [:], file(gff, checkIfExists: true) ] ).gunzip
                 ch_versions = ch_versions.mix(GUNZIP_GFF.out.versions)
             } else {
-                ch_gff = Channel.value(file(gff, checkIfExists: true)).map { [ [:], it ] }
+                gff_file = file(gff, checkIfExists: true)
+                ch_gff   = Channel.value( gff_file ).map { [ ['id': "${gff_file.baseName}"], it ] }
             }
             ch_gtf      = GFFREAD ( ch_gff, [] ).gtf.map { it[1] }
             ch_versions = ch_versions.mix(GFFREAD.out.versions)


### PR DESCRIPTION
<!--
# nf-core/rnaseq pull request

Many thanks for contributing to nf-core/rnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
-->

Hi all,

after the latest update to GFFREAD, they are using the id variable from the meta argument as the name of the output file. At the moment, the meta variable in this step is empty, therefore the resulting file has name `null.gtf`. This PR resolves this issue by specifying the basename of the input gff file as the id for this process.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/rnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
