### PR TITLE
Fix offline mode by skipping igenomes_base validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1687](https://github.com/nf-core/rnaseq/pull/1687) - Fix PREPARE_GENOME tests: use single aligner values, correct aligner assignments for index-specific tests, add Kallisto test, remove ineffective Sentieon tests, use file-names-only snapshots for all non-deterministic indices (STAR, Salmon, Kallisto, RSEM, HISAT2)
 - [PR #1688](https://github.com/nf-core/rnaseq/pull/1688) - Significantly improved prokaryotic RNA-seq support: new `-profile prokaryotic` for bacterial/archaeal data with Bowtie2+Salmon alignment, GFFREAD transcript extraction for CDS-only annotations, and automatic STAR CDS configuration. We would like to thank [Juliana Assis](https://github.com/Juassis), [Sebastian Schulz](https://github.com/sebschulz1), [Albert Palleja](https://github.com/apalleja) and [Marine Cambon](https://github.com/marccamb) for their [recommendations and extensive testing](https://github.com/nf-core/rnaseq/issues/1512).
 - [PR #1689](https://github.com/nf-core/rnaseq/pull/1689) - Migrate to topic-based version reporting for nf-core modules/subworkflows and local modules
-- [PR #1696](https://github.com/nf-core/rnaseq/pull/1696) - Fix offline mode by skipping `igenomes_base` validation ([#1690](https://github.com/nf-core/rnaseq/issues/1690))
+- [PR #1696](https://github.com/nf-core/rnaseq/pull/1696) - Fix offline mode by skipping `igenomes_base` validation when `NXF_OFFLINE=true` ([#1690](https://github.com/nf-core/rnaseq/issues/1690))
 
 ### Parameters
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -431,7 +431,7 @@ plugins {
 }
 
 validation {
-    defaultIgnoreParams = ["genomes", "igenomes_base"]
+    defaultIgnoreParams = ["genomes"] + (System.getenv('NXF_OFFLINE') == 'true' ? ["igenomes_base"] : [])
     monochromeLogs = params.monochrome_logs
 }
 


### PR DESCRIPTION
## Summary

- Conditionally skip `igenomes_base` validation when `NXF_OFFLINE=true` to prevent nf-schema from validating the S3 default path when running offline

nf-schema 2.5.0+ validates cloud storage paths for `format: "directory-path"` parameters. When running offline (e.g. on air-gapped HPC), the `FormatDirectoryPathEvaluator` tries to call `file.exists()` on the `s3://ngi-igenomes/igenomes/` default, which throws a network exception and fails validation.

Uses the `NXF_OFFLINE` env var conditional approach suggested by @nvnieuwk in nextflow-io/nf-schema#204, so online runs still get full validation.

The proper fix belongs upstream in nf-schema (nextflow-io/nf-schema#204). This is a workaround until that's resolved.

Fixes #1690

## Test plan

- [ ] Verify pipeline still validates other parameters normally
- [ ] Confirm offline runs (`NXF_OFFLINE=true`) no longer fail on `igenomes_base` validation
- [ ] Confirm online runs still validate `igenomes_base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)