### PR TITLE
Update actions/upload-artifact from v3 to v7 in cloud test workflows

### DIFF
--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -36,9 +36,9 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (aws-${{ matrix.aligner }})
           path: tower_action_*.log
 
   run-full-tests-on-azure:
@@ -64,9 +64,9 @@ jobs:
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/",
                 "igenomes_base": "${{ secrets.TOWER_IGENOMES_BASE_AZURE }}"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (azure-${{ matrix.aligner }})
           path: tower_action_*.log
 
   run-full-tests-on-gcp:
@@ -91,7 +91,7 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (gcp-${{ matrix.aligner }})
           path: tower_action_*.log

--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -36,7 +36,7 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (aws-${{ matrix.aligner }})
           path: tower_action_*.log
@@ -64,7 +64,7 @@ jobs:
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/",
                 "igenomes_base": "${{ secrets.TOWER_IGENOMES_BASE_AZURE }}"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (azure-${{ matrix.aligner }})
           path: tower_action_*.log
@@ -91,7 +91,7 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (gcp-${{ matrix.aligner }})
           path: tower_action_*.log

--- a/.github/workflows/cloud_tests_small.yml
+++ b/.github/workflows/cloud_tests_small.yml
@@ -31,7 +31,7 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (aws)
           path: tower_action_*.log
@@ -53,7 +53,7 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (azure)
           path: tower_action_*.log
@@ -75,7 +75,7 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Tower debug log file (gcp)
           path: tower_action_*.log

--- a/.github/workflows/cloud_tests_small.yml
+++ b/.github/workflows/cloud_tests_small.yml
@@ -31,9 +31,9 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (aws)
           path: tower_action_*.log
 
   run-small-tests-on-azure:
@@ -53,9 +53,9 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (azure)
           path: tower_action_*.log
 
   run-small-tests-on-gcp:
@@ -75,7 +75,7 @@ jobs:
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: Tower debug log file
+          name: Tower debug log file (gcp)
           path: tower_action_*.log


### PR DESCRIPTION
## Summary

- Update `actions/upload-artifact` from deprecated v3 to v5 (pinned SHA `330a01c`) in `cloud_tests_full.yml` and `cloud_tests_small.yml`, matching the rest of the repo
- Use unique artifact names per job (e.g. `Tower debug log file (aws-star_salmon)`) since v4+ does not allow duplicate names across jobs

The v3 deprecation causes automatic workflow failures when dispatching full-size or small cloud tests.

## Test plan

- [ ] Dispatch `cloud_tests_small.yml` on AWS to verify the workflow runs without artifact upload errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)