### PR TITLE
Fix MultiQC collapsing `_1`/`_2` sample IDs into one General Stats row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1784](https://github.com/nf-core/rnaseq/pull/1784) - Replace local `gtf2bed` module with nf-core `ea-utils/gtf2bed` module
 - [PR #1786](https://github.com/nf-core/rnaseq/pull/1786) - Replace local `bam_post_alignment_qc` subworkflow and `multiqc_custom_biotype` module with nf-core `bam_qc_rnaseq` subworkflow and `custom/multiqccustombiotype` module; update `dupradar` to topic-based version reporting
 - [PR #1790](https://github.com/nf-core/rnaseq/pull/1790) - Add `--use_gpu_ribodetector` parameter for GPU-accelerated rRNA removal with ribodetector; update ribodetector module to dual-container approach (x86 only); generalize GPU CI skip from `SKIP_PARABRICKS` to `SKIP_GPU`
+- Rename per-read FASTQ names passed to MultiQC using `_R1`/`_R2` instead of `_1`/`_2`, and restrict `table_sample_merge` to suffixes containing a literal `R`/`r`, so samplesheets with sample IDs like `foo_1` / `foo_2` are no longer incorrectly collapsed into a single `foo` row in the General Statistics table
 
 ## [[3.24.0](https://github.com/nf-core/rnaseq/releases/tag/3.24.0)] - 2026-04-09
 

--- a/workflows/rnaseq/assets/multiqc/multiqc_config.yml
+++ b/workflows/rnaseq/assets/multiqc/multiqc_config.yml
@@ -93,18 +93,23 @@ sample_names_replace_exact: true
 use_filename_as_sample_name:
   - sortmerna
 
-# Group paired-end reads together in the general stats table
+# Group paired-end reads together in the general stats table.
+#
+# Only match suffixes that unambiguously indicate a read-pair (i.e. require a
+# literal 'R'/'r' letter). Plain '_1'/'_2' is excluded on purpose so that
+# samplesheets containing sample IDs like 'foo_1' and 'foo_2' aren't
+# incorrectly collapsed into a single row. The pipeline renames per-read
+# inputs to '<sample>_R1' / '<sample>_R2' in workflows/rnaseq/main.nf so
+# that FastQC and friends still group correctly through this config.
 table_sample_merge:
   "Read 1":
-    - "_1"
     - "_R1"
     - type: regex
-      pattern: "[_.-][rR]?1$"
+      pattern: "[_.-][rR]1$"
   "Read 2":
-    - "_2"
     - "_R2"
     - type: regex
-      pattern: "[_.-][rR]?2$"
+      pattern: "[_.-][rR]2$"
 
 # Run only these modules
 run_modules:

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -802,16 +802,24 @@ workflow RNASEQ {
         // Two classes of mappings are emitted:
         //   1. The original FASTQ simpleName (e.g. 'SRR123_1') → '<id>_R1'
         //      — catches tools whose outputs keep the input FASTQ basename
-        //      (see #1657). We only add this when the simpleName differs
+        //      (see #1341). We only add this when the simpleName differs
         //      from the sample ID, to avoid conflicting mappings for
-        //      samples that share FASTQ filenames across directories.
+        //      samples that share FASTQ filenames across directories
+        //      (see #1659).
         //   2. For paired-end samples, '<id>_1' → '<id>_R1' and
         //      '<id>_2' → '<id>_R2' — catches tools like FastQC whose
         //      nf-core module renames inputs to '<prefix>_1.fastq.gz' /
         //      '<prefix>_2.fastq.gz' so MultiQC's cleaned sample name
-        //      comes out as '<id>_1' / '<id>_2'.
+        //      comes out as '<id>_1' / '<id>_2'. Skipped when the
+        //      samplesheet contains another sample whose ID literally
+        //      equals '<id>_1' or '<id>_2', mirroring the #1659 guard:
+        //      without this check we'd also rename that unrelated
+        //      sample's rows.
         //
         // Note: _raw/_trimmed suffixes are handled via extra_fn_clean_exts in multiqc_config.yml
+        def mqc_all_sample_ids = samplesheetToList(params.input, "${projectDir}/assets/schema_input.json")
+            .collect { row -> row[0].id as String } as Set
+
         ch_name_replacements = ch_fastq
             .map{ meta, reads ->
                 def paired = reads[0][1] as boolean
@@ -827,8 +835,14 @@ workflow RNASEQ {
                 }
 
                 if (paired) {
-                    mappings << ["${meta.id}_1", "${meta.id}_R1"]
-                    mappings << ["${meta.id}_2", "${meta.id}_R2"]
+                    def pe_r1_src = "${meta.id}_1" as String
+                    def pe_r2_src = "${meta.id}_2" as String
+                    if (!mqc_all_sample_ids.contains(pe_r1_src)) {
+                        mappings << [pe_r1_src, "${meta.id}_R1"]
+                    }
+                    if (!mqc_all_sample_ids.contains(pe_r2_src)) {
+                        mappings << [pe_r2_src, "${meta.id}_R2"]
+                    }
                 }
 
                 return mappings.collect { mapping -> mapping.join('\t') }

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -792,18 +792,24 @@ workflow RNASEQ {
             .mix(ch_collated_versions.map  { file -> [[:], file] })
             .mix(ch_methods_description.map{ file -> [[:], file] })
 
-        // Provide MultiQC with rename patterns to ensure it uses sample names
-        // for single-techrep samples not processed by CAT_FASTQ.
-        //
-        // We only add mappings when the FASTQ simpleName differs from the sample ID.
-        // This prevents duplicate/conflicting mappings when multiple samples share
-        // the same FASTQ filename in different directories (see #1657).
-        //
-        // For paired-end samples we append '_R1' / '_R2' (not '_1' / '_2') so
-        // that MultiQC's table_sample_merge regex (which requires a literal
-        // 'R'/'r' letter) groups the two reads together in the General Stats
-        // table, while sample IDs that naturally end with '_1' / '_2' pass
+        // Provide MultiQC with rename patterns so paired-end reads are
+        // recognised as '_R1' / '_R2' instead of '_1' / '_2'. This lets
+        // MultiQC's table_sample_merge regex (which requires a literal
+        // 'R'/'r' letter) group the two reads in the General Stats table,
+        // while samplesheet IDs that naturally end with '_1' / '_2' pass
         // through untouched and don't get incorrectly collapsed.
+        //
+        // Two classes of mappings are emitted:
+        //   1. The original FASTQ simpleName (e.g. 'SRR123_1') → '<id>_R1'
+        //      — catches tools whose outputs keep the input FASTQ basename
+        //      (see #1657). We only add this when the simpleName differs
+        //      from the sample ID, to avoid conflicting mappings for
+        //      samples that share FASTQ filenames across directories.
+        //   2. For paired-end samples, '<id>_1' → '<id>_R1' and
+        //      '<id>_2' → '<id>_R2' — catches tools like FastQC whose
+        //      nf-core module renames inputs to '<prefix>_1.fastq.gz' /
+        //      '<prefix>_2.fastq.gz' so MultiQC's cleaned sample name
+        //      comes out as '<id>_1' / '<id>_2'.
         //
         // Note: _raw/_trimmed suffixes are handled via extra_fn_clean_exts in multiqc_config.yml
         ch_name_replacements = ch_fastq
@@ -818,6 +824,11 @@ workflow RNASEQ {
                     if (paired) {
                         mappings << [file(reads[0][1]).simpleName, "${meta.id}${suffixes[1]}"]
                     }
+                }
+
+                if (paired) {
+                    mappings << ["${meta.id}_1", "${meta.id}_R1"]
+                    mappings << ["${meta.id}_2", "${meta.id}_R2"]
                 }
 
                 return mappings.collect { mapping -> mapping.join('\t') }

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -767,6 +767,9 @@ workflow RNASEQ {
         def mqc_custom_config  = params.multiqc_config ? file(params.multiqc_config, checkIfExists: true) : []
         def mqc_logo           = params.multiqc_logo   ? file(params.multiqc_logo, checkIfExists: true)   : []
 
+        // Build the MultiQC config list (default + optional custom)
+        def mqc_config_files = mqc_custom_config ? [mqc_default_config, mqc_custom_config] : [mqc_default_config]
+
         // Prepare the workflow summary
         ch_workflow_summary = channel.value(
             paramsSummaryMultiqc(
@@ -796,11 +799,17 @@ workflow RNASEQ {
         // This prevents duplicate/conflicting mappings when multiple samples share
         // the same FASTQ filename in different directories (see #1657).
         //
+        // For paired-end samples we append '_R1' / '_R2' (not '_1' / '_2') so
+        // that MultiQC's table_sample_merge regex (which requires a literal
+        // 'R'/'r' letter) groups the two reads together in the General Stats
+        // table, while sample IDs that naturally end with '_1' / '_2' pass
+        // through untouched and don't get incorrectly collapsed.
+        //
         // Note: _raw/_trimmed suffixes are handled via extra_fn_clean_exts in multiqc_config.yml
         ch_name_replacements = ch_fastq
             .map{ meta, reads ->
                 def paired = reads[0][1] as boolean
-                def suffixes = paired ? ['_1', '_2'] : ['']
+                def suffixes = paired ? ['_R1', '_R2'] : ['']
                 def mappings = []
 
                 def fastq1_simplename = file(reads[0][0]).simpleName
@@ -816,9 +825,6 @@ workflow RNASEQ {
             .flatten()
             .collectFile(name: 'name_replacement.txt', newLine: true)
             .ifEmpty([])
-
-        // Build the MultiQC config list (default + optional custom)
-        def mqc_config_files = mqc_custom_config ? [mqc_default_config, mqc_custom_config] : [mqc_default_config]
 
         if (params.skip_quantification_merge) {
             //


### PR DESCRIPTION
## Summary

Users who name samples with `_1`/`_2` (or `.1`, `-2`, etc.) suffixes were having their rows incorrectly collapsed in the MultiQC General Statistics table. MultiQC's `table_sample_merge` was configured with a broad regex (`[_.-][rR]?[12]$`) that treated any sample name ending in these patterns as a read-pair indicator, merging unrelated samples into a single row.

This PR narrows the merge behavior to only match suffixes that actually contain a literal `R`/`r` letter, and adjusts the pipeline's internal rename to emit `<sample>_R1`/`<sample>_R2` (instead of `<sample>_1`/`<sample>_2`) for paired-end reads so MultiQC still groups R1/R2 rows correctly.

## Impact for users who weren't hitting the bug

The only visible change is that read-specific entries in per-module sections (FastQC raw/trimmed/filtered, cutadapt, etc.) are labelled `<sample>_R1` / `<sample>_R2` instead of `<sample>_1` / `<sample>_2`. Specifically:

- **General Statistics table**: unchanged — still one collapsed row per sample with Read 1 / Read 2 values merged in.
- **Per-module sections**: row labels shift from `<sample>_1`/`<sample>_2` to `<sample>_R1`/`<sample>_R2`.
- **File paths on disk**: unchanged. FastQC still writes `<sample>_raw_1_fastqc.zip` / `<sample>_raw_2_fastqc.zip`; only MultiQC's internal sample name (via `--replace-names`) is different.
- **Snapshots**: md5s of a handful of `multiqc_fastqc_*.txt` files change because their sample-name cells now contain `_R1`/`_R2` instead of `_1`/`_2` (see "Snapshot updates" below).

## Changes
- `workflows/rnaseq/assets/multiqc/multiqc_config.yml`: `table_sample_merge` regex narrowed to `[_.-][rR][12]$`; plain `_1`/`_2` entries dropped from the suffix lists.
- `workflows/rnaseq/main.nf`: per-read rename now uses `_R1`/`_R2` suffixes, and additionally maps `<id>_1`→`<id>_R1` / `<id>_2`→`<id>_R2` for PE samples so that MultiQC still collapses FastQC/cutadapt R1 & R2 rows (which come out as `<id>_1`/`<id>_2` after the nf-core FastQC module rename + `extra_fn_clean_exts`).
- `CHANGELOG.md`: note added.

## Test plan

Verified on an EC2 VM with two samplesheets and the standard `test,docker` profile (full pipeline run, no `skip_*` flags):

Samplesheet with problematic names (`sample_1`, `sample_2`, `gene_1`, `gene_2`, `foo.1`, `bar-2`, `multi_tech_1` with techreps + clean `CTRL_REP1`/`CTRL_REP2`):
- PE `sample_1`, `sample_2`, `multi_tech_1`: single collapsed General Stats row with Read 1/Read 2 sub-rows. ✅
- SE `gene_1`, `gene_2`, `foo.1`, `bar-2`: each shown as their own row, never collapsed. ✅
- FastQC tables show `<id>_R1`/`<id>_R2` for PE samples and clean names for SE. ✅

Default `test.config` samplesheet (`WT_REP1`, `WT_REP2`, `RAP1_*`) regression check:
- PE samples: grouped correctly with `_R1`/`_R2` suffixes in individual sections, single row in General Stats.
- SE samples: unchanged.

### Known limitations
- Sample IDs that end with a literal `_R1`/`_R2`/`.R1`/`-r2` etc. will still be stripped by the narrowed regex (e.g. two SE samples `beta_R1` and `beta_R2` would still be grouped under `beta`). This is a much narrower edge case than the user-reported `_1`/`_2` problem.
- A samplesheet that contains both a PE sample `X` and an SE sample `X_1` is inherently ambiguous — the rename `X_1`→`X_R1` would collide with PE X's R1 data. MultiQC handles this gracefully but the result is not meaningful.

### Snapshot updates
Because MultiQC now sees `<id>_R1`/`<id>_R2` where it previously saw `<id>_1`/`<id>_2`, the md5s of several `multiqc_fastqc_fastqc_raw.txt` and `multiqc_fastqc_fastqc_trimmed.txt` entries in `tests/*.nf.test.snap` will change. Happy to push snapshot updates as a follow-up commit once the approach is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)