### PR TITLE
Bump custom/multiqccustombiotype to fail loudly on high biotype cardinality

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -47,7 +47,7 @@
                     },
                     "custom/multiqccustombiotype": {
                         "branch": "master",
-                        "git_sha": "76f0d65e94ce2f8944d94f4fb4cd9f5e4c9ad5cf",
+                        "git_sha": "18201f1a7d84a64affdaf699a3362ed138442222",
                         "installed_by": ["bam_qc_rnaseq"]
                     },
                     "custom/rsemmergecounts": {

--- a/modules/nf-core/custom/multiqccustombiotype/environment.yml
+++ b/modules/nf-core/custom/multiqccustombiotype/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python=3.12.2
+  - conda-forge::python=3.12.12

--- a/modules/nf-core/custom/multiqccustombiotype/main.nf
+++ b/modules/nf-core/custom/multiqccustombiotype/main.nf
@@ -4,15 +4,15 @@ process CUSTOM_MULTIQCCUSTOMBIOTYPE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.12' :
-        'biocontainers/python:3.12' }"
+        'https://depot.galaxyproject.org/singularity/python:3.12.12' :
+        'biocontainers/python:3.12.12' }"
 
     input:
     tuple val(meta), path(count)
     tuple val(meta2), path(header)
 
     output:
-    tuple val(meta), path("*biotype_counts_mqc.tsv")     , emit: tsv
+    tuple val(meta), path("*biotype_counts_mqc.tsv")      , emit: tsv
     tuple val(meta), path("*biotype_counts_rrna_mqc.tsv") , emit: rrna
     path "versions.yml"                                   , emit: versions, topic: versions
 

--- a/modules/nf-core/custom/multiqccustombiotype/meta.yml
+++ b/modules/nf-core/custom/multiqccustombiotype/meta.yml
@@ -42,7 +42,11 @@ output:
             Groovy Map containing sample information
       - "*biotype_counts_mqc.tsv":
           type: file
-          description: Biotype counts formatted for MultiQC
+          description: |
+            Biotype counts formatted for MultiQC. The process fails if the
+            number of biotype rows exceeds the threshold passed via
+            `ext.args = '--max_biotypes N'` (default 100), since MultiQC
+            cannot render a bar plot with that many categories.
           pattern: "*biotype_counts_mqc.tsv"
           ontologies: []
   rrna:

--- a/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
+++ b/modules/nf-core/custom/multiqccustombiotype/templates/mqc_features_stat.py
@@ -6,9 +6,12 @@
 # Written by Senthilkumar Panneerselvam and released under the MIT license.
 # Adapted for nf-core/modules by Jonathan Manning.
 
+import argparse
 import logging
 import os
 import platform
+import shlex
+import sys
 
 # Create a logger
 logging.basicConfig(format="%(name)s - %(asctime)s %(levelname)s: %(message)s")
@@ -22,6 +25,26 @@ prefix = "${task.ext.prefix}" if "${task.ext.prefix}" != "null" else "${meta.id}
 sample_name = "${meta.id}"
 
 
+def parse_ext_args(args_string):
+    """Parse arguments supplied via Nextflow's ext.args."""
+    if args_string in (None, "", "null"):
+        args_string = ""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--max_biotypes",
+        type=int,
+        default=100,
+        help="Maximum number of biotype rows to write to the MultiQC TSV. "
+        "Above this, the TSV is dropped so MultiQC does not try to plot a "
+        "category per gene.",
+    )
+    return parser.parse_args(shlex.split(args_string))
+
+
+ext_args = parse_ext_args("${task.ext.args}")
+max_biotypes = ext_args.max_biotypes
+
+
 def prepare_biotype_counts(count_file, header_file, prefix):
     """Cut gene ID and count columns from featureCounts output, prepend header."""
     outfile = f"{prefix}.biotype_counts_mqc.tsv"
@@ -32,14 +55,16 @@ def prepare_biotype_counts(count_file, header_file, prefix):
     with open(count_file) as cf:
         lines = cf.readlines()[2:]  # skip featureCounts header lines
 
+    n_rows = 0
     with open(outfile, "w") as of:
         of.write(header)
         for line in lines:
             fields = line.strip().split("\\t")
             if len(fields) >= 7:
                 of.write(f"{fields[0]}\\t{fields[6]}\\n")
+                n_rows += 1
 
-    return outfile
+    return outfile, n_rows
 
 
 mqc_main = """#id: 'biotype-gs'
@@ -97,9 +122,26 @@ def mqc_feature_stat(bfile, features, outfile, sname=None):
 
 if __name__ == "__main__":
     # Step 1: Prepare biotype counts TSV from featureCounts output
-    biotype_file = prepare_biotype_counts(count_file, header_file, prefix)
+    biotype_file, n_biotypes = prepare_biotype_counts(count_file, header_file, prefix)
 
-    # Step 2: Calculate rRNA percentage for MultiQC general stats
+    # Step 2: Fail loudly if the first column of the featureCounts output has
+    # too many unique values. MultiQC cannot render a bar plot with thousands
+    # of categories, so a high-cardinality group attribute (e.g. a per-gene
+    # identifier) passed to `featureCounts -g` is almost certainly a config
+    # mistake upstream.
+    if n_biotypes > max_biotypes:
+        logger.error(
+            f"Too many categories in '{count_file}': {n_biotypes} > "
+            f"--max_biotypes={max_biotypes}. Column 1 of this file reflects "
+            "the attribute passed to `featureCounts -g`; if a high-cardinality "
+            "attribute was used (e.g. a per-gene identifier), MultiQC cannot "
+            "plot it. Re-run featureCounts with a lower-cardinality attribute "
+            "(e.g. gene_biotype, gene_type), or raise the limit via "
+            "`ext.args = '--max_biotypes N'` if this is expected."
+        )
+        sys.exit(1)
+
+    # Step 3: Calculate rRNA percentage for MultiQC general stats
     mqc_feature_stat(
         biotype_file,
         ["rRNA"],

--- a/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test
+++ b/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test
@@ -48,6 +48,84 @@ nextflow_process {
         }
     }
 
+    test("featurecounts biotype counts - too many biotypes fails") {
+
+        when {
+            process {
+                """
+                def count_file = file("\${workDir}/too_many.featureCounts.txt")
+                def lines = [
+                    '# Program:featureCounts v2.0.1',
+                    'Geneid\tChr\tStart\tEnd\tStrand\tLength\ttest'
+                ]
+                (1..150).each { i ->
+                    lines << "biotype_\${i}\tchr1\t\${i * 1000}\t\${i * 1000 + 500}\t+\t500\t\${i}"
+                }
+                count_file.text = lines.join('\\n') + '\\n'
+
+                def header_file = file("\${workDir}/biotypes_header.txt")
+                header_file.text = [
+                    "# id: 'biotype_counts'",
+                    "# section_name: 'Biotype Counts'",
+                    "# description: 'shows reads overlapping genomic features of different biotypes'",
+                    "# plot_type: 'bargraph'",
+                    "# anchor: 'featurecounts_biotype'",
+                ].join('\\n') + '\\n'
+
+                input[0] = channel.of([ [ id:'test' ], count_file ])
+                input[1] = channel.of([ [:], header_file ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains('Too many categories') }
+            )
+        }
+    }
+
+    test("featurecounts biotype counts - custom max_biotypes via ext fails") {
+
+        config "./nextflow.config"
+
+        when {
+            process {
+                """
+                def count_file = file("\${workDir}/test.featureCounts.txt")
+                count_file.text = [
+                    '# Program:featureCounts v2.0.1',
+                    'Geneid\tChr\tStart\tEnd\tStrand\tLength\ttest',
+                    'protein_coding\tchr1\t1\t1000\t+\t1000\t5000',
+                    'rRNA\tchr1\t2000\t3000\t+\t1000\t500',
+                    'lincRNA\tchr1\t4000\t5000\t+\t1000\t200',
+                    'miRNA\tchr1\t6000\t7000\t+\t1000\t100'
+                ].join('\\n') + '\\n'
+
+                def header_file = file("\${workDir}/biotypes_header.txt")
+                header_file.text = [
+                    "# id: 'biotype_counts'",
+                    "# section_name: 'Biotype Counts'",
+                    "# description: 'shows reads overlapping genomic features of different biotypes'",
+                    "# plot_type: 'bargraph'",
+                    "# anchor: 'featurecounts_biotype'",
+                ].join('\\n') + '\\n'
+
+                input[0] = channel.of([ [ id:'test' ], count_file ])
+                input[1] = channel.of([ [:], header_file ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.failed },
+                { assert process.errorReport.contains('Too many categories') }
+            )
+        }
+    }
+
     test("featurecounts biotype counts - stub") {
 
         options "-stub"

--- a/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/multiqccustombiotype/tests/main.nf.test.snap
@@ -19,7 +19,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,5b1127473a5d4657f663101a8fd1f737"
+                    "versions.yml:md5,3cc6da489a0fecd2df301e36514b8817"
                 ],
                 "rrna": [
                     [
@@ -38,15 +38,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,5b1127473a5d4657f663101a8fd1f737"
+                    "versions.yml:md5,3cc6da489a0fecd2df301e36514b8817"
                 ]
             }
         ],
-        "timestamp": "2026-04-10T12:08:00.66332716",
         "meta": {
-            "nf-test": "0.9.5",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-17T10:51:13.066694"
     },
     "featurecounts biotype counts": {
         "content": [
@@ -68,7 +68,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,fa9a9f9b8abe32a9411e5fa5c3a65b83"
+                    "versions.yml:md5,3cc6da489a0fecd2df301e36514b8817"
                 ],
                 "rrna": [
                     [
@@ -87,14 +87,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,fa9a9f9b8abe32a9411e5fa5c3a65b83"
+                    "versions.yml:md5,3cc6da489a0fecd2df301e36514b8817"
                 ]
             }
         ],
-        "timestamp": "2026-04-10T12:07:55.638491947",
         "meta": {
-            "nf-test": "0.9.5",
+            "nf-test": "0.9.3",
             "nextflow": "25.10.4"
-        }
+        },
+        "timestamp": "2026-04-17T10:50:58.059883"
     }
 }

--- a/modules/nf-core/custom/multiqccustombiotype/tests/nextflow.config
+++ b/modules/nf-core/custom/multiqccustombiotype/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'CUSTOM_MULTIQCCUSTOMBIOTYPE' {
+        ext.args = '--max_biotypes 2'
+    }
+}


### PR DESCRIPTION
## Summary

Updates `custom/multiqccustombiotype` to the version merged in [nf-core/modules#11212](https://github.com/nf-core/modules/pull/11212).

The module now fails loudly (rather than hanging MultiQC) when the featureCounts output has more unique biotype categories than `--max_biotypes` (default 100). This catches the common misconfiguration where `--featurecounts_group_type` is pointed at a per-gene identifier instead of a biotype attribute, which used to produce an unplottable MultiQC bar chart.

Closes #424.

### Notes

- No pipeline-side code changes are needed - default `gene_biotype` cardinality is well under 100, so the check is transparent for normal runs.
- Users who deliberately run with a high-cardinality group attribute can raise the limit with `ext.args = '--max_biotypes N'` scoped to `CUSTOM_MULTIQCCUSTOMBIOTYPE`.
- Module also pins `python:3.12.12` (conda + both containers) so `versions.yml` no longer drifts with the mutable `:3.12` tag.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Module updated via `nf-core modules install --force`; `modules.json` `git_sha` bumped.
- [x] `CHANGELOG.md` updated.