### PR TITLE
chore: sync nf-core components and retire ch_versions plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1806](https://github.com/nf-core/rnaseq/pull/1806) - Pass `-k 200` to Bowtie2 by default when using `--aligner bowtie2_salmon` so downstream Salmon EM can redistribute multimapping reads; override via `--extra_bowtie2_align_args "-k N"`
 - [PR #1811](https://github.com/nf-core/rnaseq/pull/1811) - Default `--ribo_database_manifest` moves to SortMeRNA's SILVA 138 `smr_v4.3_fast_db`; other variants documented as opt-in. Closes [#1354](https://github.com/nf-core/rnaseq/issues/1354), enabled by [sortmerna/sortmerna#458](https://github.com/sortmerna/sortmerna/issues/458)
 - [PR #1812](https://github.com/nf-core/rnaseq/pull/1812) - Narrow the pipeline-level test matrix by adding `--skip_pseudo_alignment` to aligner-focused tests (HISAT2, STAR-RSEM, UMI, Parabricks, Sentieon), merging `skip_quantification_merge` into the Salmon test file, and folding `min_mapped_reads` into `skip_qc` as a single `--skip_qc --min_mapped_reads 90` case so both filters are exercised in one run
+- [PR #1814](https://github.com/nf-core/rnaseq/pull/1814) - Sync `fq/lint`, `ribodetector`, `tximeta/tximport`, `fastq_fastqc_umitools_trimgalore`, and `custom/catadditionalfasta` with their latest upstream versions; migrate the last local module (`deseq2_qc`) to topic-based version emission and retire the now-redundant `ch_versions` plumbing across `main.nf`, `workflows/rnaseq`, and `subworkflows/local/prepare_genome`
 
 ## [[3.24.0](https://github.com/nf-core/rnaseq/releases/tag/3.24.0)] - 2026-04-09
 

--- a/conf/modules/prepare_genome.config
+++ b/conf/modules/prepare_genome.config
@@ -114,7 +114,16 @@ process {
         ]
     }
 
-    withName: 'CAT_ADDITIONAL_FASTA|PREPROCESS_TRANSCRIPTS_FASTA_GENCODE' {
+    withName: 'CUSTOM_CATADDITIONALFASTA' {
+        ext.prefix = { "${params.genome ?: fasta.baseName}_${add_fasta.baseName}" }
+        publishDir = [
+            path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+        ]
+    }
+
+    withName: 'PREPROCESS_TRANSCRIPTS_FASTA_GENCODE' {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,

--- a/main.nf
+++ b/main.nf
@@ -56,8 +56,6 @@ workflow NFCORE_RNASEQ {
 
     main:
 
-    ch_versions = channel.empty()
-
     //
     // SUBWORKFLOW: Prepare reference genome files
     //
@@ -94,7 +92,6 @@ workflow NFCORE_RNASEQ {
         params.use_parabricks_star,
         params.contaminant_screening
     )
-    ch_versions = ch_versions.mix(PREPARE_GENOME.out.versions)
 
     // Check if contigs in genome fasta file > 512 Mbp
     if (!params.skip_alignment && !params.bam_csi_index) {
@@ -117,7 +114,6 @@ workflow NFCORE_RNASEQ {
 
     RNASEQ (
         ch_samplesheet,
-        ch_versions,
         PREPARE_GENOME.out.fasta,
         PREPARE_GENOME.out.gtf,
         PREPARE_GENOME.out.fai,
@@ -138,14 +134,12 @@ workflow NFCORE_RNASEQ {
         PREPARE_GENOME.out.kraken_db,
         qc_tools
     )
-    ch_versions = ch_versions.mix(RNASEQ.out.versions)
 
     emit:
     trim_status    = RNASEQ.out.trim_status    // channel: [id, boolean]
     map_status     = RNASEQ.out.map_status     // channel: [id, boolean]
     strand_status  = RNASEQ.out.strand_status  // channel: [id, boolean]
     multiqc_report = RNASEQ.out.multiqc_report // channel: /path/to/multiqc_report.html
-    versions       = ch_versions               // channel: [version1, version2, ...]
 }
 
 /*

--- a/modules.json
+++ b/modules.json
@@ -37,7 +37,7 @@
                     },
                     "custom/catadditionalfasta": {
                         "branch": "master",
-                        "git_sha": "96c57dfd98a0641886a67bd449fe33ee2ec0e374",
+                        "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
                         "installed_by": ["modules"]
                     },
                     "custom/gtffilter": {
@@ -86,7 +86,7 @@
                     },
                     "fq/lint": {
                         "branch": "master",
-                        "git_sha": "14b8e6cceb84242e16094fe979762e05bc8de526",
+                        "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
                         "installed_by": ["fastq_qc_trim_filter_setstrandedness", "modules"]
                     },
                     "fq/subsample": {
@@ -161,7 +161,7 @@
                     },
                     "ribodetector": {
                         "branch": "master",
-                        "git_sha": "20423f58f6ff54c4bc851dfd143d75f9b9f86f41",
+                        "git_sha": "fbfb84479283933dae1ba16df948ac04c0a49549",
                         "installed_by": ["fastq_remove_rrna"]
                     },
                     "rsem/calculateexpression": {
@@ -354,7 +354,7 @@
                     },
                     "tximeta/tximport": {
                         "branch": "master",
-                        "git_sha": "a6c47e72998bd959036602ccd15171103c89111f",
+                        "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
                         "installed_by": ["quant_tximport_summarizedexperiment", "quantify_pseudo_alignment"]
                     },
                     "ucsc/bedclip": {
@@ -463,7 +463,7 @@
                     },
                     "fastq_fastqc_umitools_trimgalore": {
                         "branch": "master",
-                        "git_sha": "8f2ec534d0418bf724cfd5f053176a9c500fae78",
+                        "git_sha": "e5777ea46cc591b519b9bb931e952e4a149cb47d",
                         "installed_by": ["fastq_qc_trim_filter_setstrandedness", "subworkflows"]
                     },
                     "fastq_qc_trim_filter_setstrandedness": {

--- a/modules/local/deseq2_qc/main.nf
+++ b/modules/local/deseq2_qc/main.nf
@@ -22,7 +22,8 @@ process DESEQ2_QC {
     path "*sample.dists_mqc.tsv", optional:true, emit: dists_multiqc
     path "*.log"                , optional:true, emit: log
     path "size_factors"         , optional:true, emit: size_factors
-    path "versions.yml"         , emit: versions
+    tuple val("${task.process}"), val('r-base'), eval("Rscript -e 'cat(as.character(getRversion()))'"), topic: versions
+    tuple val("${task.process}"), val('bioconductor-deseq2'), eval("Rscript -e \"library(DESeq2); cat(as.character(packageVersion('DESeq2')))\""), topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -54,12 +55,6 @@ process DESEQ2_QC {
         cat clustering_header.tmp *.sample.dists.txt > ${label_lower}.sample.dists_mqc.tsv
         rm clustering_header.tmp
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        r-base: \$(echo \$(R --version 2>&1) | sed 's/^.*R version //; s/ .*\$//')
-        bioconductor-deseq2: \$(Rscript -e "library(DESeq2); cat(as.character(packageVersion('DESeq2')))")
-    END_VERSIONS
     """
 
     stub:
@@ -81,11 +76,5 @@ process DESEQ2_QC {
     do
         touch size_factors/\${i}.size_factors.RData
     done
-
-    cat <<-END_VERSIONS >versions.yml
-    "${task.process}":
-        r-base: \$(echo \$(R --version 2>&1) | sed 's/^.*R version //; s/ .*\$//')
-        bioconductor-deseq2: \$(Rscript -e "library(DESeq2); cat(as.character(packageVersion('DESeq2')))")
-    END_VERSIONS
     """
 }

--- a/modules/local/deseq2_qc/main.nf
+++ b/modules/local/deseq2_qc/main.nf
@@ -22,8 +22,8 @@ process DESEQ2_QC {
     path "*sample.dists_mqc.tsv", optional:true, emit: dists_multiqc
     path "*.log"                , optional:true, emit: log
     path "size_factors"         , optional:true, emit: size_factors
-    tuple val("${task.process}"), val('r-base'), eval("Rscript -e 'cat(as.character(getRversion()))'"), topic: versions
-    tuple val("${task.process}"), val('bioconductor-deseq2'), eval("Rscript -e \"library(DESeq2); cat(as.character(packageVersion('DESeq2')))\""), topic: versions
+    tuple val("${task.process}"), val('r-base'), eval("Rscript -e 'cat(as.character(getRversion()))'"), emit: versions_r_base, topic: versions
+    tuple val("${task.process}"), val('bioconductor-deseq2'), eval("Rscript -e \"library(DESeq2); cat(as.character(packageVersion('DESeq2')))\""), emit: versions_deseq2, topic: versions
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/deseq2_qc/tests/main.nf.test
+++ b/modules/local/deseq2_qc/tests/main.nf.test
@@ -23,8 +23,7 @@ nextflow_process {
                 { assert path(process.out.pca_txt.get(0)).exists() },
                 { assert snapshot(
                     process.out.dists_multiqc,
-                    process.out.pca_multiqc,
-                    process.out.versions
+                    process.out.pca_multiqc
                 ).match() }
             )
         }

--- a/modules/local/deseq2_qc/tests/main.nf.test
+++ b/modules/local/deseq2_qc/tests/main.nf.test
@@ -23,7 +23,9 @@ nextflow_process {
                 { assert path(process.out.pca_txt.get(0)).exists() },
                 { assert snapshot(
                     process.out.dists_multiqc,
-                    process.out.pca_multiqc
+                    process.out.pca_multiqc,
+                    process.out.versions_r_base,
+                    process.out.versions_deseq2
                 ).match() }
             )
         }

--- a/modules/local/deseq2_qc/tests/main.nf.test.snap
+++ b/modules/local/deseq2_qc/tests/main.nf.test.snap
@@ -77,10 +77,24 @@
                         "WT_REP2.size_factors.RData:md5,d41d8cd98f00b204e9800998ecf8427e",
                         "deseq2.size_factors.RData:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "versions_deseq2": [
+                    [
+                        "DESEQ2_QC",
+                        "bioconductor-deseq2",
+                        "1.46.0"
+                    ]
+                ],
+                "versions_r_base": [
+                    [
+                        "DESEQ2_QC",
+                        "r-base",
+                        "4.4.2"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2026-04-22T19:16:49.535920219",
+        "timestamp": "2026-04-23T08:21:07.295093921",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -93,12 +107,26 @@
             ],
             [
                 
+            ],
+            [
+                [
+                    "DESEQ2_QC",
+                    "r-base",
+                    "4.4.2"
+                ]
+            ],
+            [
+                [
+                    "DESEQ2_QC",
+                    "bioconductor-deseq2",
+                    "1.46.0"
+                ]
             ]
         ],
-        "timestamp": "2025-11-27T13:28:49.884314",
+        "timestamp": "2026-04-23T08:20:49.843146053",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/modules/local/deseq2_qc/tests/main.nf.test.snap
+++ b/modules/local/deseq2_qc/tests/main.nf.test.snap
@@ -34,7 +34,18 @@
                     ]
                 ],
                 "8": [
-                    "versions.yml:md5,334928b64c46461488576cd735ec439c"
+                    [
+                        "DESEQ2_QC",
+                        "r-base",
+                        "4.4.2"
+                    ]
+                ],
+                "9": [
+                    [
+                        "DESEQ2_QC",
+                        "bioconductor-deseq2",
+                        "1.46.0"
+                    ]
                 ],
                 "dists_multiqc": [
                     
@@ -66,34 +77,28 @@
                         "WT_REP2.size_factors.RData:md5,d41d8cd98f00b204e9800998ecf8427e",
                         "deseq2.size_factors.RData:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
-                ],
-                "versions": [
-                    "versions.yml:md5,334928b64c46461488576cd735ec439c"
                 ]
             }
         ],
+        "timestamp": "2026-04-22T19:16:49.535920219",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-11-27T13:29:23.049264"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "parse count data correctly": {
         "content": [
             [
-
+                
             ],
             [
-
-            ],
-            [
-                "versions.yml:md5,334928b64c46461488576cd735ec439c"
+                
             ]
         ],
+        "timestamp": "2025-11-27T13:28:49.884314",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-11-27T13:28:49.884314"
+        }
     }
 }

--- a/modules/nf-core/custom/catadditionalfasta/main.nf
+++ b/modules/nf-core/custom/catadditionalfasta/main.nf
@@ -4,26 +4,28 @@ process CUSTOM_CATADDITIONALFASTA {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/python:3.12' :
-        'biocontainers/python:3.12' }"
+        'quay.io/biocontainers/python:3.12' }"
 
     input:
     tuple val(meta), path(fasta), path(gtf)
     tuple val(meta2), path(add_fasta)
-    val  biotype
+    val(biotype)
 
     output:
-    tuple val(meta), path("*/*.fasta") , emit: fasta
-    tuple val(meta), path("*/*.gtf")   , emit: gtf
-    path "versions.yml"                , emit: versions
+    tuple val(meta), path("out/${prefix}.fasta"), emit: fasta
+    tuple val(meta), path("out/${prefix}.gtf")  , emit: gtf
+    path "versions.yml"                         , emit: versions, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
+    prefix = task.ext.prefix ?: "${meta.id}"
+
     template 'fasta2gtf.py'
 
     stub:
-    def prefix = task.ext.prefix ?: "${meta.id}"
+    prefix = task.ext.prefix ?: "${meta.id}"
     """
     mkdir out
     touch out/${prefix}.fasta

--- a/modules/nf-core/custom/catadditionalfasta/meta.yml
+++ b/modules/nf-core/custom/catadditionalfasta/meta.yml
@@ -1,7 +1,6 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "custom_catadditionalfasta"
-description: Custom module to Add a new fasta file to an old one and update an associated
-  GTF
+description: Custom module to Add a new fasta file to an old one and update an
+  associated GTF
 keywords:
   - fasta
   - gtf
@@ -11,9 +10,9 @@ tools:
       description: "Custom module to Add a new fasta file to an old one and update an
         associated GTF"
       tool_dev_url: "https://github.com/nf-core/modules/blob/master/modules/nf-core/custom/catadditionalfasta/main.nf"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
-
 input:
   - - meta:
         type: map
@@ -47,7 +46,7 @@ output:
           type: map
           description: |
             Groovy Map containing fasta information
-      - "*/*.fasta":
+      - out/${prefix}.fasta:
           type: file
           description: FASTA-format combined sequence file
           pattern: "*.{fasta,fa}"
@@ -57,11 +56,19 @@ output:
           type: map
           description: |
             Groovy Map containing fasta information
-      - "*/*.gtf":
+      - out/${prefix}.gtf:
           type: file
           description: GTF-format combined annotation file
           pattern: "*.gtf"
           ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+topics:
   versions:
     - versions.yml:
         type: file

--- a/modules/nf-core/custom/catadditionalfasta/templates/fasta2gtf.py
+++ b/modules/nf-core/custom/catadditionalfasta/templates/fasta2gtf.py
@@ -114,9 +114,7 @@ def main() -> None:
     fasta_to_gtf("$add_fasta", f"{add_name}.gtf", "$biotype")
 
     # Concatenate new fasta to existing fasta, and the GTF we just generated to the GTF
-    genome_name = "$params.genome" if "$params.genome" != "null" else os.path.splitext(os.path.basename("$fasta"))[0]
-    output_prefix = "$task.ext.prefix" if "$task.ext.prefix" != "null" else f"{genome_name}_{add_name}"
-
+    output_prefix = "$prefix"
     os.mkdir("out")
     os.system(f"cat $fasta $add_fasta > out/{output_prefix}.fasta")
     os.system(f"cat $gtf {add_name}.gtf > out/{output_prefix}.gtf")

--- a/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test
+++ b/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test
@@ -14,13 +14,13 @@ nextflow_process {
         when {
             process {
                 """
-                input[0] = Channel.of([
-                    [ id:'test', single_end:false ],
+                input[0] = channel.of([
+                    [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
                 ])
-                input[1] = Channel.of([
-                    [ id:'test', single_end:false ],
+                input[1] = channel.of([
+                    [ id:'transcriptome' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/transcriptome.fasta', checkIfExists: true)
                 ])
                 input[2] = 'test_biotype'
@@ -34,7 +34,8 @@ nextflow_process {
                 { assert snapshot(
                     process.out.fasta,
                     process.out.gtf,
-                    process.out.versions
+                    process.out.versions,
+                    path(process.out.versions[0]).yaml
                 ).match() }
             )
         }
@@ -45,18 +46,15 @@ nextflow_process {
         options "-stub"
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
-                input[0] = Channel.of([
-                    [ id:'test', single_end:false ],
+                input[0] = channel.of([
+                    [ id:'genome' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.gtf', checkIfExists: true)
                 ])
-                input[1] = Channel.of([
-                    [ id:'test', single_end:false ],
+                input[1] = channel.of([
+                    [ id:'transcriptome' ],
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/transcriptome.fasta', checkIfExists: true)
                 ])
                 input[2] = 'test_biotype'
@@ -66,8 +64,11 @@ nextflow_process {
 
         then {
             assertAll(
-            { assert process.success },
-            { assert snapshot(process.out).match() }
+                { assert process.success },
+                { assert snapshot(
+                    sanitizeOutput(process.out),
+                    path(process.out.versions[0]).yaml
+                ).match() }
             )
         }
     }

--- a/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/catadditionalfasta/tests/main.nf.test.snap
@@ -4,82 +4,67 @@
             [
                 [
                     {
-                        "id": "test",
-                        "single_end": false
+                        "id": "genome"
                     },
-                    "genome_transcriptome.fasta:md5,6a20c1a2e465519320a0d01f338f5cb5"
+                    "genome.fasta:md5,6a20c1a2e465519320a0d01f338f5cb5"
                 ]
             ],
             [
                 [
                     {
-                        "id": "test",
-                        "single_end": false
+                        "id": "genome"
                     },
-                    "genome_transcriptome.gtf:md5,bc88d95e7f27540e6b9906105d5be361"
+                    "genome.gtf:md5,bc88d95e7f27540e6b9906105d5be361"
                 ]
             ],
             [
                 "versions.yml:md5,5917ae30ad1ee71ad6b62659d5b628d1"
-            ]
+            ],
+            {
+                "CUSTOM_CATADDITIONALFASTA": {
+                    "python": "3.12.2"
+                }
+            }
         ],
+        "timestamp": "2026-04-22T08:32:17.633360221",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-19T21:07:02.01253345"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - fastq - gtf - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,8ab7a953e43316a447ad37b2e29e9c75"
-                ],
                 "fasta": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "genome"
                         },
-                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "genome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "gtf": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "genome"
                         },
-                        "test.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "genome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
                     "versions.yml:md5,8ab7a953e43316a447ad37b2e29e9c75"
                 ]
+            },
+            {
+                "CUSTOM_CATADDITIONALFASTA": {
+                    "python": "3.12.2"
+                }
             }
         ],
+        "timestamp": "2026-04-22T08:32:25.68466616",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-19T21:07:12.9817063"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/fq/lint/main.nf
+++ b/modules/nf-core/fq/lint/main.nf
@@ -5,10 +5,10 @@ process FQ_LINT {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/fq:0.12.0--h9ee0642_0':
-        'biocontainers/fq:0.12.0--h9ee0642_0' }"
+        'quay.io/biocontainers/fq:0.12.0--h9ee0642_0' }"
 
     input:
-    tuple val(meta), path(fastq)
+    tuple val(meta), path(fastq, arity: '1..2')
 
     output:
     tuple val(meta), path("*.fq_lint.txt"), emit: lint

--- a/modules/nf-core/fq/lint/tests/main.nf.test
+++ b/modules/nf-core/fq/lint/tests/main.nf.test
@@ -36,6 +36,32 @@ nextflow_process {
 
     }
 
+    test("test_fq_lint_rejects_more_than_two_fastqs") {
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                def fq1 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                def fq2 = file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                def fq3 = file("\${workDir}/test_3.fastq.gz")
+                fq3.bytes = fq1.bytes
+                input[0] = [ [ id:'test', single_end:false ],
+                             [ fq1, fq2, fq3 ]
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert !process.success }
+            )
+        }
+
+    }
+
     test("test_fq_lint_fail") {
         when {
             params {

--- a/modules/nf-core/ribodetector/environment.gpu.yml
+++ b/modules/nf-core/ribodetector/environment.gpu.yml
@@ -5,4 +5,5 @@ channels:
   - bioconda
 dependencies:
   - "bioconda::ribodetector=0.3.3"
-  - "conda-forge::pytorch-gpu=1.11.0"
+  - "conda-forge::pytorch-gpu=2.1.0"
+  - "conda-forge::cuda-version=11.2"

--- a/modules/nf-core/ribodetector/main.nf
+++ b/modules/nf-core/ribodetector/main.nf
@@ -4,8 +4,8 @@ process RIBODETECTOR {
 
 	conda "${ task.accelerator ? "${moduleDir}/environment.gpu.yml" : "${moduleDir}/environment.yml" }"
 	container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        (task.accelerator ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/eb/ebcccef2cd8b4c10d4bbd8fce542b46502b7817115cb144b9566792b0aac9bc0/data' : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data') :
-        (task.accelerator ? 'community.wave.seqera.io/library/ribodetector_pytorch-gpu:f2d45093d4093307' : 'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502') }"
+        (task.accelerator ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/51/51100097fc2e31d7b78074bc954774f77726099220e820382e939278817a66da/data' : 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/46/463b8ad941e7f1f2decef20844d666c1c8ac233e166d2bc766164c4a93905a3c/data') :
+        (task.accelerator ? 'community.wave.seqera.io/library/ribodetector_pytorch-gpu_cuda-version:fa9183da731515ea' : 'community.wave.seqera.io/library/ribodetector:0.3.3--ad3d7071e408b502') }"
 
 	input:
 	tuple val(meta), path(fastq)
@@ -15,6 +15,7 @@ process RIBODETECTOR {
 	tuple val(meta), path("*.nonrna*.fastq.gz"), emit: fastq
 	tuple val(meta), path("*.log")             , emit: log
 	tuple val("${task.process}"), val('ribodetector'), eval('ribodetector --version | sed "s/ribodetector //"'), emit: versions_ribodetector, topic: versions
+	tuple val("${task.process}"), val('cuda'), eval('python -c "import torch; print(torch.version.cuda or \'no CUDA available\')"'), emit: versions_cuda, topic: versions
 
 	when:
 	task.ext.when == null || task.ext.when

--- a/modules/nf-core/ribodetector/meta.yml
+++ b/modules/nf-core/ribodetector/meta.yml
@@ -76,6 +76,16 @@ output:
       - ribodetector --version | sed "s/ribodetector //":
           type: eval
           description: The expression to obtain the version of the tool
+  versions_cuda:
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - cuda:
+          type: string
+          description: Name of the runtime
+      - python -c "import torch; print(torch.version.cuda or 'no CUDA available')":
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 
 topics:
   versions:
@@ -88,6 +98,15 @@ topics:
       - ribodetector --version | sed "s/ribodetector //":
           type: eval
           description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: Name of the process
+      - cuda:
+          type: string
+          description: Name of the runtime
+      - python -c "import torch; print(torch.version.cuda or 'no CUDA available')":
+          type: eval
+          description: CUDA version bundled with the task's pytorch build, or `no CUDA available` on the non-GPU path
 
 authors:
   - "@maxibor"

--- a/modules/nf-core/ribodetector/tests/main.gpu.nf.test.snap
+++ b/modules/nf-core/ribodetector/tests/main.gpu.nf.test.snap
@@ -8324,6 +8324,13 @@
                 "SRR5665260.1.998901/2"
             ],
             {
+                "versions_cuda": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "11.2"
+                    ]
+                ],
                 "versions_ribodetector": [
                     [
                         "RIBODETECTOR",
@@ -8333,10 +8340,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-14T11:11:46.109723883",
+        "timestamp": "2026-04-22T13:15:51.198102608",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.2"
         }
     },
     "ribodetector - GPU stub rnaseq PE input": {
@@ -8370,6 +8377,13 @@
                         "0.3.3"
                     ]
                 ],
+                "3": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "11.2"
+                    ]
+                ],
                 "fastq": [
                     [
                         {
@@ -8391,6 +8405,13 @@
                         "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
+                "versions_cuda": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "11.2"
+                    ]
+                ],
                 "versions_ribodetector": [
                     [
                         "RIBODETECTOR",
@@ -8400,10 +8421,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-04-14T11:11:53.692394926",
+        "timestamp": "2026-04-22T13:16:06.36963835",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "25.10.2"
         }
     }
 }

--- a/modules/nf-core/ribodetector/tests/main.nf.test.snap
+++ b/modules/nf-core/ribodetector/tests/main.nf.test.snap
@@ -8324,6 +8324,13 @@
                 "SRR5665260.1.998901/2"
             ],
             {
+                "versions_cuda": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "versions_ribodetector": [
                     [
                         "RIBODETECTOR",
@@ -8370,6 +8377,13 @@
                         "0.3.3"
                     ]
                 ],
+                "3": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "no CUDA available"
+                    ]
+                ],
                 "fastq": [
                     [
                         {
@@ -8389,6 +8403,13 @@
                             "single_end": false
                         },
                         "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_cuda": [
+                    [
+                        "RIBODETECTOR",
+                        "cuda",
+                        "no CUDA available"
                     ]
                 ],
                 "versions_ribodetector": [

--- a/modules/nf-core/tximeta/tximport/main.nf
+++ b/modules/nf-core/tximeta/tximport/main.nf
@@ -5,7 +5,7 @@ process TXIMETA_TXIMPORT {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bioconductor-tximeta%3A1.20.1--r43hdfd78af_0' :
-        'biocontainers/bioconductor-tximeta:1.20.1--r43hdfd78af_0' }"
+        'quay.io/biocontainers/bioconductor-tximeta:1.20.1--r43hdfd78af_0' }"
 
     input:
     tuple val(meta), path("quants/*")

--- a/modules/nf-core/tximeta/tximport/templates/tximport.r
+++ b/modules/nf-core/tximeta/tximport/templates/tximport.r
@@ -81,10 +81,11 @@ write_se_table <- function(params, prefix) {
 #' @param gene_id_col Column name for gene IDs.
 #' @param gene_name_col Column name for gene names.
 #'
-#' @return A list containing three elements:
+#' @return A list containing four elements:
 #' - `transcript`: A data frame with transcript IDs, gene IDs, and gene names, indexed by transcript IDs.
 #' - `gene`: A data frame with unique gene IDs and gene names.
 #' - `tx2gene`: A data frame mapping transcript IDs to gene IDs.
+#' - `extra`: A character vector of transcript IDs found in quantification output but missing from the tx2gene file.
 
 read_transcript_info <- function(tinfo_path, tx_col, gene_id_col, gene_name_col){
     info <- file.info(tinfo_path)
@@ -104,13 +105,23 @@ read_transcript_info <- function(tinfo_path, tx_col, gene_id_col, gene_name_col)
     )
 
     extra <- setdiff(rownames(txi[[1]]), as.character(transcript_info[["tx"]]))
+    if (length(extra) > 0) {
+        warning(
+            length(extra), " transcripts found in quantification output but missing from ",
+            "the tx2gene mapping (GTF). These will be included in transcript-level outputs ",
+            "but excluded from gene-level summaries. This usually means the transcript FASTA ",
+            "and GTF are from different sources or versions. First 5: ",
+            paste(head(extra, 5), collapse = ", ")
+        )
+    }
     transcript_info <- rbind(transcript_info, data.frame(tx=extra, gene_id=extra, gene_name=extra, check.names = FALSE))
     transcript_info <- transcript_info[match(rownames(txi[[1]]), transcript_info[["tx"]]), ]
     rownames(transcript_info) <- transcript_info[["tx"]]
 
     list(transcript = transcript_info,
         gene = unique(transcript_info[,2:3]),
-        tx2gene = transcript_info[,1:2])
+        tx2gene = transcript_info[,1:2],
+        extra = extra)
 }
 
 #' Create a SummarizedExperiment Object
@@ -205,6 +216,21 @@ if ("tx2gene" %in% names(transcript_info) && !is.null(transcript_info\$tx2gene))
     gi <- summarizeToGene(txi, tx2gene = tx2gene)
     gi.ls <- summarizeToGene(txi, tx2gene = tx2gene, countsFromAbundance = "lengthScaledTPM")
     gi.s <- summarizeToGene(txi, tx2gene = tx2gene, countsFromAbundance = "scaledTPM")
+
+    # Remove fake gene entries created by unmapped transcripts (where gene_id
+    # was set to the transcript ID). These would break downstream processes
+    # like SummarizedExperiment that try to match gene IDs against the tx2gene.
+    if (length(transcript_info\$extra) > 0) {
+        real_genes <- setdiff(rownames(gi[[1]]), transcript_info\$extra)
+        filter_rows <- function(txi_list, genes) {
+            lapply(txi_list, function(x) {
+                if (is.matrix(x)) x[genes, , drop = FALSE] else x
+            })
+        }
+        gi    <- filter_rows(gi, real_genes)
+        gi.ls <- filter_rows(gi.ls, real_genes)
+        gi.s  <- filter_rows(gi.s, real_genes)
+    }
 
     gene_info <- transcript_info\$gene[match(rownames(gi[[1]]), transcript_info\$gene[["gene_id"]]),]
     rownames(gene_info) <- NULL

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test
@@ -214,6 +214,81 @@ nextflow_process {
 
     }
 
+    test("saccharomyces_cerevisiae - salmon - gtf - mismatched_transcripts") {
+
+        setup {
+            run("UNTAR") {
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test'], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/salmon_results.tar.gz', checkIfExists: true)
+                    ])
+                    """
+                }
+            }
+            run("CUSTOM_TX2GENE") {
+                script "../../../custom/tx2gene/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([
+                        [ id:'test'], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/eukaryotes/saccharomyces_cerevisiae/genome_gfp.gtf', checkIfExists: true)
+                    ])
+                    input[1] = UNTAR.out.untar.map { meta, dir -> [ meta, dir.listFiles().collect() ] }
+                    input[2] = 'salmon'
+                    input[3] = 'gene_id'
+                    input[4] = 'gene_name'
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = UNTAR.out.untar.map { meta, dir -> [ meta, dir.listFiles().collect() ] }
+                // Remove half the entries from tx2gene to simulate FASTA/GTF mismatch
+                input[1] = CUSTOM_TX2GENE.out.tx2gene.map { meta, tx2gene ->
+                    def lines = tx2gene.readLines()
+                    def header = lines[0]
+                    def kept = lines[1..Math.max(1, (int)(lines.size() / 2))]
+                    def modified = file("\${workDir}/truncated_tx2gene.tsv")
+                    modified.text = ([header] + kept).join('\\n') + '\\n'
+                    [meta, modified]
+                }
+                input[2] = 'salmon'
+                """
+            }
+        }
+
+        then {
+            // The truncated tx2gene covers only a subset of transcripts.
+            // Without filtering, unmapped transcripts would appear as fake
+            // genes (gene_id = transcript_id), inflating the gene count to
+            // match the transcript count (yeast has ~1:1 gene:transcript).
+            // With filtering, gene rows should be strictly fewer.
+            def gene_counts = path(process.out.counts_gene[0][1])
+            def gene_lines = gene_counts.readLines()
+            def tx_lines = path(process.out.counts_transcript[0][1]).readLines()
+            def n_genes = gene_lines.size() - 1        // subtract header
+            def n_transcripts = tx_lines.size() - 1
+
+            // Read .command.err from the work directory to check for warning
+            def commandErr = gene_counts.parent.resolve('.command.err').text
+
+            assertAll(
+                { assert process.success },
+                { assert n_genes > 0 },
+                { assert n_genes < n_transcripts :
+                    "Gene count rows ($n_genes) should be fewer than transcript rows ($n_transcripts) after filtering unmapped transcripts" },
+                { assert commandErr.contains("transcripts found in quantification output but missing from") :
+                    "Expected warning about unmapped transcripts in .command.err" }
+            )
+        }
+    }
+
     test("saccharomyces_cerevisiae - salmon - gtf - stub") {
 
         options "-stub"

--- a/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
+++ b/modules/nf-core/tximeta/tximport/tests/main.nf.test.snap
@@ -138,11 +138,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-09T11:02:50.661043856",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:26:21.185522"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - salmon - gtf": {
         "content": [
@@ -214,11 +214,11 @@
                 "versions.yml:md5,6ff317cceddc686f84d79cb976e1e28b"
             ]
         ],
+        "timestamp": "2026-04-09T11:03:02.256857186",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:27:19.912432"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - salmon - gtf - stub": {
         "content": [
@@ -359,11 +359,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-09T11:03:28.936272282",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:28:42.817097"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - kallisto - gtf - custom_column_names": {
         "content": [
@@ -435,11 +435,11 @@
                 "versions.yml:md5,6ff317cceddc686f84d79cb976e1e28b"
             ]
         ],
+        "timestamp": "2026-04-09T11:04:06.859776382",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:29:35.461954"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - rsem - gtf - stub": {
         "content": [
@@ -580,11 +580,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-09T11:03:55.191304215",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-11T10:59:46.025734857"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - kallisto - gtf": {
         "content": [
@@ -656,11 +656,11 @@
                 "versions.yml:md5,6ff317cceddc686f84d79cb976e1e28b"
             ]
         ],
+        "timestamp": "2026-04-09T11:02:24.289256682",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:23:53.102679"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - rsem - gtf": {
         "content": [
@@ -732,11 +732,11 @@
                 "versions.yml:md5,6ff317cceddc686f84d79cb976e1e28b"
             ]
         ],
+        "timestamp": "2026-04-09T11:03:40.511252751",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-02-11T10:59:31.386695001"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "saccharomyces_cerevisiae - kallisto - gtf - extra_attributes": {
         "content": [
@@ -808,10 +808,10 @@
                 "versions.yml:md5,6ff317cceddc686f84d79cb976e1e28b"
             ]
         ],
+        "timestamp": "2026-04-09T11:02:35.957379387",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.0"
-        },
-        "timestamp": "2025-12-09T09:24:47.963548"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -78,9 +78,6 @@ workflow PREPARE_GENOME {
     contaminant_screening    // string: contaminant screening tool ('kraken2', 'kraken2_bracken', 'sylph', or null)
 
     main:
-    // Versions collector
-    ch_versions = channel.empty()
-
     //---------------------------
     // 1) Uncompress GTF or GFF -> GTF
     //---------------------------
@@ -153,7 +150,6 @@ workflow PREPARE_GENOME {
         )
         ch_fasta    = CUSTOM_CATADDITIONALFASTA.out.fasta.map { tuple -> tuple[1] }.first()
         ch_gtf      = CUSTOM_CATADDITIONALFASTA.out.gtf.map { tuple -> tuple[1] }.first()
-        ch_versions = ch_versions.mix(CUSTOM_CATADDITIONALFASTA.out.versions)
     }
 
     //------------------------------------------------------
@@ -477,5 +473,4 @@ workflow PREPARE_GENOME {
     salmon_index     = ch_salmon_index           // channel: path(salmon/index/)
     kallisto_index   = ch_kallisto_index         // channel: [ meta, path(kallisto/index/) ]
     kraken_db        = ch_kraken_db              // channel: path(kraken2/db/)
-    versions         = ch_versions               // channel: [ versions.yml ]
 }

--- a/subworkflows/local/prepare_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test
@@ -74,8 +74,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -157,8 +156,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -240,8 +238,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -323,8 +320,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -406,8 +402,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -489,8 +484,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -572,8 +566,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -655,8 +648,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -738,8 +730,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -821,8 +812,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -904,8 +894,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -987,8 +976,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1070,8 +1058,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1153,8 +1140,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1236,8 +1222,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1319,8 +1304,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1402,8 +1386,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1485,8 +1468,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1568,8 +1550,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1651,8 +1632,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1734,8 +1714,7 @@ nextflow_workflow {
                     workflow.out.rsem_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.hisat2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
                     workflow.out.bowtie2_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.kallisto_index.collect { meta, path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -1894,8 +1873,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -1979,8 +1957,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2064,8 +2041,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2218,8 +2194,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2303,8 +2278,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2388,8 +2362,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2473,8 +2446,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2558,8 +2530,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2643,8 +2614,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2728,8 +2698,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2813,8 +2782,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2898,8 +2866,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -2983,8 +2950,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3068,8 +3034,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3153,8 +3118,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3238,8 +3202,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3323,8 +3286,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3477,8 +3439,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }
@@ -3562,8 +3523,7 @@ nextflow_workflow {
                     workflow.out.sortmerna_index,
                     workflow.out.splicesites,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }

--- a/subworkflows/local/prepare_genome/tests/main.nf.test.snap
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test.snap
@@ -2,19 +2,19 @@
     "skip_gtf_filter = true - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -30,9 +30,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:18:02.907387483",
@@ -44,19 +41,19 @@
     "skip_pseudo_alignment - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -72,9 +69,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:14:59.778250245",
@@ -114,10 +108,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:08:41.40483402",
         "meta": {
@@ -128,19 +119,19 @@
     "gencode = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -156,9 +147,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:13:58.848517702",
@@ -170,19 +158,19 @@
     "gff = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -198,9 +186,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:15:30.9437002",
@@ -212,19 +197,19 @@
     "skip_pseudoalignment = true - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -240,9 +225,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:18:49.000402027",
@@ -254,19 +236,19 @@
     "featurecounts_group_type = 'gene_type' - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -282,9 +264,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:17:48.228724117",
@@ -324,10 +303,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:09:45.361003981",
         "meta": {
@@ -363,7 +339,6 @@
             [
                 "[Genome, Log.out, SA, SAindex, chrLength.txt, chrName.txt, chrNameLength.txt, chrStart.txt, exonGeTrInfo.tab, exonInfo.tab, geneInfo.tab, genomeParameters.txt, sjdbInfo.txt, sjdbList.fromGTF.out.tab, sjdbList.out.tab, transcriptInfo.tab]"
             ],
-            [],
             [],
             [],
             [],
@@ -406,10 +381,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:12:56.117595679",
         "meta": {
@@ -420,19 +392,19 @@
     "salmon_index = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -448,9 +420,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:16:46.098242334",
@@ -488,10 +457,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-03-28T07:52:56.66953058",
         "meta": {
@@ -530,8 +496,7 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            []
+            ]
         ],
         "timestamp": "2026-04-10T21:33:59.272306338",
         "meta": {
@@ -570,10 +535,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:08:25.920430446",
         "meta": {
@@ -612,10 +574,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:08:09.71990742",
         "meta": {
@@ -626,19 +585,19 @@
     "gencode = true - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -654,9 +613,6 @@
             ],
             [
                 "transcriptome.fixed.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:17:32.9227987",
@@ -668,19 +624,19 @@
     "skip_alignment - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -694,9 +650,6 @@
             [],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:14:44.63644103",
@@ -709,10 +662,10 @@
         "content": [
             {
                 "0": [
-                    "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "1": [
-                    "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "10": [
                     [
@@ -742,20 +695,17 @@
                 ],
                 "15": [],
                 "16": [],
-                "17": [
-                    "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
-                ],
                 "2": [
-                    "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "3": [
-                    "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "4": [
                     "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
                 ],
                 "5": [
-                    "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "6": [],
                 "7": [],
@@ -764,19 +714,19 @@
                 "bbsplit_index": [],
                 "bowtie2_index": [],
                 "chrom_sizes": [
-                    "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "fai": [
-                    "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "fasta": [
-                    "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "gene_bed": [
-                    "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "gtf": [
-                    "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "hisat2_index": [],
                 "kallisto_index": [],
@@ -810,9 +760,6 @@
                 ],
                 "transcript_fasta": [
                     "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-                ],
-                "versions": [
-                    "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
                 ]
             }
         ],
@@ -853,10 +800,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:10:32.275536723",
         "meta": {
@@ -895,10 +839,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:13:28.455466062",
         "meta": {
@@ -909,19 +850,19 @@
     "skip_gtf_filter - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -937,9 +878,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:14:13.428713931",
@@ -979,10 +917,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:12:09.515995661",
         "meta": {
@@ -1023,9 +958,6 @@
             [],
             [
                 "[]"
-            ],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
             ]
         ],
         "timestamp": "2026-02-05T15:11:53.504856464",
@@ -1067,10 +999,7 @@
                 "[genome_gfp.1.ht2, genome_gfp.2.ht2, genome_gfp.3.ht2, genome_gfp.4.ht2, genome_gfp.5.ht2, genome_gfp.6.ht2, genome_gfp.7.ht2, genome_gfp.8.ht2]"
             ],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:11:37.493884502",
         "meta": {
@@ -1081,25 +1010,25 @@
     "rsem_index = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
             [],
             [
-                "[genome_transcriptome.fasta]"
+                "[genome_gfp.fasta]"
             ],
             [
                 "[]"
@@ -1111,9 +1040,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:16:30.758215437",
@@ -1153,10 +1079,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:12:25.47430627",
         "meta": {
@@ -1167,19 +1090,19 @@
     "with bed - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/ngscheckmate.bed"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1195,9 +1118,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:16:15.524125356",
@@ -1209,19 +1129,19 @@
     "kallisto_index = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1239,9 +1159,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:17:16.672035485",
@@ -1281,10 +1198,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:09:28.730151387",
         "meta": {
@@ -1323,10 +1237,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:08:56.822209444",
         "meta": {
@@ -1365,10 +1276,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:10:48.544567099",
         "meta": {
@@ -1379,19 +1287,19 @@
     "gtf = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1407,9 +1315,6 @@
             ],
             [
                 "transcriptome.fixed.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:15:15.712030364",
@@ -1449,10 +1354,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:10:01.340639858",
         "meta": {
@@ -1463,19 +1365,19 @@
     "default options - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1491,9 +1393,6 @@
             ],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:13:43.57191866",
@@ -1533,10 +1432,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:11:20.554766453",
         "meta": {
@@ -1577,10 +1473,7 @@
             ],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-04-08T08:15:00.198816144",
         "meta": {
@@ -1591,19 +1484,19 @@
     "skip_alignment = true - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1617,9 +1510,6 @@
             [],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:18:33.384723589",
@@ -1631,19 +1521,19 @@
     "transcriptome = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [],
@@ -1659,9 +1549,6 @@
             ],
             [
                 "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:16:00.857080017",
@@ -1699,10 +1586,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:13:12.237316243",
         "meta": {
@@ -1741,10 +1625,7 @@
             [],
             [],
             [],
-            [],
-            [
-                "versions.yml:md5,04400316552e6253e0008f052b20d866"
-            ]
+            []
         ],
         "timestamp": "2026-02-05T15:12:40.806443339",
         "meta": {
@@ -1755,19 +1636,19 @@
     "hisat2_index = false - stub": {
         "content": [
             [
-                "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [
                 "[]"
@@ -1780,14 +1661,11 @@
             ],
             [],
             [
-                "genome_transcriptome.splice_sites.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "genome_gfp.splice_sites.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
             ],
             [],
             [
                 "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-            ],
-            [
-                "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
             ]
         ],
         "timestamp": "2026-02-05T15:17:01.422677699",
@@ -1800,10 +1678,10 @@
         "content": [
             {
                 "0": [
-                    "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "1": [
-                    "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "10": [
                     [
@@ -1833,20 +1711,17 @@
                 ],
                 "15": [],
                 "16": [],
-                "17": [
-                    "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
-                ],
                 "2": [
-                    "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "3": [
-                    "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "4": [
                     "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
                 ],
                 "5": [
-                    "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "6": [],
                 "7": [],
@@ -1855,19 +1730,19 @@
                 "bbsplit_index": [],
                 "bowtie2_index": [],
                 "chrom_sizes": [
-                    "genome_transcriptome.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "fai": [
-                    "genome_transcriptome.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "fasta": [
-                    "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "gene_bed": [
-                    "genome_transcriptome.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "gtf": [
-                    "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    "genome_gfp.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
                 ],
                 "hisat2_index": [],
                 "kallisto_index": [],
@@ -1901,9 +1776,6 @@
                 ],
                 "transcript_fasta": [
                     "/ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/reference/transcriptome.fasta"
-                ],
-                "versions": [
-                    "versions.yml:md5,d475dace58c4e9b4911e8a60bda85041"
                 ]
             }
         ],

--- a/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test
@@ -69,8 +69,7 @@ nextflow_workflow {
                     workflow.out.fai,
                     workflow.out.gene_bed,
                     workflow.out.chrom_sizes,
-                    workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.versions
+                    workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() }
                 ).match() }
             )
         }
@@ -148,8 +147,7 @@ nextflow_workflow {
                     workflow.out.gene_bed,
                     workflow.out.gtf,
                     workflow.out.star_index.collect { path -> file(path).listFiles().collect { f -> f.getName() }.sort().toString() },
-                    workflow.out.transcript_fasta,
-                    workflow.out.versions
+                    workflow.out.transcript_fasta
                 ).match() }
             )
         }

--- a/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test.snap
+++ b/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test.snap
@@ -21,9 +21,6 @@
             ],
             [
                 "[Genome, SA, SAindex, chrLength.txt, chrName.txt, chrNameLength.txt, chrStart.txt, exonGeTrInfo.tab, exonInfo.tab, geneInfo.tab, genomeParameters.txt, sjdbInfo.txt, sjdbList.fromGTF.out.tab, sjdbList.out.tab, transcriptInfo.tab]"
-            ],
-            [
-                
             ]
         ],
         "meta": {
@@ -54,9 +51,6 @@
             ],
             [
                 "genome.transcripts.fa:md5,d41d8cd98f00b204e9800998ecf8427e"
-            ],
-            [
-                
             ]
         ],
         "meta": {

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/main.nf
@@ -36,22 +36,22 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
     min_trimmed_reads // integer: > 0
 
     main:
-    fastqc_html = channel.empty()
-    fastqc_zip = channel.empty()
+    ch_fastqc_html = channel.empty()
+    ch_fastqc_zip = channel.empty()
     if (!skip_fastqc) {
         FASTQC(reads)
-        fastqc_html = FASTQC.out.html
-        fastqc_zip = FASTQC.out.zip
+        ch_fastqc_html = FASTQC.out.html
+        ch_fastqc_zip = FASTQC.out.zip
     }
 
-    trimmer_reads = reads
-    umi_log = channel.empty()
-    umi_reads = channel.empty()
+    ch_trimmer_reads = reads
+    ch_umi_log = channel.empty()
+    ch_umi_reads = channel.empty()
     if (with_umi && !skip_umi_extract) {
         UMITOOLS_EXTRACT(reads)
-        trimmer_reads = UMITOOLS_EXTRACT.out.reads
-        umi_reads = UMITOOLS_EXTRACT.out.reads
-        umi_log = UMITOOLS_EXTRACT.out.log
+        ch_trimmer_reads = UMITOOLS_EXTRACT.out.reads
+        ch_umi_reads = UMITOOLS_EXTRACT.out.reads
+        ch_umi_log = UMITOOLS_EXTRACT.out.log
 
         // Discard R1 / R2 if required
         if (umi_discard_read in [1, 2]) {
@@ -59,35 +59,35 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
                 .map { meta, reads_ ->
                     meta.single_end ? [meta, reads_] : [meta + ['single_end': true], reads_[umi_discard_read % 2]]
                 }
-                .set { trimmer_reads }
+                .set { ch_trimmer_reads }
         }
     }
 
-    trim_reads = trimmer_reads
-    trim_unpaired = channel.empty()
-    trim_html = channel.empty()
-    trim_zip = channel.empty()
-    trim_log = channel.empty()
-    trim_read_count = channel.empty()
+    ch_trim_reads = ch_trimmer_reads
+    ch_trim_unpaired = channel.empty()
+    ch_trim_html = channel.empty()
+    ch_trim_zip = channel.empty()
+    ch_trim_log = channel.empty()
+    ch_trim_read_count = channel.empty()
     if (!skip_trimming) {
-        TRIMGALORE(trimmer_reads)
-        trim_unpaired = TRIMGALORE.out.unpaired
-        trim_html = TRIMGALORE.out.html
-        trim_zip = TRIMGALORE.out.zip
-        trim_log = TRIMGALORE.out.log
+        TRIMGALORE(ch_trimmer_reads)
+        ch_trim_unpaired = TRIMGALORE.out.unpaired
+        ch_trim_html = TRIMGALORE.out.html
+        ch_trim_zip = TRIMGALORE.out.zip
+        ch_trim_log = TRIMGALORE.out.log
 
         //
         // Filter FastQ files based on minimum trimmed read count after adapter trimming
         //
         TRIMGALORE.out.reads
-            .join(trim_log, remainder: true)
-            .map { meta, reads_, trim_log_ ->
+            .join(ch_trim_log, remainder: true)
+            .map { meta, reads_, trim_log ->
                 if (trim_log) {
-                    def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log_ : trim_log_[-1])
+                    def num_reads = getTrimGaloreReadsAfterFiltering(meta.single_end ? trim_log : trim_log[-1])
                     [meta, reads_, num_reads]
                 }
                 else {
-                    [meta, reads, min_trimmed_reads.toFloat() + 1]
+                    [meta, reads_, min_trimmed_reads.toFloat() + 1]
                 }
             }
             .set { ch_num_trimmed_reads }
@@ -95,22 +95,22 @@ workflow FASTQ_FASTQC_UMITOOLS_TRIMGALORE {
         ch_num_trimmed_reads
             .filter { _meta, _reads, num_reads -> num_reads >= min_trimmed_reads.toFloat() }
             .map { meta, reads_, _num_reads -> [meta, reads_] }
-            .set { trim_reads }
+            .set { ch_trim_reads }
 
         ch_num_trimmed_reads
             .map { meta, _reads, num_reads -> [meta, num_reads] }
-            .set { trim_read_count }
+            .set { ch_trim_read_count }
     }
 
     emit:
-    reads           = trim_reads // channel: [ val(meta), [ reads ] ]
-    fastqc_html     // channel: [ val(meta), [ html ] ]
-    fastqc_zip      // channel: [ val(meta), [ zip ] ]
-    umi_log         // channel: [ val(meta), [ log ] ]
-    umi_reads       // channel: [ val(meta), [ reads ] ]
-    trim_unpaired   // channel: [ val(meta), [ reads ] ]
-    trim_html       // channel: [ val(meta), [ html ] ]
-    trim_zip        // channel: [ val(meta), [ zip ] ]
-    trim_log        // channel: [ val(meta), [ txt ] ]
-    trim_read_count // channel: [ val(meta), val(count) ]
+    reads           = ch_trim_reads       // channel: [ val(meta), [ reads ] ]
+    fastqc_html     = ch_fastqc_html      // channel: [ val(meta), [ html ] ]
+    fastqc_zip      = ch_fastqc_zip       // channel: [ val(meta), [ zip ] ]
+    umi_log         = ch_umi_log          // channel: [ val(meta), [ log ] ]
+    umi_reads       = ch_umi_reads        // channel: [ val(meta), [ reads ] ]
+    trim_unpaired   = ch_trim_unpaired    // channel: [ val(meta), [ reads ] ]
+    trim_html       = ch_trim_html        // channel: [ val(meta), [ html ] ]
+    trim_zip        = ch_trim_zip         // channel: [ val(meta), [ zip ] ]
+    trim_log        = ch_trim_log         // channel: [ val(meta), [ txt ] ]
+    trim_read_count = ch_trim_read_count  // channel: [ val(meta), val(count) ]
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test
@@ -115,6 +115,42 @@ nextflow_workflow {
         }
     }
 
+    test("test paired end read without UMI - hardtrim5 (no trim log)") {
+
+        config './nextflow-hardtrim.config'
+
+        when {
+            workflow {
+                """
+                input[0] = channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
+                    ]
+                ])
+                input[1] = true  // skip_fastqc
+                input[2] = false // with_umi
+                input[3] = true  // skip_umi_extract
+                input[4] = false // skip_trimming
+                input[5] = 0     // umi_discard_read
+                input[6] = 1     // min_trimmed_reads
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    workflow.out.reads,
+                    workflow.out.trim_read_count,
+                    workflow.out.trim_unpaired,
+                ).match() }
+            )
+        }
+    }
+
     test("test skip all steps") {
 
         when {

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/main.nf.test.snap
@@ -523,5 +523,38 @@
             "nextflow": "25.10.3"
         },
         "timestamp": "2026-02-03T13:21:36.092099503"
+    },
+    "test paired end read without UMI - hardtrim5 (no trim log)": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1.8bp_5prime.fq.gz:md5,70f5059c1a54be0cb280ef42ee849122",
+                        "test_2.8bp_5prime.fq.gz:md5,fdec97e9e36ac5f30685f4fa0975dcf7"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    2.0
+                ]
+            ],
+            [
+                
+            ]
+        ],
+        "timestamp": "2026-04-20T10:04:54.300393835",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/nextflow-hardtrim.config
+++ b/subworkflows/nf-core/fastq_fastqc_umitools_trimgalore/tests/nextflow-hardtrim.config
@@ -1,0 +1,11 @@
+process {
+    withName: UMITOOLS_EXTRACT {
+        ext.args = '--bc-pattern="NNNN"'
+    }
+    withName: TRIMGALORE {
+        // --hardtrim5 makes trim_galore skip the adapter / quality pass and not emit a
+        // *_trimming_report.txt, so the trim_log channel join leaves a null element.
+        // Used to exercise the null-log branch of the read-count map.
+        ext.args = '--hardtrim5 8'
+    }
+}

--- a/tests/bam_input.nf.test.snap
+++ b/tests/bam_input.nf.test.snap
@@ -117,10 +117,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "multiqc",
                 "multiqc/multiqc_report.html",
                 "multiqc/multiqc_report_data",
@@ -862,8 +858,6 @@
                 "star_salmon/stringtie/WT_REP2.transcripts.gtf"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "multiqc_citations.txt:md5,564145971ac42922310b2f992a6dcb70",
                 "multiqc_featurecounts_biotype_plot.txt:md5,b633d12b9d6c5993350f45177b103243",
                 "multiqc_samtools_idxstats.txt:md5,14838fa75205d1b87bb387784e7a56ab",
@@ -949,11 +943,11 @@
                 "i_data.ctab:md5,041edee3193df311f621c09f4991892b"
             ]
         ],
+        "timestamp": "2026-04-22T17:10:55.214026301",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-26T13:51:27.63099365"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "BAM input for RSEM": {
         "content": [
@@ -1084,10 +1078,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "multiqc",
                 "multiqc/multiqc_report.html",
                 "multiqc/multiqc_report_data",
@@ -1804,8 +1794,6 @@
                 "star_rsem/stringtie/WT_REP2.transcripts.gtf"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "multiqc_citations.txt:md5,210a3666a96ac8e0460b87f91deb9476",
                 "multiqc_featurecounts_biotype_plot.txt:md5,62b0407251d2f4778005401bc7256098",
                 "multiqc_samtools_idxstats.txt:md5,347afbde271047e89ccfafe8c81f299d",
@@ -1880,10 +1868,10 @@
                 "i_data.ctab:md5,7e81ace0a68bfe42482420b7275de195"
             ]
         ],
+        "timestamp": "2026-04-22T17:11:00.247700127",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-13T14:58:30.502549129"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/tests/contaminant_screening_input.nf.test.snap
+++ b/tests/contaminant_screening_input.nf.test.snap
@@ -50,10 +50,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -94,14 +90,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-03-31T17:29:28.665283571",
+        "timestamp": "2026-04-22T17:09:08.666478589",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: contaminant_screening_input=trimmed screens pre-alignment reads": {
@@ -254,10 +249,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1366,8 +1357,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1489,10 +1478,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-03-28T11:16:10.497395581",
+        "timestamp": "2026-04-22T17:16:09.077795332",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: contaminant_screening_input=unmapped (default) screens post-alignment reads": {
@@ -1645,10 +1634,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -2757,8 +2742,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -2880,10 +2863,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-03-28T11:20:09.713081388",
+        "timestamp": "2026-04-22T17:16:18.890515571",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: contaminant screening trimmed input with skip_alignment - stub": {
@@ -2931,10 +2914,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -2974,14 +2953,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-03-31T17:30:01.490209123",
+        "timestamp": "2026-04-22T17:09:11.755621085",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -46,10 +46,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -90,14 +86,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-04T16:55:44.46471142",
+        "timestamp": "2026-04-22T17:05:15.139623477",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: default": {
@@ -265,10 +260,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1423,8 +1414,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1566,7 +1555,7 @@
                 "i_data.ctab:md5,041edee3193df311f621c09f4991892b"
             ]
         ],
-        "timestamp": "2026-04-21T15:30:03.716277583",
+        "timestamp": "2026-04-22T16:55:37.518809226",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/featurecounts_group_type.nf.test.snap
+++ b/tests/featurecounts_group_type.nf.test.snap
@@ -43,10 +43,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -76,14 +72,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-04T16:59:46.520896834",
+        "timestamp": "2026-04-22T17:17:16.00263487",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: --featurecounts_group_type false": {
@@ -183,10 +178,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -656,8 +647,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,b4776accd1bf7206c7ab0f1d84e4721e",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -745,7 +734,7 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-21T20:11:17.952866791",
+        "timestamp": "2026-04-22T17:20:28.012909805",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/gpu_ribodetector.nf.test.snap
+++ b/tests/gpu_ribodetector.nf.test.snap
@@ -31,6 +31,7 @@
                     "gunzip": 1.13
                 },
                 "RIBODETECTOR": {
+                    "cuda": 11.2,
                     "ribodetector": "0.3.3"
                 },
                 "SALMON_QUANT": {
@@ -50,10 +51,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -115,8 +112,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,5e63cda3dcafc0d6ad0a738133af9d54",
                 "RAP1_IAA_30M_REP1.rrna_removal_stats.tsv:md5,47edd6f22fb2f741c983ae93470b9299",
                 "RAP1_UNINDUCED_REP1.rrna_removal_stats.tsv:md5,244a43575c0c7e8c8f1c3e521b895224",
                 "RAP1_UNINDUCED_REP2.rrna_removal_stats.tsv:md5,10423aa5ad8557645f4b0c6a4942c62c",
@@ -163,10 +158,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -189,8 +180,7 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
         "meta": {

--- a/tests/hisat2.nf.test.snap
+++ b/tests/hisat2.nf.test.snap
@@ -47,10 +47,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -91,14 +87,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-04T17:02:38.159554469",
+        "timestamp": "2026-04-22T17:11:20.845830751",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: --aligner hisat2": {
@@ -231,10 +226,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1136,8 +1127,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "RAP1_IAA_30M_REP1.biotype_counts_mqc.tsv:md5,cd7494b3bb12295a287f36506638f3c6",
                 "RAP1_IAA_30M_REP1.biotype_counts_rrna_mqc.tsv:md5,dde2de0cb90e10d0195c726f768e9941",
                 "RAP1_IAA_30M_REP1.featureCounts.tsv:md5,289e47b060051eb33c17e52aa0ce52cc",
@@ -1217,7 +1206,7 @@
                 "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,6c323b383a6506d124506405b9463d93"
             ]
         ],
-        "timestamp": "2026-04-20T15:53:44.307291807",
+        "timestamp": "2026-04-22T17:17:55.017730677",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/parabricks_default.nf.test.snap
+++ b/tests/parabricks_default.nf.test.snap
@@ -101,10 +101,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -575,8 +571,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -688,10 +682,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -732,8 +722,7 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
         "meta": {
@@ -789,10 +778,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -833,8 +818,7 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
         "meta": {
@@ -945,10 +929,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1409,8 +1389,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",

--- a/tests/remove_ribo_rna.nf.test.snap
+++ b/tests/remove_ribo_rna.nf.test.snap
@@ -57,10 +57,6 @@
             [
                 "bowtie2_rrna",
                 "bowtie2_rrna/index",
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -93,13 +89,11 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "smr_v4.3_fast_db_dna_converted.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940",
                 "smr_v4.3_fast_db_prefixed.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
             ]
         ],
-        "timestamp": "2026-04-20T14:31:42.858449865",
+        "timestamp": "2026-04-22T17:21:48.312879133",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -214,10 +208,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -707,8 +697,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -796,7 +784,7 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-21T20:17:36.729457523",
+        "timestamp": "2026-04-22T17:21:44.295368206",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -852,10 +840,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -885,11 +869,10 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-04-20T14:26:10.915187953",
+        "timestamp": "2026-04-22T17:24:56.139466018",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -1030,10 +1013,6 @@
                 "bowtie2_rrna/WT_REP1.bowtie2_rrna.bowtie2.log",
                 "bowtie2_rrna/WT_REP2.bowtie2_rrna.bowtie2.log",
                 "bowtie2_rrna/index",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -1527,8 +1506,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1618,7 +1595,7 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-21T21:08:42.437783691",
+        "timestamp": "2026-04-22T17:24:58.844418127",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/rustqc.nf.test.snap
+++ b/tests/rustqc.nf.test.snap
@@ -46,10 +46,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -90,14 +86,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-04-01T14:08:15.127923591",
+        "timestamp": "2026-04-22T17:25:36.47970729",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Params: use_rustqc": {
@@ -232,10 +227,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1384,8 +1375,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1550,7 +1539,7 @@
                 "i_data.ctab:md5,041edee3193df311f621c09f4991892b"
             ]
         ],
-        "timestamp": "2026-04-21T15:34:43.072294784",
+        "timestamp": "2026-04-22T17:26:31.584067743",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/salmon.nf.test.snap
+++ b/tests/salmon.nf.test.snap
@@ -1258,10 +1258,6 @@
                 "WT_REP2/trimgalore",
                 "WT_REP2/trimgalore/WT_REP2_trimmed_1.fastq.gz_trimming_report.txt",
                 "WT_REP2/trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "pipeline_info",
                 "pipeline_info/nf_core_rnaseq_software_mqc_versions.yml",
                 "salmon",
@@ -1423,12 +1419,10 @@
                 "observed_bias_3p.gz:md5,92bcd0592d22a6a58d0360fc76103e56",
                 "cmd_info.json:md5,fe66c9d876645b9260d8c2488157d4d4",
                 "lib_format_counts.json:md5,088fd51db07022ffde47033bbd029400",
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-20T15:58:39.567539731",
+        "timestamp": "2026-04-22T17:29:06.762359837",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -1503,10 +1497,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -1753,8 +1743,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1804,7 +1792,7 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-21T20:25:38.348734681",
+        "timestamp": "2026-04-22T17:27:10.699537381",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -1940,10 +1928,6 @@
                 "WT_REP2/trimgalore",
                 "WT_REP2/trimgalore/WT_REP2_trimmed_1.fastq.gz_trimming_report.txt",
                 "WT_REP2/trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "pipeline_info",
                 "pipeline_info/nf_core_rnaseq_software_mqc_versions.yml"
             ],
@@ -1962,12 +1946,10 @@
                 "multiqc_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
                 ".stub:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "multiqc_report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                "multiqc_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-04-20T16:19:39.79029725",
+        "timestamp": "2026-04-22T17:26:23.085720345",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -2012,10 +1994,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -2044,14 +2022,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-04T17:31:37.170058949",
+        "timestamp": "2026-04-22T17:22:31.000255519",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/sentieon_default.nf.test.snap
+++ b/tests/sentieon_default.nf.test.snap
@@ -46,10 +46,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -90,8 +86,7 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
         "meta": {
@@ -260,10 +255,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1300,8 +1291,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",

--- a/tests/skip_qc.nf.test.snap
+++ b/tests/skip_qc.nf.test.snap
@@ -114,10 +114,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fastqc/trim/RAP1_IAA_30M_REP1_trimmed_1_val_1_fastqc.html",
@@ -617,8 +613,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -719,7 +713,7 @@
                 "i_data.ctab:md5,525413b70bcf62c24c8f96182e09883e"
             ]
         ],
-        "timestamp": "2026-04-22T13:50:55.404021676",
+        "timestamp": "2026-04-22T17:31:56.890594261",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -769,10 +763,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/trim",
                 "fq_lint",
@@ -802,11 +792,10 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-04-22T14:09:21.275483844",
+        "timestamp": "2026-04-22T17:23:19.511258206",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/skip_trimming.nf.test.snap
+++ b/tests/skip_trimming.nf.test.snap
@@ -161,10 +161,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1233,8 +1229,6 @@
                 "star_salmon/stringtie/stringtie_merge.gtf"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "fastqc_raw-status-check-heatmap.txt:md5,5a89b0d8d162f6b1dbdaf39457bbc03b",
                 "fastqc_raw_adapter_content_plot.txt:md5,da0389be84cfdd189b1d045212eb2974",
                 "fastqc_raw_overrepresented_sequences_plot.txt:md5,25d88ea8a72f55e8a374ae802bc7f0b1",
@@ -1363,7 +1357,7 @@
                 "i_data.ctab:md5,042075e0929819608527f05b28b063d6"
             ]
         ],
-        "timestamp": "2026-04-21T15:59:00.307010298",
+        "timestamp": "2026-04-22T17:33:36.961272897",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/tests/star_rsem.nf.test.snap
+++ b/tests/star_rsem.nf.test.snap
@@ -169,10 +169,6 @@
                 "bbsplit/RAP1_UNINDUCED_REP2.stats.txt",
                 "bbsplit/WT_REP1.stats.txt",
                 "bbsplit/WT_REP2.stats.txt",
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/filtered",
                 "fastqc/filtered/RAP1_IAA_30M_REP1_filtered_1_fastqc.html",
@@ -1183,8 +1179,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,6fa381627f7c1f664f3d4b2cb79cce90",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,13dfa866fd91dbb072689efe9aa83b1f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,07145dd8dd3db654859b18eb0389046c",
@@ -1284,7 +1278,7 @@
                 "i_data.ctab:md5,7e81ace0a68bfe42482420b7275de195"
             ]
         ],
-        "timestamp": "2026-04-21T15:45:08.363904155",
+        "timestamp": "2026-04-22T17:31:07.391686257",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -1340,10 +1334,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -1384,14 +1374,13 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-13T11:34:58.939150504",
+        "timestamp": "2026-04-22T17:32:41.06267044",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/umi.nf.test.snap
+++ b/tests/umi.nf.test.snap
@@ -142,10 +142,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw_1_fastqc.html",
@@ -1118,8 +1114,6 @@
                 "umitools/WT_REP2.umi_extract_2.fastq.gz"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,3f122969fa288888e5abef061b7963f2",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,5e8a821c9a4deb46c11bc65969b8864f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,bf8abefa7c5f2f1e1140749983279d9d",
@@ -1237,7 +1231,7 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-22T14:03:54.839507775",
+        "timestamp": "2026-04-22T17:34:37.104038632",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -1377,10 +1371,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw_1_fastqc.html",
@@ -2379,8 +2369,6 @@
                 "umitools/WT_REP2.umi_extract_2.fastq.gz"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,3f122969fa288888e5abef061b7963f2",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,5e8a821c9a4deb46c11bc65969b8864f",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,bf8abefa7c5f2f1e1140749983279d9d",
@@ -2509,7 +2497,7 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-20T16:19:25.966852452",
+        "timestamp": "2026-04-22T17:37:05.820604066",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -2630,10 +2618,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw_1_fastqc.html",
@@ -3441,8 +3425,6 @@
                 "umitools/WT_REP2.umi_extract_2.fastq.gz"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "RAP1_IAA_30M_REP1.biotype_counts_mqc.tsv:md5,8433a395e65315feb0f8bfca4a1d1aba",
                 "RAP1_IAA_30M_REP1.biotype_counts_rrna_mqc.tsv:md5,dde2de0cb90e10d0195c726f768e9941",
                 "RAP1_IAA_30M_REP1.featureCounts.tsv:md5,783a4395a02312e94b9f890fb9e18f6e",
@@ -3513,7 +3495,7 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-20T16:05:26.523308427",
+        "timestamp": "2026-04-22T17:25:23.385280417",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -3569,10 +3551,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_transcriptome.fasta",
-                "custom/out/genome_transcriptome.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw.html",
@@ -3619,14 +3597,13 @@
                 "umitools/WT_REP2.umi_extract.log"
             ],
             [
-                "genome_transcriptome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "genome_transcriptome.gtf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                
             ]
         ],
-        "timestamp": "2026-02-04T17:51:58.400008189",
+        "timestamp": "2026-04-22T17:33:28.968724315",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }

--- a/tests/uncompressed_fastq.nf.test.snap
+++ b/tests/uncompressed_fastq.nf.test.snap
@@ -145,10 +145,6 @@
                 }
             },
             [
-                "custom",
-                "custom/out",
-                "custom/out/genome_gfp.fasta",
-                "custom/out/genome_gfp.gtf",
                 "fastqc",
                 "fastqc/raw",
                 "fastqc/raw/RAP1_IAA_30M_REP1_raw_1_fastqc.html",
@@ -1227,8 +1223,6 @@
                 "trimgalore/WT_REP2_trimmed_2.fastq.gz_trimming_report.txt"
             ],
             [
-                "genome_gfp.fasta:md5,e23e302af63736a199985a169fdac055",
-                "genome_gfp.gtf:md5,c98b12c302f15731bfc36bcf297cfe28",
                 "cutadapt_filtered_reads_plot.txt:md5,2875db20890141d1c23f7d1310ab65f0",
                 "cutadapt_trimmed_sequences_plot_3_Counts.txt:md5,c54c003a04b4630f52c4c34a86ddca8d",
                 "cutadapt_trimmed_sequences_plot_3_Obs_Exp.txt:md5,afbad9fda5caa0b86ab791765df63e4c",
@@ -1353,7 +1347,7 @@
                 "i_data.ctab:md5,fca03502dd5b5e2831a64ff133d8c0b5"
             ]
         ],
-        "timestamp": "2026-04-21T15:40:19.344165885",
+        "timestamp": "2026-04-22T17:29:28.690498135",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -70,7 +70,6 @@ workflow RNASEQ {
 
     take:
     ch_samplesheet          // channel: path(sample_sheet.csv)
-    ch_versions             // channel: [ path(versions.yml) ]
     ch_fasta                // channel: path(genome.fasta)
     ch_gtf                  // channel: path(genome.gtf)
     ch_fai                  // channel: path(genome.fai)
@@ -122,7 +121,9 @@ workflow RNASEQ {
     def collapseAgg = { row -> [row[0].id, row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     //
-    // Collect versions from topic channel (for modules that emit versions via topics)
+    // Collect versions from the topic channel. Entries are either
+    // `path(versions.yml)` (legacy file-emit style) or
+    // `(task.process, tool, version)` tuples (inline `eval` style).
     //
     def topic_versions = channel.topic('versions')
         .distinct()
@@ -437,7 +438,6 @@ workflow RNASEQ {
             )
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_RSEM.out.pca_multiqc.collect().map { file -> [[:], file] })
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_RSEM.out.dists_multiqc.collect().map { file -> [[:], file] })
-            ch_versions = ch_versions.mix(DESEQ2_QC_RSEM.out.versions)
         }
 
     } else if (params.aligner in ['star_salmon', 'bowtie2_salmon']) {
@@ -468,7 +468,6 @@ workflow RNASEQ {
             )
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_BAM_SALMON.out.pca_multiqc.collect().map { file -> [[:], file] })
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_BAM_SALMON.out.dists_multiqc.collect().map { file -> [[:], file] })
-            ch_versions = ch_versions.mix(DESEQ2_QC_BAM_SALMON.out.versions)
         }
     }
 
@@ -792,15 +791,13 @@ workflow RNASEQ {
             )
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_PSEUDO.out.pca_multiqc.collect().map { file -> [[:], file] })
             ch_multiqc_files = ch_multiqc_files.mix(DESEQ2_QC_PSEUDO.out.dists_multiqc.collect().map { file -> [[:], file] })
-            ch_versions = ch_versions.mix(DESEQ2_QC_PSEUDO.out.versions)
         }
     }
 
     //
-    // Collate and save software versions
-    // Combines traditional versions.yml files with versions emitted via topic channels
+    // Collate and save software versions from the `versions` topic
     //
-    ch_collated_versions = softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))
+    ch_collated_versions = softwareVersionsToYAML(topic_versions.versions_file)
         .mix(topic_versions_string)
         .collectFile(storeDir: "${params.outdir}/pipeline_info", name: 'nf_core_rnaseq_software_mqc_versions.yml', sort: true, newLine: true)
 
@@ -878,7 +875,6 @@ workflow RNASEQ {
     map_status     = ch_map_status     // channel: [id, boolean]
     strand_status  = ch_strand_status  // channel: [id, boolean]
     multiqc_report = ch_multiqc_report // channel: /path/to/multiqc_report.html
-    versions       = ch_versions       // channel: [ path(versions.yml) ]
 }
 
 /*


### PR DESCRIPTION
## Summary

Sync five nf-core components with their latest upstream versions, wire in the new `custom/catadditionalfasta` interface, migrate the last local module still on `versions.yml` to topic-based versions, and retire the now-redundant `ch_versions` plumbing.

### Component syncs

- `fq/lint` — [nf-core/modules#11227](https://github.com/nf-core/modules/pull/11227): constrain reads input to arity 1..2
- `ribodetector` — [nf-core/modules#11258](https://github.com/nf-core/modules/pull/11258): unpin GPU container from `pytorch-gpu=1.11.0` (the `__cuda` workaround is no longer needed); also emits a `cuda` version on the `versions` topic, which now shows up in `nf_core_rnaseq_software_mqc_versions.yml` under `RIBODETECTOR`.
- `tximeta/tximport` — [nf-core/modules#11141](https://github.com/nf-core/modules/pull/11141): fix gene-level crash on mismatched transcript FASTA / GTF
- `fastq_fastqc_umitools_trimgalore` — [nf-core/modules#11228](https://github.com/nf-core/modules/pull/11228): handle null `trim_log` in the read-count map
- `custom/catadditionalfasta` — [nf-core/modules#11256](https://github.com/nf-core/modules/pull/11256): topic-based versions, explicit `out/${prefix}.{fasta,gtf}` paths, and `task.ext.prefix ?: meta.id` prefix handling

### Pipeline-side rewiring for `custom/catadditionalfasta`

- Fix stale `CAT_ADDITIONAL_FASTA` → `CUSTOM_CATADDITIONALFASTA` selector in `conf/modules/prepare_genome.config`; split `PREPROCESS_TRANSCRIPTS_FASTA_GENCODE` into its own block.
- Set `ext.prefix = "${params.genome ?: fasta.baseName}_${add_fasta.baseName}"` on `CUSTOM_CATADDITIONALFASTA` so output filenames continue to follow the `{genome}_{add_name}` pattern; the new module default would otherwise rename outputs to `${meta.id}.{fasta,gtf}` (i.e. `genome_transcriptome.{fasta,gtf}`).
- Drop the manual `.mix(CUSTOM_CATADDITIONALFASTA.out.versions)` now that versions flow via the `versions` topic.

**Behavior note**: fixing the withName selector exposes a pre-existing intent that has been masked for some time — `CUSTOM_CATADDITIONALFASTA` outputs are only published when `--save_reference` is set. Previously the stale selector meant those files fell through to the default publishDir and were always dropped into `<outdir>/custom/out/`, regardless of `--save_reference`. Snapshots that captured `custom/out/genome_*.{fasta,gtf}` in their published-file listings lose those entries after this change; the config's own `saveAs` has always filtered them out when `save_reference` is false, the selector just wasn't firing.

### Local module: `deseq2_qc` → topic versions

`modules/local/deseq2_qc` was the last local module still emitting `path "versions.yml", emit: versions`. Converted both `script` and `stub` to emit `r-base` and `bioconductor-deseq2` via two `topic: versions` tuples using `eval` directives (with `Rscript -e 'cat(as.character(getRversion()))'` for r-base to avoid shell parse errors on the release-date parens in `R --version` output).

### Retire `ch_versions` plumbing

Every module the pipeline drives now emits software versions via `topic: versions`, so the hand-rolled `ch_versions` channel is dead plumbing. `channel.topic('versions')` + the existing branch/collate path in `workflows/rnaseq/main.nf` already feeds `softwareVersionsToYAML` for the MultiQC input.

Removed:
- `ch_versions = channel.empty()` initialisers across `main.nf`, `workflows/rnaseq/main.nf`, `subworkflows/local/prepare_genome/main.nf`.
- The `ch_versions` take / emit blocks on `PREPARE_GENOME`, `RNASEQ`, `NFCORE_RNASEQ`.
- Every `ch_versions.mix(... .out.versions)` call site.
- `workflow.out.versions` / `process.out.versions` assertions in `prepare_genome` and `deseq2_qc` tests.

`softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))` becomes `softwareVersionsToYAML(topic_versions.versions_file)` — the topic already contains everything we collated manually.

### Notes

- `nf-core/multiqc` still has `emit: versions` on a plain channel by design — pushing to the topic it also consumes would deadlock — and nothing on our side collects that emit, so no further plumbing to cut.

## Test plan

- [x] Full CI matrix green (83 pass / 0 fail across docker, docker-arm64, GPU docker + GPU singularity)
- [x] Snapshot diffs match expectations from the publishDir selector fix, prefix rewire, versions-topic migration, and `ch_versions` removal
- [x] `tests/gpu_ribodetector.nf.test` still exercises the updated ribodetector container (passes under GPU CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)