### PR TITLE
fix: always skip igenomes_base validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements and fixes
 
 - [PR #1740](https://github.com/nf-core/rnaseq/pull/1740) - Bump version to 3.24.0dev after release 3.23.0; always set ID/SM read group tags for STAR and HISAT2 even when `seq_center`/`seq_platform` are not provided
-- [PR #xxxx](https://github.com/nf-core/rnaseq/pull/xxxx) - Always skip validation of `igenomes_base` and remove `format: directory-path` from schema to prevent S3 access errors
+- [PR #1745](https://github.com/nf-core/rnaseq/pull/1745) - Always skip validation of `igenomes_base` and remove `format: directory-path` from schema to prevent S3 access errors
 
 ## [[3.23.0](https://github.com/nf-core/rnaseq/releases/tag/3.23.0)] - 2026-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements and fixes
 
 - [PR #1740](https://github.com/nf-core/rnaseq/pull/1740) - Bump version to 3.24.0dev after release 3.23.0; always set ID/SM read group tags for STAR and HISAT2 even when `seq_center`/`seq_platform` are not provided
+- [PR #xxxx](https://github.com/nf-core/rnaseq/pull/xxxx) - Always skip validation of `igenomes_base` and remove `format: directory-path` from schema to prevent S3 access errors
 
 ## [[3.23.0](https://github.com/nf-core/rnaseq/releases/tag/3.23.0)] - 2026-02-27
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -456,7 +456,7 @@ plugins {
 }
 
 validation {
-    defaultIgnoreParams = ["genomes"] + (System.getenv('NXF_OFFLINE') == 'true' ? ["igenomes_base"] : [])
+    defaultIgnoreParams = ["genomes", "igenomes_base"]
     monochromeLogs = params.monochrome_logs
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -245,7 +245,6 @@
                 },
                 "igenomes_base": {
                     "type": "string",
-                    "format": "directory-path",
                     "description": "The base path to the igenomes reference files",
                     "fa_icon": "fas fa-ban",
                     "hidden": true,


### PR DESCRIPTION
## Summary

- Always ignore `igenomes_base` during parameter validation (not just when `NXF_OFFLINE=true`)
- Remove `format: directory-path` from the `igenomes_base` schema definition

The previous fix (PR #1696) only skipped `igenomes_base` validation when `NXF_OFFLINE=true`. But users without AWS credentials also get validation failures (403 Access Denied) when nf-schema tries to check the S3 default path. Since `igenomes_base` is never used directly - derived reference paths are validated individually - we should always skip it.

This follows the nf-schema maintainer's recommendation in nextflow-io/nf-schema#204:
> Having `--igenomes_base` as a default ignored parameter is the best solution here since all files derived from that path are validated themselves anyways.

> Something I've also started doing is removing `"format": "directory-path"` and `"exists": true` from the igenomes base schema.

Fixes #1690

## Test plan

- [ ] Verify pipeline validates other parameters normally
- [ ] Confirm runs without AWS credentials no longer fail on `igenomes_base` validation
- [ ] Confirm `igenomes_base` is still functional when explicitly provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)