### PR TITLE
Enable SeqKit stats MultiQC module for RiboDetector rRNA removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1663](https://github.com/nf-core/rnaseq/pull/1663) - Bump version after release 3.22.2
 - [PR #1664](https://github.com/nf-core/rnaseq/pull/1664) - Add support for multiple rRNA removal tools (`--ribo_removal_tool`): SortMeRNA (default), Bowtie2, and RiboDetector; enable BBSplit MultiQC reporting; add paired-end read grouping in MultiQC
 - [PR #1665](https://github.com/nf-core/rnaseq/pull/1665) - Bulk update modules/subworkflows; replace CUSTOM_GETCHROMSIZES with SAMTOOLS_FAIDX; update RSEQC modules with Wave containers for ARM compatibility; update ARM containers for RSEQC and UMITOOLS
+- [PR #1669](https://github.com/nf-core/rnaseq/pull/1669) - Enable SeqKit stats MultiQC module for RiboDetector rRNA removal
 
 ### Parameters
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/nextflow.config
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/nextflow.config
@@ -59,6 +59,16 @@ if (params.remove_ribo_rna && params.ribo_removal_tool in ['sortmerna', 'bowtie2
 
 if (params.remove_ribo_rna && params.ribo_removal_tool == 'ribodetector') {
     process {
+        withName: '.*:FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS:.*:SEQKIT_STATS' {
+            ext.args   = '--all'
+            ext.prefix = { "${meta.id}.rrna_removal_stats" }
+            publishDir = [
+                path: { "${params.outdir}/ribodetector" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            ]
+        }
+
         withName: '.*:FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS:.*:RIBODETECTOR' {
             ext.args   = '-e rrna'
             cpus       = 1

--- a/tests/remove_ribo_rna.nf.test
+++ b/tests/remove_ribo_rna.nf.test
@@ -3,6 +3,7 @@ nextflow_pipeline {
     name "Test pipeline with ribosomal RNA removal"
     script "../main.nf"
     tag "pipeline"
+    tag "remove_ribo_rna"
 
     test("Params: --remove_ribo_rna") {
 

--- a/workflows/rnaseq/assets/multiqc/multiqc_config.yml
+++ b/workflows/rnaseq/assets/multiqc/multiqc_config.yml
@@ -102,6 +102,7 @@ run_modules:
   - fastqc
   - cutadapt
   - fastp
+  - seqkit
   - bbmap
   - sortmerna
   - bowtie2
@@ -131,6 +132,11 @@ module_order:
         - "*_raw*fastqc.zip"
   - cutadapt
   - fastp
+  - seqkit:
+      name: "SeqKit Stats (rRNA removal)"
+      info: "Read length statistics used by RiboDetector for rRNA removal."
+      path_filters:
+        - "*.rrna_removal_stats.tsv"
   - fastqc:
       anchor: "fastqc_trimmed"
       name: "FastQC (trimmed)"
@@ -184,6 +190,9 @@ sp:
 
   hisat2:
     fn: "*.hisat2.summary.log"
+
+  seqkit/stats:
+    fn: "*.rrna_removal_stats.tsv"
 
   salmon/meta:
     fn: "meta_info.json"


### PR DESCRIPTION
## Summary

- Enables the SeqKit stats MultiQC module when using RiboDetector for rRNA removal
- Displays read length statistics used to determine optimal parameters for RiboDetector
- Follows the pattern established in nf-core/riboseq for SeqKit MultiQC integration

## Changes

- Add `seqkit` to `run_modules` in `multiqc_config.yml`
- Add `module_order` entry with custom name "SeqKit Stats (rRNA removal)" and path filter
- Add search pattern `seqkit/stats` for `*.rrna_removal_stats.tsv` files
- Configure `SEQKIT_STATS` process with:
  - Custom prefix `${meta.id}.rrna_removal_stats`
  - Published to `${params.outdir}/ribodetector` directory

## Test plan

- [ ] Run pipeline with `--remove_ribo_rna --ribo_removal_tool ribodetector` 
- [ ] Verify SeqKit stats appear in MultiQC report under "SeqKit Stats (rRNA removal)" section
- [ ] Verify stats files are published to the ribodetector output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)