### PR TITLE
Fix iGenomes STAR version detection and index building logic

### DIFF
--- a/subworkflows/local/align_star/main.nf
+++ b/subworkflows/local/align_star/main.nf
@@ -30,7 +30,7 @@ workflow ALIGN_STAR {
     index                // channel: [ val(meta), [ index ] ]
     gtf                  // channel: [ val(meta), [ gtf ] ]
     star_ignore_sjdbgtf  // boolean: when using pre-built STAR indices do not re-extract and use splice junctions from the GTF file
-    is_aws_igenome       // boolean: whether the genome files are from AWS iGenomes
+    use_igenomes_star    // boolean: whether to use iGenomes-pinned STAR (2.6.1d) for pre-built index compatibility
     fasta_fai            // channel: [ val(meta), path(fasta), path(fai) ]
     use_sentieon_star    // boolean: whether star alignment is accelerated with Sentieon
     use_parabricks_star  // boolean: whether star alignment (and mark duplicates) is accelerated with Parabricks
@@ -53,7 +53,7 @@ workflow ALIGN_STAR {
         PARABRICKS_RNA_FQ2BAM(reads, fasta_fai.map { meta, fasta, _fai -> [ meta, fasta ] }, index, true, !skip_markduplicates)
         ch_star_out = PARABRICKS_RNA_FQ2BAM
 
-    } else if (is_aws_igenome) {
+    } else if (use_igenomes_star) {
 
         STAR_ALIGN_IGENOMES(reads, index, gtf, star_ignore_sjdbgtf)
         ch_star_out = STAR_ALIGN_IGENOMES

--- a/subworkflows/local/align_star/tests/main.nf.test
+++ b/subworkflows/local/align_star/tests/main.nf.test
@@ -29,7 +29,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -47,7 +47,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -105,7 +105,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = true
+                use_igenomes_star      = true
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -123,7 +123,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -181,7 +181,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -199,7 +199,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -259,7 +259,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = true
+                use_igenomes_star      = true
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -277,7 +277,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),

--- a/subworkflows/local/align_star/tests/main.parabricks.nf.test
+++ b/subworkflows/local/align_star/tests/main.parabricks.nf.test
@@ -29,7 +29,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star   = false
                 use_parabricks_star = true
                 skip_markduplicates = false
@@ -47,7 +47,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -86,7 +86,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star   = false
                 use_parabricks_star = true
                 skip_markduplicates = false
@@ -104,7 +104,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),

--- a/subworkflows/local/align_star/tests/main.rg.nf.test
+++ b/subworkflows/local/align_star/tests/main.rg.nf.test
@@ -29,7 +29,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -47,7 +47,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -95,7 +95,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = false
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -113,7 +113,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),

--- a/subworkflows/local/align_star/tests/main.sentieon.nf.test
+++ b/subworkflows/local/align_star/tests/main.sentieon.nf.test
@@ -29,7 +29,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = true
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -47,7 +47,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
@@ -105,7 +105,7 @@ nextflow_workflow {
             workflow {
                 """
                 star_ignore_sjdbgtf = false
-                is_aws_igenome      = false
+                use_igenomes_star      = false
                 use_sentieon_star    = true
                 use_parabricks_star  = false
                 skip_markduplicates  = false
@@ -123,7 +123,7 @@ nextflow_workflow {
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = is_aws_igenome
+                input[4] = use_igenomes_star
                 input[5] = Channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -40,7 +40,6 @@ include { SENTIEON_RSEMPREPAREREFERENCE as SENTIEON_MAKE_TRANSCRIPTS_FASTA      
 include { PREPROCESS_TRANSCRIPTS_FASTA_GENCODE } from '../../../modules/local/preprocess_transcripts_fasta_gencode'
 include { GTF2BED                              } from '../../../modules/local/gtf2bed'
 include { GTF_FILTER                           } from '../../../modules/local/gtf_filter'
-include { STAR_GENOMEGENERATE as STAR_GENOMEGENERATE_IGENOMES } from '../../../modules/nf-core/star/genomegenerate'
 
 workflow PREPARE_GENOME {
 
@@ -294,7 +293,13 @@ workflow PREPARE_GENOME {
     //----------------------------------------------------
     ch_star_index = channel.empty()
     if (prepare_tool_indices.intersect(['star_salmon', 'star_rsem'])) {
-        if (star_index) {
+        if (use_parabricks_star && fasta_provided) {
+            // Parabricks needs its own STAR index built with its bundled STAR version
+            ch_star_index = PARABRICKS_STARGENOMEGENERATE(
+                ch_fasta.map { item -> [ [:], item ] },
+                ch_gtf.map   { item -> [ [:], item ] }
+            ).index.map { tuple -> tuple[1] }
+        } else if (star_index) {
             if (star_index.endsWith('.tar.gz')) {
                 ch_star_index = UNTAR_STAR_INDEX ([ [:], file(star_index, checkIfExists: true) ]).untar.map { tuple -> tuple[1] }
             } else {
@@ -302,28 +307,12 @@ workflow PREPARE_GENOME {
             }
         }
         else if (fasta_provided) {
-            // Build new STAR index
-            // Possibly check AWS iGenome conditions
-            def is_aws_igenome = false
-            if (file(fasta, checkIfExists: true).getName() - '.gz' == 'genome.fa' && file(gtf, checkIfExists: true).getName() - '.gz' == 'genes.gtf') {
-                is_aws_igenome = true
-            }
-            if (is_aws_igenome) {
-                ch_star_index = STAR_GENOMEGENERATE_IGENOMES(
-                    ch_fasta.map { item -> [ [:], item ] },
-                    ch_gtf.map   { item -> [ [:], item ] }
-                ).index.map { tuple -> tuple[1] }
-            } else if (use_parabricks_star) {
-                ch_star_index = PARABRICKS_STARGENOMEGENERATE(
-                    ch_fasta.map { item -> [ [:], item ] },
-                    ch_gtf.map   { item -> [ [:], item ] }
-                ).index.map { tuple -> tuple[1] }
-            } else {
-                ch_star_index = STAR_GENOMEGENERATE(
-                    ch_fasta.map { item -> [ [:], item ] },
-                    ch_gtf.map { item -> [ [:], item ] }
-                ).index.map { tuple -> tuple[1] }
-            }
+            // Build new STAR index with current STAR version.
+            // No need for iGenomes STAR 2.6.1d here - that's only for pre-built index compatibility.
+            ch_star_index = STAR_GENOMEGENERATE(
+                ch_fasta.map { item -> [ [:], item ] },
+                ch_gtf.map { item -> [ [:], item ] }
+            ).index.map { tuple -> tuple[1] }
         }
     }
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -322,6 +322,10 @@ def validateInputParameters() {
         error("Parabricks rna_fq2bam does not support --sjdbGTFfeatureExon CDS, which is required for prokaryotic alignment. Please use standard STAR instead.")
     }
 
+    if (params.use_parabricks_star && params.genome) {
+        error("Parabricks (--use_parabricks_star) is not compatible with --genome. iGenomes STAR indices are built with a different STAR version than Parabricks bundles. Please supply --fasta and --gtf explicitly instead.")
+    }
+
     if (params.with_umi && !params.skip_umi_extract) {
         if (!params.umitools_bc_pattern && !params.umitools_bc_pattern2) {
             error("UMI-tools requires a barcode pattern to extract barcodes from the reads.")

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -241,20 +241,15 @@ workflow RNASEQ {
     ch_star_log            = channel.empty()
 
     if (!params.skip_alignment && (params.aligner == 'star_salmon' || params.aligner == 'star_rsem')) {
-        // Check if an AWS iGenome has been provided to use the appropriate version of STAR
-        def is_aws_igenome = false
-        if (params.fasta && params.gtf) {
-            if ((file(params.fasta).getName() - '.gz' == 'genome.fa') && (file(params.gtf).getName() - '.gz' == 'genes.gtf')) {
-                is_aws_igenome = true
-            }
-        }
+        // Use iGenomes-pinned STAR (2.6.1d) only when aligning with a pre-built iGenomes index
+        def use_igenomes_star = params.genome && params.star_index ? true : false
 
         ALIGN_STAR (
             ch_strand_inferred_filtered_fastq,
             ch_star_index.map { item -> [ [:], item ] },
             ch_gtf.map { item -> [ [:], item ] },
             params.star_ignore_sjdbgtf,
-            is_aws_igenome,
+            use_igenomes_star,
             ch_fasta_fai,
             params.use_sentieon_star,
             params.use_parabricks_star,


### PR DESCRIPTION
## Summary

The `is_aws_igenome` detection used filename heuristics (`genome.fa`/`genes.gtf`) to decide whether to use STAR 2.6.1d for both index building and alignment. This was overly broad and could cause issues (notably with Parabricks, but also in principle for any user supplying files with iGenomes-standard names from non-iGenomes sources).

STAR 2.6.1d is only needed for **alignment** against pre-built iGenomes indices. There is no reason to **build** indices with STAR 2.6.1d:
- All 38 genome entries in `igenomes.config` provide pre-built STAR indices, so when `--genome` is set the build path is never reached
- When building from scratch (no `--genome`), there is no pre-built index to be compatible with

The original logic was introduced in `a5fd03845` (2022, Harshil Patel) with the comment "2.7X indices incompatible with AWS iGenomes". That concern is valid for alignment, but the `STAR_GENOMEGENERATE_IGENOMES` build path was never necessary.

## Changes

1. **Remove `STAR_GENOMEGENERATE_IGENOMES` from index building** - when building from scratch, always use current STAR. Parabricks builds its own index first if enabled.
2. **Replace filename-based heuristic with explicit check** - rename `is_aws_igenome` to `use_igenomes_star`, conditioned on `params.genome && params.star_index` (true only when actually using a pre-built iGenomes index)
3. **Add validation error for `--use_parabricks_star` + `--genome`** - these are incompatible since iGenomes STAR indices were built with a different STAR version than Parabricks bundles

## Context

This was discovered when Parabricks benchmark runs failed with:

> FATAL ERROR: Genome version: 20201 is INCOMPATIBLE with running STAR version: 2.7.2a

The filename heuristic matched the iGenomes fasta/gtf names, built the index with STAR 2.6.1d, then Parabricks (which bundles STAR 2.7.2a) couldn't use it. But the underlying issue is broader than Parabricks - the filename heuristic was always fragile and the iGenomes index build path was unnecessary.

## Test plan

- [ ] Existing `align_star` subworkflow tests pass (variable rename)
- [ ] Parabricks pipeline tests pass (`tests/parabricks_default.nf.test`)
- [ ] Standard pipeline tests pass with `--genome` (pre-built iGenomes index used, alignment with STAR 2.6.1d)
- [ ] Standard pipeline tests pass without `--genome` (index built with current STAR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)