### PR TITLE
Update ribodetector module to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Special thanks to the following for their contributions to the release:
 ### Enhancements and fixes
 
 - [PR #1740](https://github.com/nf-core/rnaseq/pull/1740) - Bump version to 3.24.0dev after release 3.23.0; always set ID/SM read group tags for STAR and HISAT2 even when `seq_center`/`seq_platform` are not provided
+- [PR #1744](https://github.com/nf-core/rnaseq/pull/1744) - Add `--skip_quantification_merge` for per-sample tximport and MultiQC at scale, with sample-centric output directory structure
 - [PR #1745](https://github.com/nf-core/rnaseq/pull/1745) - Always skip validation of `igenomes_base` and remove `format: directory-path` from schema to prevent S3 access errors
 - [PR #1746](https://github.com/nf-core/rnaseq/pull/1746) - Add `--contaminant_screening_input` to choose contaminant screening on trimmed/filter-passed reads or aligner-unmapped reads, keep `unmapped` as the default, and preserve stable sample IDs throughout the workflow
 - [PR #1749](https://github.com/nf-core/rnaseq/pull/1749) - Fix bowtie2 version extraction failing when Perl locale warnings are present (common in WSL/conda setups), which caused MultiQC to crash
@@ -29,12 +30,14 @@ Special thanks to the following for their contributions to the release:
 - [PR #1751](https://github.com/nf-core/rnaseq/pull/1751) - Clarify in docs that GFF files should be provided via `--gff`, not `--gtf` ([#1584](https://github.com/nf-core/rnaseq/issues/1584))
 - [PR #1752](https://github.com/nf-core/rnaseq/pull/1752) - Remove STAR from RSEM conda environments since STAR alignment runs as a separate process in this workflow, fixing ARM conda compatibility
 - [PR #1754](https://github.com/nf-core/rnaseq/pull/1754) - Add experimental RustQC support (`--use_rustqc`): high-performance single-pass replacement for dupRadar, featureCounts biotype QC, RSeQC, Preseq, Qualimap, and SAMtools stats/flagstat/idxstats.
+- [PR #1756](https://github.com/nf-core/rnaseq/pull/1756) - Fix iGenomes STAR version detection: replace filename heuristic with explicit check, remove unnecessary `STAR_GENOMEGENERATE_IGENOMES` build path
 - [PR #1761](https://github.com/nf-core/rnaseq/pull/1761) - Fix Bowtie2 alignment logs appearing under "Bowtie2 (rRNA removal)" in MultiQC report when using `--aligner bowtie2_salmon`
 - [PR #1762](https://github.com/nf-core/rnaseq/pull/1762) - Restore `extra_star_align_args` deduplication so user-supplied STAR flags override pipeline defaults instead of causing a fatal duplicate parameter error ([#1757](https://github.com/nf-core/rnaseq/issues/1757))
 - [PR #1763](https://github.com/nf-core/rnaseq/pull/1763) - Bump version to 3.24.0 ahead of release
 - [PR #1764](https://github.com/nf-core/rnaseq/pull/1764) - Update nf-core template to v3.5.2, update ro-crate maintainer
 - [PR #1766](https://github.com/nf-core/rnaseq/pull/1766) - Update samtools modules to 1.23.1, fixing conda CI snapshot mismatches
 - [PR #1769](https://github.com/nf-core/rnaseq/pull/1769) - Remove `--star` from RSEM preparereference test config, fixing conda CI failure after PR #1752 removed STAR from the RSEM environment
+- [PR #1768](https://github.com/nf-core/rnaseq/pull/1768) - Update `actions/upload-artifact` from deprecated v3 to v5 in cloud test workflows
 - [PR #1770](https://github.com/nf-core/rnaseq/pull/1770) - Exclude non-deterministic qualimap MultiQC files from snapshots, fixing x86/ARM cross-platform CI mismatches
 - [PR #1771](https://github.com/nf-core/rnaseq/pull/1771) - Update ribodetector module to 0.3.3 (nf-core/modules#11131)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1766](https://github.com/nf-core/rnaseq/pull/1766) - Update samtools modules to 1.23.1, fixing conda CI snapshot mismatches
 - [PR #1769](https://github.com/nf-core/rnaseq/pull/1769) - Remove `--star` from RSEM preparereference test config, fixing conda CI failure after PR #1752 removed STAR from the RSEM environment
 - [PR #1770](https://github.com/nf-core/rnaseq/pull/1770) - Exclude non-deterministic qualimap MultiQC files from snapshots, fixing x86/ARM cross-platform CI mismatches
+- [PR #1771](https://github.com/nf-core/rnaseq/pull/1771) - Update ribodetector module to 0.3.3 (nf-core/modules#11131)
 
 ## [[3.23.0](https://github.com/nf-core/rnaseq/releases/tag/3.23.0)] - 2026-02-27
 

--- a/modules.json
+++ b/modules.json
@@ -146,7 +146,7 @@
                     },
                     "ribodetector": {
                         "branch": "master",
-                        "git_sha": "5cb9a8694da0a0e550921636bb60bc8c56445fd7",
+                        "git_sha": "278c4ebdaa1c51fa0dc1b09be0da2b53962a87f5",
                         "installed_by": ["fastq_remove_rrna"]
                     },
                     "rsem/calculateexpression": {

--- a/modules/nf-core/ribodetector/environment.yml
+++ b/modules/nf-core/ribodetector/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::ribodetector=0.3.2"
+  - "bioconda::ribodetector=0.3.3"

--- a/modules/nf-core/ribodetector/main.nf
+++ b/modules/nf-core/ribodetector/main.nf
@@ -4,8 +4,8 @@ process RIBODETECTOR {
 
 	conda "${moduleDir}/environment.yml"
 	container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4d/4de8fe74d21198e6fc8218cb3209d929b3d7dab750678501b096b0ccc324307b/data' :
-        'community.wave.seqera.io/library/ribodetector:0.3.2--cbe1c77fa14eeb53' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data' :
+        'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502' }"
 
 	input:
 	tuple val(meta), path(fastq)

--- a/modules/nf-core/ribodetector/tests/main.nf.test.snap
+++ b/modules/nf-core/ribodetector/tests/main.nf.test.snap
@@ -6,16 +6,16 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-11-29T21:25:27.269196"
+        "timestamp": "2026-04-08T08:49:28.027509457"
     },
     "ribodetector - stub rnaseq PE input": {
         "content": [
@@ -45,7 +45,7 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ],
                 "fastq": [
@@ -73,15 +73,15 @@
                     [
                         "RIBODETECTOR",
                         "ribodetector",
-                        "0.3.2"
+                        "0.3.3"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.10.3"
         },
-        "timestamp": "2025-11-29T21:44:20.650130249"
+        "timestamp": "2026-04-08T08:49:35.087539868"
     }
 }


### PR DESCRIPTION
## Summary
- Update ribodetector module from 0.3.2 to 0.3.3 via `nf-core modules update`
- Upstream: nf-core/modules#11131
- Also adds missing changelog entries for PRs #1744, #1756, #1768 that were merged but not recorded

## Test plan
- [ ] CI passes with updated module

🤖 Generated with [Claude Code](https://claude.com/claude-code)