### PR TITLE
Fix strict syntax errors

### DIFF
--- a/modules/local/star_align_igenomes/main.nf
+++ b/modules/local/star_align_igenomes/main.nf
@@ -36,7 +36,8 @@ process STAR_ALIGN_IGENOMES {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def reads1 = [], reads2 = []
+    def reads1 = []
+    def reads2 = []
     meta.single_end ? [reads].flatten().each{reads1 << it} : reads.eachWithIndex{ v, ix -> ( ix & 1 ? reads2 : reads1) << v }
     def ignore_gtf      = star_ignore_sjdbgtf ? '' : "--sjdbGTFfile $gtf"
     def seq_platform    = seq_platform ? "'PL:$seq_platform'" : ""

--- a/modules/nf-core/hisat2/build/main.nf
+++ b/modules/nf-core/hisat2/build/main.nf
@@ -33,7 +33,7 @@ process HISAT2_BUILD {
     def ss = ''
     def exon = ''
     def extract_exons = ''
-    def hisat2_build_memory = params.hisat2_build_memory ? (params.hisat2_build_memory as nextflow.util.MemoryUnit).toGiga() : 0
+    def hisat2_build_memory = params.hisat2_build_memory ? (params.hisat2_build_memory as MemoryUnit).toGiga() : 0
     if (avail_mem >= hisat2_build_memory) {
         log.info "[HISAT2 index build] At least ${hisat2_build_memory} GB available, so using splice sites and exons to build HISAT2 index"
         extract_exons = gtf ? "hisat2_extract_exons.py $gtf > ${gtf.baseName}.exons.txt" : ""

--- a/modules/nf-core/salmon/quant/main.nf
+++ b/modules/nf-core/salmon/quant/main.nf
@@ -29,7 +29,8 @@ process SALMON_QUANT {
     prefix   = task.ext.prefix ?: "${meta.id}"
 
     def reference   = "--index $index"
-    def reads1 = [], reads2 = []
+    def reads1 = []
+    def reads2 = []
     meta.single_end ? [reads].flatten().each{reads1 << it} : reads.eachWithIndex{ v, ix -> ( ix & 1 ? reads2 : reads1) << v }
     def input_reads = meta.single_end ? "-r ${reads1.join(" ")}" : "-1 ${reads1.join(" ")} -2 ${reads2.join(" ")}"
     if (alignment_mode) {

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -2,8 +2,6 @@
 // Subworkflow with functionality specific to the nf-core/rnaseq pipeline
 //
 
-import groovy.json.JsonSlurper
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS
@@ -80,10 +78,6 @@ workflow PIPELINE_INITIALISATION {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-def pass_mapped_reads  = [:]
-def pass_trimmed_reads = [:]
-def pass_strand_check  = [:]
-
 workflow PIPELINE_COMPLETION {
 
     take:
@@ -99,6 +93,10 @@ workflow PIPELINE_COMPLETION {
     strand_status      // map: pass/fail status per sample for strandedness check
 
     main:
+    def pass_mapped_reads  = [:]
+    def pass_trimmed_reads = [:]
+    def pass_strand_check  = [:]
+
     summary_params = paramsSummaryMap(workflow, parameters_schema: "nextflow_schema.json")
     def multiqc_reports = multiqc_report.toList()
 
@@ -117,8 +115,6 @@ workflow PIPELINE_COMPLETION {
             id, status -> pass_strand_check[id] = status
         }
 
-    def multiqc_report_list = multiqc_report.toList()
-
     //
     // Completion email and summary
     //
@@ -135,7 +131,7 @@ workflow PIPELINE_COMPLETION {
             )
         }
 
-        rnaseqSummary(monochrome_logs=monochrome_logs, pass_mapped_reads=pass_mapped_reads, pass_trimmed_reads=pass_trimmed_reads, pass_strand_check=pass_strand_check)
+        rnaseqSummary(monochrome_logs, pass_mapped_reads, pass_trimmed_reads, pass_strand_check)
 
         if (hook_url) {
             imNotification(summary_params, hook_url)
@@ -301,7 +297,7 @@ def validateInputParameters() {
 
     // Check rRNA databases for sortmerna
     if (params.remove_ribo_rna) {
-        ch_ribo_db = file(params.ribo_database_manifest)
+        def ch_ribo_db = file(params.ribo_database_manifest)
         if (ch_ribo_db.isEmpty()) {
             error("File provided with --ribo_database_manifest is empty: ${ch_ribo_db.getName()}!")
         }
@@ -309,7 +305,7 @@ def validateInputParameters() {
 
     // Check if file with list of fastas is provided when running BBSplit
     if (!params.skip_bbsplit && !params.bbsplit_index && params.bbsplit_fasta_list) {
-        ch_bbsplit_fasta_list = file(params.bbsplit_fasta_list)
+        def ch_bbsplit_fasta_list = file(params.bbsplit_fasta_list)
         if (ch_bbsplit_fasta_list.isEmpty()) {
             error("File provided with --bbsplit_fasta_list is empty: ${ch_bbsplit_fasta_list.getName()}!")
         }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_fastp/main.nf
@@ -10,13 +10,12 @@ include { FASTP                 } from '../../../modules/nf-core/fastp/main'
 //
 // Function that parses fastp json output file to get total number of reads after trimming
 //
-import groovy.json.JsonSlurper
 
 def getFastpReadsAfterFiltering(json_file, min_num_reads) {
 
     if ( workflow.stubRun ) { return min_num_reads }
 
-    def Map json = (Map) new JsonSlurper().parseText(json_file.text).get('summary')
+    def json = new groovy.json.JsonSlurper().parseText(json_file.text).get('summary') as Map
     return json['after_filtering']['total_reads'].toLong()
 }
 
@@ -24,13 +23,12 @@ def getFastpAdapterSequence(json_file){
 
     if ( workflow.stubRun ) { return "" }
 
-    def Map json = (Map) new JsonSlurper().parseText(json_file.text)
+    def json = new groovy.json.JsonSlurper().parseText(json_file.text) as Map
     try{
-        adapter = json['adapter_cutting']['read1_adapter_sequence']
+        return json['adapter_cutting']['read1_adapter_sequence']
     } catch(Exception ex){
-        adapter = ""
+        return ""
     }
-    return adapter
 }
 
 workflow FASTQ_FASTQC_UMITOOLS_FASTP {

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -87,7 +87,7 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
             .map {
                 meta, reads, trim_log ->
                     if (trim_log) {
-                        num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log : trim_log[-1])
+                        def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log : trim_log[-1])
                         [ meta, reads, num_reads ]
                     } else {
                         [ meta, reads, min_trimmed_reads.toFloat() + 1 ]

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -69,13 +69,6 @@ include { FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS              } from '../../subwor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// Header files for MultiQC
-ch_pca_header_multiqc           = file("$projectDir/workflows/rnaseq/assets/multiqc/deseq2_pca_header.txt", checkIfExists: true)
-sample_status_header_multiqc    = file("$projectDir/workflows/rnaseq/assets/multiqc/sample_status_header.txt", checkIfExists: true)
-ch_clustering_header_multiqc    = file("$projectDir/workflows/rnaseq/assets/multiqc/deseq2_clustering_header.txt", checkIfExists: true)
-ch_biotypes_header_multiqc      = file("$projectDir/workflows/rnaseq/assets/multiqc/biotypes_header.txt", checkIfExists: true)
-ch_dummy_file                   = ch_pca_header_multiqc
-
 workflow RNASEQ {
 
     take:
@@ -99,6 +92,13 @@ workflow RNASEQ {
     make_sortmerna_index // boolean: Whether to create an index before running sortmerna
 
     main:
+
+    // Header files for MultiQC
+    ch_pca_header_multiqc           = file("$projectDir/workflows/rnaseq/assets/multiqc/deseq2_pca_header.txt", checkIfExists: true)
+    sample_status_header_multiqc    = file("$projectDir/workflows/rnaseq/assets/multiqc/sample_status_header.txt", checkIfExists: true)
+    ch_clustering_header_multiqc    = file("$projectDir/workflows/rnaseq/assets/multiqc/deseq2_clustering_header.txt", checkIfExists: true)
+    ch_biotypes_header_multiqc      = file("$projectDir/workflows/rnaseq/assets/multiqc/biotypes_header.txt", checkIfExists: true)
+    ch_dummy_file                   = ch_pca_header_multiqc
 
     ch_multiqc_files = Channel.empty()
     ch_trim_status = Channel.empty()
@@ -545,7 +545,7 @@ workflow RNASEQ {
         // Get RSeqC modules to run
         def rseqc_modules = params.rseqc_modules ? params.rseqc_modules.split(',').collect{ it.trim().toLowerCase() } : []
         if (params.bam_csi_index) {
-            for (rseqc_module in ['read_distribution', 'inner_distance', 'tin']) {
+            ['read_distribution', 'inner_distance', 'tin'].each { rseqc_module ->
                 if (rseqc_modules.contains(rseqc_module)) {
                     rseqc_modules.remove(rseqc_module)
                 }
@@ -572,12 +572,12 @@ workflow RNASEQ {
                 .map {
                     meta, strand_log ->
                         def rseqc_inferred_strand = getInferexperimentStrandedness(strand_log, params.stranded_threshold, params.unstranded_threshold)
-                        rseqc_strandedness = rseqc_inferred_strand.inferred_strandedness
+                        def rseqc_strandedness = rseqc_inferred_strand.inferred_strandedness
 
                         def status = 'fail'
                         def multiqc_lines = []
                         if (meta.salmon_strand_analysis) {
-                            salmon_strandedness = meta.salmon_strand_analysis.inferred_strandedness
+                            def salmon_strandedness = meta.salmon_strand_analysis.inferred_strandedness
 
                             if (salmon_strandedness == rseqc_strandedness && rseqc_strandedness != 'undetermined') {
                                 status = 'pass'


### PR DESCRIPTION
This PR fixes syntax errors reported by the language server / `nextflow lint`.

The next release of the VS Code extension comes with a custom Pipeline view, which uses the language server to display a tree view of workflows and processes. Due to these syntax errors, the language server isn't able to parse several files and as a result the Pipeline view is incomplete. Fixing these syntax errors should allow the language server to provide the entire call tree.