### PR TITLE
Bump nf-core/multiqc module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements and fixes
 
 - [PR #1656](https://github.com/nf-core/rnaseq/pull/1656) - Bump version after release 3.22.1
+- [PR #1658](https://github.com/nf-core/rnaseq/pull/1658) - Bump nf-core/multiqc module
 
 ## [[3.22.1](https://github.com/nf-core/rnaseq/releases/tag/3.22.1)] - 2025-12-04
 

--- a/modules.json
+++ b/modules.json
@@ -108,7 +108,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "e10b76ca0c66213581bec2833e30d31f239dec0b",
+                        "git_sha": "9656d955b700a8707c4a67821ab056f8c1095675",
                         "installed_by": ["modules"]
                     },
                     "picard/markduplicates": {

--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::multiqc=1.31
+  - bioconda::multiqc=1.33

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -3,11 +3,11 @@ process MULTIQC {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/ef/eff0eafe78d5f3b65a6639265a16b89fdca88d06d18894f90fcdb50142004329/data' :
-        'community.wave.seqera.io/library/multiqc:1.31--1efbafd542a23882' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/34/34e733a9ae16a27e80fe00f863ea1479c96416017f24a907996126283e7ecd4d/data' :
+        'community.wave.seqera.io/library/multiqc:1.33--ee7739d47738383b' }"
 
     input:
-    path  multiqc_files, stageAs: "?/*"
+    path multiqc_files, stageAs: "?/*"
     path(multiqc_config)
     path(extra_multiqc_config)
     path(multiqc_logo)
@@ -15,10 +15,11 @@ process MULTIQC {
     path(sample_names)
 
     output:
-    path "*multiqc_report.html", emit: report
-    path "*_data"              , emit: data
-    path "*_plots"             , optional:true, emit: plots
-    path "versions.yml"        , emit: versions
+    path "*.html"      , emit: report
+    path "*_data"      , emit: data
+    path "*_plots"     , optional:true, emit: plots
+    tuple val("${task.process}"), val('multiqc'), eval('multiqc --version | sed "s/.* //g"'), emit: versions
+    // MultiQC should not push its versions to the `versions` topic. Its input depends on the versions topic to be resolved thus outputting to the topic will let the pipeline hang forever
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,38 +27,29 @@ process MULTIQC {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ? "--filename ${task.ext.prefix}.html" : ''
-    def config = multiqc_config ? "--config $multiqc_config" : ''
-    def extra_config = extra_multiqc_config ? "--config $extra_multiqc_config" : ''
+    def config = multiqc_config ? "--config ${multiqc_config}" : ''
+    def extra_config = extra_multiqc_config ? "--config ${extra_multiqc_config}" : ''
     def logo = multiqc_logo ? "--cl-config 'custom_logo: \"${multiqc_logo}\"'" : ''
     def replace = replace_names ? "--replace-names ${replace_names}" : ''
     def samples = sample_names ? "--sample-names ${sample_names}" : ''
     """
     multiqc \\
         --force \\
-        $args \\
-        $config \\
-        $prefix \\
-        $extra_config \\
-        $logo \\
-        $replace \\
-        $samples \\
+        ${args} \\
+        ${config} \\
+        ${prefix} \\
+        ${extra_config} \\
+        ${logo} \\
+        ${replace} \\
+        ${samples} \\
         .
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
-    END_VERSIONS
     """
 
     stub:
     """
     mkdir multiqc_data
+    touch multiqc_data/.stub
     mkdir multiqc_plots
     touch multiqc_report.html
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -57,10 +57,10 @@ input:
         - edam: http://edamontology.org/format_3475 # TSV
 output:
   report:
-    - "*multiqc_report.html":
+    - "*.html":
         type: file
         description: MultiQC report file
-        pattern: "multiqc_report.html"
+        pattern: ".html"
         ontologies: []
   data:
     - "*_data":
@@ -74,12 +74,16 @@ output:
         pattern: "*_data"
         ontologies: []
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - multiqc:
+          type: string
+          description: The tool name
+      - multiqc --version | sed "s/.* //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@abhi18av"
   - "@bunop"

--- a/modules/nf-core/multiqc/tests/custom_prefix.config
+++ b/modules/nf-core/multiqc/tests/custom_prefix.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'MULTIQC' {
+        ext.prefix = "custom_prefix"
+    }
+}

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -30,7 +30,33 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("multiqc_versions_single") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions")}).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 single-end [fastqc] - custom prefix") {
+        config "./custom_prefix.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastqc/test_fastqc.zip', checkIfExists: true))
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                input[4] = []
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.report[0] ==~ ".*/custom_prefix.html" },
+                { assert process.out.data[0] ==~ ".*/custom_prefix_data" }
             )
         }
 
@@ -56,7 +82,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
                 { assert process.out.data[0] ==~ ".*/multiqc_data" },
-                { assert snapshot(process.out.versions).match("multiqc_versions_config") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith("versions")}).match() }
             )
         }
     }
@@ -84,7 +110,7 @@ nextflow_process {
                 { assert snapshot(process.out.report.collect { file(it).getName() } +
                                 process.out.data.collect { file(it).getName() } +
                                 process.out.plots.collect { file(it).getName() } +
-                                process.out.versions ).match("multiqc_stub") }
+                                process.out.findAll { key, val -> key.startsWith("versions")} ).match() }
             )
         }
 

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -1,41 +1,61 @@
 {
-    "multiqc_versions_single": {
+    "sarscov2 single-end [fastqc]": {
         "content": [
-            [
-                "versions.yml:md5,8968b114a3e20756d8af2b80713bcc4f"
-            ]
+            {
+                "versions": [
+                    [
+                        "MULTIQC",
+                        "multiqc",
+                        "1.33"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-08T20:57:36.139055243"
+        "timestamp": "2025-12-09T10:10:43.020315838"
     },
-    "multiqc_stub": {
+    "sarscov2 single-end [fastqc] - stub": {
         "content": [
             [
                 "multiqc_report.html",
                 "multiqc_data",
                 "multiqc_plots",
-                "versions.yml:md5,8968b114a3e20756d8af2b80713bcc4f"
+                {
+                    "versions": [
+                        [
+                            "MULTIQC",
+                            "multiqc",
+                            "1.33"
+                        ]
+                    ]
+                }
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-08T20:59:15.142230631"
+        "timestamp": "2025-12-09T10:11:14.131950776"
     },
-    "multiqc_versions_config": {
+    "sarscov2 single-end [fastqc] [config]": {
         "content": [
-            [
-                "versions.yml:md5,8968b114a3e20756d8af2b80713bcc4f"
-            ]
+            {
+                "versions": [
+                    [
+                        "MULTIQC",
+                        "multiqc",
+                        "1.33"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-09-08T20:58:29.629087066"
+        "timestamp": "2025-12-09T10:11:07.15692209"
     }
 }

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -47,6 +47,7 @@ umitools/*.umi_extract.log
 {hisat2,star_rsem,star_salmon}/stringtie/*.gene.abundance.txt
 {hisat2,star_rsem,star_salmon}/stringtie/*.{coverage,transcripts}.gtf
 {hisat2,star_rsem,star_salmon}/{umitools,umicollapse}/{genomic,transcriptomic}_dedup_log/*.log
+{multiqc,multiqc/**}/.stub
 {multiqc,multiqc/**}/multiqc_report.html
 {multiqc,multiqc/**}/multiqc_report_data/multiqc.parquet
 {multiqc,multiqc/**}/multiqc_report_data/fastqc_{raw,trimmed}_top_overrepresented_sequences_table.txt

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -75,6 +75,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/featurecounts_group_type.nf.test.snap
+++ b/tests/featurecounts_group_type.nf.test.snap
@@ -75,6 +75,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/hisat2.nf.test.snap
+++ b/tests/hisat2.nf.test.snap
@@ -76,6 +76,7 @@
                 "multiqc",
                 "multiqc/hisat2",
                 "multiqc/hisat2/multiqc_data",
+                "multiqc/hisat2/multiqc_data/.stub",
                 "multiqc/hisat2/multiqc_plots",
                 "multiqc/hisat2/multiqc_report.html",
                 "pipeline_info",

--- a/tests/kallisto.nf.test.snap
+++ b/tests/kallisto.nf.test.snap
@@ -320,6 +320,7 @@
                 "fq_lint/raw/WT_REP2.fq_lint.txt",
                 "multiqc",
                 "multiqc/multiqc_data",
+                "multiqc/multiqc_data/.stub",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",

--- a/tests/min_mapped_reads.nf.test.snap
+++ b/tests/min_mapped_reads.nf.test.snap
@@ -1276,6 +1276,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/remove_ribo_rna.nf.test.snap
+++ b/tests/remove_ribo_rna.nf.test.snap
@@ -1486,6 +1486,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/salmon.nf.test.snap
+++ b/tests/salmon.nf.test.snap
@@ -407,6 +407,7 @@
                 "fq_lint/raw/WT_REP2.fq_lint.txt",
                 "multiqc",
                 "multiqc/multiqc_data",
+                "multiqc/multiqc_data/.stub",
                 "multiqc/multiqc_plots",
                 "multiqc/multiqc_report.html",
                 "pipeline_info",

--- a/tests/sentieon_default.nf.test.snap
+++ b/tests/sentieon_default.nf.test.snap
@@ -75,6 +75,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/skip_qc.nf.test.snap
+++ b/tests/skip_qc.nf.test.snap
@@ -61,6 +61,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",

--- a/tests/star_rsem.nf.test.snap
+++ b/tests/star_rsem.nf.test.snap
@@ -1420,6 +1420,7 @@
                 "multiqc",
                 "multiqc/star_rsem",
                 "multiqc/star_rsem/multiqc_data",
+                "multiqc/star_rsem/multiqc_data/.stub",
                 "multiqc/star_rsem/multiqc_plots",
                 "multiqc/star_rsem/multiqc_report.html",
                 "pipeline_info",

--- a/tests/umi.nf.test.snap
+++ b/tests/umi.nf.test.snap
@@ -2812,6 +2812,7 @@
                 "multiqc",
                 "multiqc/star_salmon",
                 "multiqc/star_salmon/multiqc_data",
+                "multiqc/star_salmon/multiqc_data/.stub",
                 "multiqc/star_salmon/multiqc_plots",
                 "multiqc/star_salmon/multiqc_report.html",
                 "pipeline_info",


### PR DESCRIPTION
## Summary
- Bump nf-core/multiqc module to latest version (1.31 → 1.33)
- Update nf-test snapshots to include `.stub` files in directory listings
- Add `.stub` to `.nftignore` to exclude stub file content checks

The updated MultiQC module now creates a `.stub` file inside `multiqc_data/` during stub runs to ensure the directory is not empty and gets properly captured in outputs.

## Test plan
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)