### PR TITLE
Restrict ARM CI tests to Docker profile only

### DIFF
--- a/.github/workflows/nf-test-arm.yml
+++ b/.github/workflows/nf-test-arm.yml
@@ -71,15 +71,7 @@ jobs:
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes-arm.outputs.shard) }}
         archProfile: [arm64]
-        profile: [conda, docker, singularity]
-        isMain:
-          - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
-        # Exclude conda and singularity on dev
-        exclude:
-          - isMain: false
-            profile: "conda"
-          - isMain: false
-            profile: "singularity"
+        profile: [docker]
         NXF_VER:
           - "25.04.0"
           - "latest-everything"

--- a/.github/workflows/nf-test-arm.yml
+++ b/.github/workflows/nf-test-arm.yml
@@ -72,6 +72,14 @@ jobs:
         shard: ${{ fromJson(needs.nf-test-changes-arm.outputs.shard) }}
         archProfile: [arm64]
         profile: [docker]
+        isMain:
+          - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
+        # Exclude conda and singularity on dev
+        exclude:
+          - isMain: false
+            profile: "conda"
+          - isMain: false
+            profile: "singularity"
         NXF_VER:
           - "25.04.0"
           - "latest-everything"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1641](https://github.com/nf-core/rnaseq/pull/1641) - Add arm-based CI tests and fix arm-related issues
 - [PR #1645](https://github.com/nf-core/rnaseq/pull/1645) - Fix BAM CSI index access error with UMI deduplication ([#1643](https://github.com/nf-core/rnaseq/issues/1643))
 - [PR #1642](https://github.com/nf-core/rnaseq/pull/1642) - Add long format to rsem merge
+- [PR #1650](https://github.com/nf-core/rnaseq/pull/1650) - Restrict ARM CI tests to Docker profile only
 
 ## [[3.22.0](https://github.com/nf-core/rnaseq/releases/tag/3.22.0)] - 2025-11-26
 


### PR DESCRIPTION
## Summary
- Restrict ARM CI tests to use only Docker profile, removing conda and singularity
- Simplifies the test matrix for ARM runners

## Test plan
- [ ] Verify ARM CI workflow runs successfully with Docker profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)