### PR TITLE
Fix bigwig strand labeling for reverse-stranded libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Special thanks to the following for their contributions to the release:
 
 - [Elad Herzog](https://github.com/EladH1)
+- [Emily Miyoshi](https://github.com/emilymiyoshi)
 
 ### Enhancements and fixes
 
 - [PR #1608](https://github.com/nf-core/rnaseq/pull/1608) - Bump version after release 3.21.0
 - [PR #1617](https://github.com/nf-core/rnaseq/pull/1617) - Update bbmap/bbsplit module
+- [PR #1620](https://github.com/nf-core/rnaseq/pull/1620) - Fix bigwig strand labeling for reverse-stranded libraries ([#1591](https://github.com/nf-core/rnaseq/issues/1591))
 
 ## [[3.21.0](https://github.com/nf-core/rnaseq/releases/tag/3.21.0)] - 2025-09-18
 

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -499,6 +499,7 @@ workflow RNASEQ {
 
     //
     // MODULE: Genome-wide coverage with BEDTools
+    // Note: Strand parameters are conditional on library strandedness (see nextflow.config)
     //
     if (!params.skip_bigwig) {
 

--- a/workflows/rnaseq/nextflow.config
+++ b/workflows/rnaseq/nextflow.config
@@ -335,7 +335,7 @@ if (!params.skip_bigwig) {
     process {
         withName: 'BEDTOOLS_GENOMECOV_FW' {
             ext.prefix = { meta.strandedness == 'reverse' ? meta.id + '.reverse' :  meta.id + '.forward' }
-            ext.args   = '-split -du -strand + -bg'
+            ext.args   = { meta.strandedness == 'reverse' ? '-split -du -strand - -bg' : '-split -du -strand + -bg' }
             publishDir = [
                 enabled: false
             ]
@@ -343,7 +343,7 @@ if (!params.skip_bigwig) {
 
         withName: 'BEDTOOLS_GENOMECOV_REV' {
             ext.prefix = { meta.strandedness == 'reverse' ? meta.id + '.forward' :  meta.id + '.reverse' }
-            ext.args   = '-split -du -strand - -bg'
+            ext.args   = { meta.strandedness == 'reverse' ? '-split -du -strand + -bg' : '-split -du -strand - -bg' }
             publishDir = [
                 enabled: false
             ]


### PR DESCRIPTION
## Summary

Fixes #1591 - Corrects mislabeled bigwig files for reverse-stranded (dUTP) libraries where forward and reverse strand signals were inverted in the final output files.

## Background

For reverse-stranded libraries, reads align to the **opposite strand** of the genes they represent:
- Forward (+) strand genes → reads map to the reverse (-) strand  
- Reverse (-) strand genes → reads map to the forward (+) strand

This is due to the dUTP library preparation method where the second strand synthesis incorporates dUTPs, which are later degraded, preserving only the strand opposite to the original RNA.

## The Problem

The pipeline was always using:
- `BEDTOOLS_GENOMECOV_FW` with `-strand +` → output labeled as `.forward.bigWig`
- `BEDTOOLS_GENOMECOV_REV` with `-strand -` → output labeled as `.reverse.bigWig`

This is **correct** for forward-stranded and unstranded libraries, but produces **inverted labels** for reverse-stranded libraries:
- `.forward.bigWig` contained coverage from reads on the `+` strand, which represent `-` strand genes ❌
- `.reverse.bigWig` contained coverage from reads on the `-` strand, which represent `+` strand genes ❌

This caused the bigwig tracks to appear inverted when visualized in IGV or other genome browsers.

## The Solution

Made the `-strand` parameter conditional on `meta.strandedness` in the nextflow config:

**For reverse-stranded libraries:**
- `BEDTOOLS_GENOMECOV_FW` now uses `-strand -` (captures forward genes) ✓
- `BEDTOOLS_GENOMECOV_REV` now uses `-strand +` (captures reverse genes) ✓

**For other library types:**
- Behavior remains unchanged (uses `-strand +` and `-strand -` respectively)

This ensures:
- `.forward.bigWig` always contains coverage of forward (+) strand genes
- `.reverse.bigWig` always contains coverage of reverse (-) strand genes

...regardless of library preparation method.

## Changes

- Modified `workflows/rnaseq/nextflow.config` to make `ext.args` conditional for both `BEDTOOLS_GENOMECOV_FW` and `BEDTOOLS_GENOMECOV_REV` processes

## Test Plan

- [ ] Run pipeline with reverse-stranded library data (e.g., dUTP method)
- [ ] Verify bigwig files in IGV show correct strand orientation
- [ ] Compare with known genes to confirm forward genes appear in forward.bigWig
- [ ] Test with forward-stranded libraries to ensure no regression
- [ ] Test with unstranded libraries to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)