### PR TITLE
fix(prokaryotic): skip StringTie by default in the prokaryotic profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1795](https://github.com/nf-core/rnaseq/pull/1795) - Bump `custom/multiqccustombiotype` to fail loudly when the featureCounts output exceeds `--max_biotypes` (default 100), catching misconfigured `--featurecounts_group_type` values that previously hung MultiQC ([#424](https://github.com/nf-core/rnaseq/issues/424))
 - [PR #1796](https://github.com/nf-core/rnaseq/pull/1796) - Clarify prokaryotic profile docs: transcripts are extracted from all transcript-like features (CDS, tRNA, rRNA, tmRNA, ncRNA, etc.), not only CDS; CDS is only required for featureCounts biotype QC
 - [PR #1755](https://github.com/nf-core/rnaseq/pull/1755) - When `--stringtie_ignore_gtf` is set, switch to StringTie's recommended de novo workflow: per-sample assembly into `<sample>.denovo.transcripts.gtf`, cross-sample merge into `stringtie_merge.gtf`, then re-quantification against the merged annotation. Previously this path ran transcript discovery and quantification in a single pass per sample, producing outputs that were not comparable across samples
+- Skip StringTie by default in the `prokaryotic` profile. StringTie is a splice-aware transcript assembler and does not apply to prokaryotes; for the `bowtie2_salmon` aligner the "genome" BAM is actually transcriptome-aligned, so StringTie output would be meaningless regardless. Users can still opt back in with `--skip_stringtie false`
 
 ## [[3.24.0](https://github.com/nf-core/rnaseq/releases/tag/3.24.0)] - 2026-04-09
 

--- a/conf/prokaryotic.config
+++ b/conf/prokaryotic.config
@@ -35,4 +35,10 @@ params {
 
     // Skip bigWig generation (Bowtie2 aligns to transcriptome, not genome)
     skip_bigwig   = true
+
+    // Skip StringTie: it is a splice-aware transcript assembler and does not
+    // apply to prokaryotes, which lack introns. For the bowtie2_salmon aligner
+    // the "genome" BAM is actually transcriptome-aligned, so StringTie output
+    // would be meaningless regardless.
+    skip_stringtie = true
 }


### PR DESCRIPTION
## Summary

Reported on Slack by Weisheng Wu: the prokaryotic profile still produces a `stringtie/` folder under the `bowtie2_salmon` output directory, even though StringTie's output is not biologically meaningful for prokaryotic data.

Two reasons StringTie does not belong here:

1. **StringTie is a splice-aware transcript assembler.** Prokaryotes do not have introns, so there is nothing for StringTie to assemble.
2. **The input BAM is transcriptome-aligned, not genome-aligned.** For the `bowtie2_salmon` aligner the channel labelled `ch_genome_bam` is actually Bowtie2's transcriptome alignment (see the comment at `workflows/rnaseq/main.nf:336`). Feeding that into StringTie, which expects genomic coordinates with splice junctions, is doubly wrong.

Thomas Danhorn confirmed in the Slack thread that StringTie does not make sense for bacteria.

## Changes

- Set `skip_stringtie = true` in `conf/prokaryotic.config` (alongside `skip_rseqc`, `skip_dupradar`, `skip_qualimap`, `skip_bigwig`), with a comment explaining why.
- CHANGELOG entry.

Users can still opt back in with `--skip_stringtie false` if they have a reason.

## Related

Draft PRs also going up for the two other issues Weisheng raised on the same thread:
- Salmon-inferred strandedness not visible in MultiQC when `skip_rseqc` is set
- Bowtie2 reporting a single best alignment defeats Salmon's EM for reads mapping to overlapping CDS

## Test plan

- [ ] Run the prokaryotic test profile and confirm no `stringtie/` folder is produced
- [ ] Confirm setting `--skip_stringtie false` still runs StringTie (opt-in restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)