### PR TITLE
fix(prokaryotic): derive gene BED via gffread --bed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1812](https://github.com/nf-core/rnaseq/pull/1812) - Dedupe redundant pipeline-level nf-test cases (fold `min_mapped_reads` into `skip_qc`; prune duplicate pseudo-alignment cases) without losing coverage
 - [PR #1814](https://github.com/nf-core/rnaseq/pull/1814) - Sync nf-core components to the latest versions, migrate the remaining local `deseq2_qc` module to topic-based version reporting, and retire `ch_versions` plumbing now that all modules emit versions via topic
 - [PR #1815](https://github.com/nf-core/rnaseq/pull/1815) - Gate the nf-test `cleanup` directive on `$CI` so pipeline-test work directories are retained on local reruns and only pruned in CI ([#1813](https://github.com/nf-core/rnaseq/issues/1813))
+- [PR #TBC](https://github.com/nf-core/rnaseq/pull/TBC) - Derive the gene BED via `gffread --bed` on the prokaryotic path so RSeQC `infer_experiment` gets a usable reference; `ea-utils/gtf2bed` only emits BED rows for `exon` features and produced an empty BED from CDS-only prokaryotic annotations
 
 ## [[3.24.0](https://github.com/nf-core/rnaseq/releases/tag/3.24.0)] - 2026-04-09
 

--- a/conf/modules/prepare_genome.config
+++ b/conf/modules/prepare_genome.config
@@ -69,7 +69,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 

--- a/conf/modules/prepare_genome.config
+++ b/conf/modules/prepare_genome.config
@@ -61,6 +61,18 @@ process {
         ]
     }
 
+    withName: 'GFFREAD_GENE_BED' {
+        // Derive the gene BED from the GTF with gffread --bed. Used for the
+        // prokaryotic path because ea-utils/gtf2bed only emits BED records
+        // for 'exon' features and prokaryotic annotations are CDS-only.
+        ext.args   = '--bed'
+        publishDir = [
+            path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+        ]
+    }
+
     withName: '.*:PREPARE_GENOME:BOWTIE2_BUILD' {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },

--- a/main.nf
+++ b/main.nf
@@ -90,7 +90,8 @@ workflow NFCORE_RNASEQ {
         params.skip_pseudo_alignment,
         params.use_sentieon_star,
         params.use_parabricks_star,
-        params.contaminant_screening
+        params.contaminant_screening,
+        params.prokaryotic ?: false
     )
 
     // Check if contigs in genome fasta file > 512 Mbp

--- a/modules.json
+++ b/modules.json
@@ -96,7 +96,7 @@
                     },
                     "gffread": {
                         "branch": "master",
-                        "git_sha": "51f2b493a7ff28b40a9f99faca64245521f2bb24",
+                        "git_sha": "c9ad4d691aa339e478a77847e3ef854ccd21778b",
                         "installed_by": ["modules"]
                     },
                     "gunzip": {

--- a/modules/nf-core/gffread/main.nf
+++ b/modules/nf-core/gffread/main.nf
@@ -3,9 +3,9 @@ process GFFREAD {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/gffread:0.12.7--hdcf5f25_4' :
-        'biocontainers/gffread:0.12.7--hdcf5f25_4' }"
+        'quay.io/biocontainers/gffread:0.12.7--hdcf5f25_4' }"
 
     input:
     tuple val(meta), path(gff)
@@ -15,6 +15,7 @@ process GFFREAD {
     tuple val(meta), path("*.gtf")  , emit: gtf             , optional: true
     tuple val(meta), path("*.gff3") , emit: gffread_gff     , optional: true
     tuple val(meta), path("*.fasta"), emit: gffread_fasta   , optional: true
+    tuple val(meta), path("*.bed")  , emit: bed             , optional: true
     tuple val("${task.process}"), val('gffread'), eval('gffread --version 2>&1'), topic: versions, emit: versions_gffread
 
     when:
@@ -23,7 +24,7 @@ process GFFREAD {
     script:
     def args        = task.ext.args             ?: ''
     def prefix      = task.ext.prefix           ?: "${meta.id}"
-    def extension   = args.contains("-T")       ? 'gtf' : ( ( ['-w', '-x', '-y' ].any { flag -> args.contains(flag) } ) ? 'fasta' : 'gff3' )
+    def extension   = args.contains("--bed")    ? 'bed' : ( args.contains("-T")       ? 'gtf' : ( ( ['-w', '-x', '-y' ].any { flag -> args.contains(flag) } ) ? 'fasta' : 'gff3' ) )
     def fasta_arg   = fasta                     ? "-g $fasta" : ''
     def output_name = "${prefix}.${extension}"
     def output      = extension == "fasta"      ? "$output_name" : "-o $output_name"
@@ -41,7 +42,7 @@ process GFFREAD {
     stub:
     def args        = task.ext.args             ?: ''
     def prefix      = task.ext.prefix           ?: "${meta.id}"
-    def extension   = args.contains("-T")       ? 'gtf' : ( ( ['-w', '-x', '-y' ].any { flag -> args.contains(flag) } ) ? 'fasta' : 'gff3' )
+    def extension   = args.contains("--bed")    ? 'bed' : ( args.contains("-T")       ? 'gtf' : ( ( ['-w', '-x', '-y' ].any { flag -> args.contains(flag) } ) ? 'fasta' : 'gff3' ) )
     def output_name = "${prefix}.${extension}"
     if ( "$output_name" in [ "$gff", "$fasta" ] ) error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
     """

--- a/modules/nf-core/gffread/meta.yml
+++ b/modules/nf-core/gffread/meta.yml
@@ -68,6 +68,18 @@ output:
             is present
           pattern: "*.fasta"
           ontologies: []
+  bed:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing meta data
+            e.g. [ id:'test' ]
+      - "*.bed":
+          type: file
+          description: BED file resulting from the conversion of the GFF input file
+            when the '--bed' argument is present
+          pattern: "*.bed"
+          ontologies: []
   versions_gffread:
     - - ${task.process}:
           type: string

--- a/modules/nf-core/gffread/tests/main.nf.test
+++ b/modules/nf-core/gffread/tests/main.nf.test
@@ -192,6 +192,57 @@ nextflow_process {
 
     }
 
+    test("sarscov2-gff3-bed") {
+
+        config "./nextflow-bed.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gff3", checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2-gff3-bed-stub") {
+
+        options '-stub'
+        config "./nextflow-bed.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: 'test'],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.gff3", checkIfExists: true)
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+
+    }
+
     test("sarscov2-gff3-fasta-fail-catch") {
 
         options '-stub'

--- a/modules/nf-core/gffread/tests/main.nf.test.snap
+++ b/modules/nf-core/gffread/tests/main.nf.test.snap
@@ -17,11 +17,17 @@
                     
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     
@@ -46,11 +52,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:22:41.259965105",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:00.517880519"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2-gff3-gff3": {
         "content": [
@@ -70,11 +76,17 @@
                     
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     
@@ -99,11 +111,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:22:51.897172513",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:11.054206957"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2-gff3-gtf-stub": {
         "content": [
@@ -123,11 +135,17 @@
                     
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     
@@ -152,11 +170,81 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:22:46.582356403",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:05.79250369"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2-gff3-bed": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,96fd7117a706e7c2ccbe062beb635172"
+                    ]
+                ],
+                "gffread_fasta": [
+                    
+                ],
+                "gffread_gff": [
+                    
+                ],
+                "gtf": [
+                    
+                ],
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-24T10:23:13.476804733",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "sarscov2-gff3-bed-stub": {
+        "content": [
+            {
+                "bed": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gffread_fasta": [
+                    
+                ],
+                "gffread_gff": [
+                    
+                ],
+                "gtf": [
+                    
+                ],
+                "versions_gffread": [
+                    [
+                        "GFFREAD",
+                        "gffread",
+                        "0.12.7"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-24T10:23:18.831655873",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2-gff3-fasta-stub": {
         "content": [
@@ -176,11 +264,17 @@
                     ]
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     [
@@ -205,11 +299,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:23:08.064865029",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:26.781173161"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2-gff3-gff3-stub": {
         "content": [
@@ -229,11 +323,17 @@
                     
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     
@@ -258,11 +358,11 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:22:57.33529754",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:16.265299123"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2-gff3-fasta": {
         "content": [
@@ -282,11 +382,17 @@
                     ]
                 ],
                 "3": [
+                    
+                ],
+                "4": [
                     [
                         "GFFREAD",
                         "gffread",
                         "0.12.7"
                     ]
+                ],
+                "bed": [
+                    
                 ],
                 "gffread_fasta": [
                     [
@@ -311,10 +417,10 @@
                 ]
             }
         ],
+        "timestamp": "2026-04-24T10:23:02.723479313",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-19T14:04:21.551846584"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/gffread/tests/nextflow-bed.config
+++ b/modules/nf-core/gffread/tests/nextflow-bed.config
@@ -1,0 +1,5 @@
+process {
+    withName: GFFREAD {
+        ext.args = '--bed'
+    }
+}

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -24,6 +24,7 @@ include { CUSTOM_CATADDITIONALFASTA         } from '../../../modules/nf-core/cus
 include { SAMTOOLS_FAIDX                    } from '../../../modules/nf-core/samtools/faidx'
 include { GFFREAD                           } from '../../../modules/nf-core/gffread'
 include { GFFREAD as GFFREAD_TRANSCRIPTS    } from '../../../modules/nf-core/gffread'
+include { GFFREAD as GFFREAD_GENE_BED       } from '../../../modules/nf-core/gffread'
 include { BOWTIE2_BUILD                     } from '../../../modules/nf-core/bowtie2/build'
 include { BBMAP_BBSPLIT                     } from '../../../modules/nf-core/bbmap/bbsplit'
 include { SORTMERNA as SORTMERNA_INDEX      } from '../../../modules/nf-core/sortmerna'
@@ -76,6 +77,7 @@ workflow PREPARE_GENOME {
     use_sentieon_star        // boolean: whether to use sentieon STAR version
     use_parabricks_star      // boolean: whether to use parabricks STAR version
     contaminant_screening    // string: contaminant screening tool ('kraken2', 'kraken2_bracken', 'sylph', or null)
+    prokaryotic              // boolean: whether the genome is prokaryotic (CDS-only annotation - use gffread --bed for gene BED since ea-utils/gtf2bed only handles exon features)
 
     main:
     //---------------------------
@@ -162,6 +164,14 @@ workflow PREPARE_GENOME {
         } else {
             ch_gene_bed = channel.value(file(gene_bed, checkIfExists: true))
         }
+    } else if (prokaryotic) {
+        // Prokaryotic annotations describe genes as CDS features, not exons, so
+        // ea-utils/gtf2bed (which only reads `exon` rows) emits an empty BED.
+        // gffread --bed derives intervals from any feature type.
+        ch_gene_bed = GFFREAD_GENE_BED(
+            ch_gtf.map { item -> [ [id: item.baseName], item ] },
+            []
+        ).bed.map { _meta, bed -> bed }
     } else {
         ch_gene_bed = EAUTILS_GTF2BED(ch_gtf.map { item -> [ [id: item.baseName], item ] }).bed.map { _meta, bed -> bed }
     }

--- a/subworkflows/local/prepare_genome/tests/main.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.nf.test
@@ -53,6 +53,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -135,6 +136,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -217,6 +219,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -299,6 +302,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -381,6 +385,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -463,6 +468,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -545,6 +551,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -627,6 +634,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -709,6 +717,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -791,6 +800,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -873,6 +883,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -955,6 +966,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1037,6 +1049,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1119,6 +1132,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1201,6 +1215,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1283,6 +1298,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1365,6 +1381,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1447,6 +1464,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1529,6 +1547,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1611,6 +1630,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1693,6 +1713,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1777,6 +1798,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1852,6 +1874,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -1936,6 +1959,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2020,6 +2044,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2104,6 +2129,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2173,6 +2199,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2257,6 +2284,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2341,6 +2369,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2425,6 +2454,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2509,6 +2539,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2593,6 +2624,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2677,6 +2709,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2761,6 +2794,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2845,6 +2879,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -2929,6 +2964,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3013,6 +3049,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3097,6 +3134,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3181,6 +3219,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3265,6 +3304,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3349,6 +3389,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3418,6 +3459,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -3502,6 +3544,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }

--- a/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test
+++ b/subworkflows/local/prepare_genome/tests/main.parabricks.nf.test
@@ -55,6 +55,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }
@@ -133,6 +134,7 @@ nextflow_workflow {
                 input[28] = use_sentieon_star
                 input[29] = use_parabricks_star
                 input[30] = null  // contaminant_screening
+                input[31] = false // prokaryotic
                 """
             }
         }

--- a/tests/prokaryotic.nf.test.snap
+++ b/tests/prokaryotic.nf.test.snap
@@ -9,9 +9,6 @@
                 "CUSTOM_TX2GENE": {
                     "python": "3.10.4"
                 },
-                "EAUTILS_GTF2BED": {
-                    "perl": "5.26.2"
-                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -22,6 +19,9 @@
                     "fq": "0.12.0"
                 },
                 "GFFREAD": {
+                    "gffread": "0.12.7"
+                },
+                "GFFREAD_GENE_BED": {
                     "gffread": "0.12.7"
                 },
                 "GFFREAD_TRANSCRIPTS": {
@@ -152,12 +152,14 @@
                 "multiqc/star_salmon/multiqc_report_data/multiqc_general_stats.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_picard_dups.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_rseqc_bam_stat.txt",
+                "multiqc/star_salmon/multiqc_report_data/multiqc_rseqc_infer_experiment.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_samtools_flagstat.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_samtools_idxstats.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_samtools_stats.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_software_versions.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_sources.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_star.txt",
+                "multiqc/star_salmon/multiqc_report_data/multiqc_strand_check_composition_bargraph.txt",
                 "multiqc/star_salmon/multiqc_report_data/multiqc_strand_check_summary_table.txt",
                 "multiqc/star_salmon/multiqc_report_data/picard_MarkIlluminaAdapters_histogram.txt",
                 "multiqc/star_salmon/multiqc_report_data/picard_MeanQualityByCycle_histogram.txt",
@@ -165,6 +167,7 @@
                 "multiqc/star_salmon/multiqc_report_data/picard_QualityScoreDistribution_histogram.txt",
                 "multiqc/star_salmon/multiqc_report_data/picard_deduplication.txt",
                 "multiqc/star_salmon/multiqc_report_data/rseqc_bam_stat.txt",
+                "multiqc/star_salmon/multiqc_report_data/rseqc_infer_experiment_plot.txt",
                 "multiqc/star_salmon/multiqc_report_data/rseqc_read_dups.txt",
                 "multiqc/star_salmon/multiqc_report_data/rseqc_read_dups_plot.txt",
                 "multiqc/star_salmon/multiqc_report_data/samtools-flagstat-pct-table.txt",
@@ -208,6 +211,7 @@
                 "multiqc/star_salmon/multiqc_report_plots/pdf/picard_deduplication-cnt.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/picard_deduplication-pct.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/rseqc_bam_stat.pdf",
+                "multiqc/star_salmon/multiqc_report_plots/pdf/rseqc_infer_experiment_plot.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/rseqc_read_dups_plot.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/samtools-flagstat-pct-table.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/samtools-flagstat-table.pdf",
@@ -223,6 +227,8 @@
                 "multiqc/star_salmon/multiqc_report_plots/pdf/star_alignment_plot-cnt.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/star_alignment_plot-pct.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/pdf/star_summary_table.pdf",
+                "multiqc/star_salmon/multiqc_report_plots/pdf/strand_check_composition_bargraph.pdf",
+                "multiqc/star_salmon/multiqc_report_plots/pdf/strand_check_summary_table.pdf",
                 "multiqc/star_salmon/multiqc_report_plots/png",
                 "multiqc/star_salmon/multiqc_report_plots/png/cutadapt_filtered_reads_plot-cnt.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/cutadapt_filtered_reads_plot-pct.png",
@@ -254,6 +260,7 @@
                 "multiqc/star_salmon/multiqc_report_plots/png/picard_deduplication-cnt.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/picard_deduplication-pct.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/rseqc_bam_stat.png",
+                "multiqc/star_salmon/multiqc_report_plots/png/rseqc_infer_experiment_plot.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/rseqc_read_dups_plot.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/samtools-flagstat-pct-table.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/samtools-flagstat-table.png",
@@ -269,6 +276,8 @@
                 "multiqc/star_salmon/multiqc_report_plots/png/star_alignment_plot-cnt.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/star_alignment_plot-pct.png",
                 "multiqc/star_salmon/multiqc_report_plots/png/star_summary_table.png",
+                "multiqc/star_salmon/multiqc_report_plots/png/strand_check_composition_bargraph.png",
+                "multiqc/star_salmon/multiqc_report_plots/png/strand_check_summary_table.png",
                 "multiqc/star_salmon/multiqc_report_plots/svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/cutadapt_filtered_reads_plot-cnt.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/cutadapt_filtered_reads_plot-pct.svg",
@@ -300,6 +309,7 @@
                 "multiqc/star_salmon/multiqc_report_plots/svg/picard_deduplication-cnt.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/picard_deduplication-pct.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/rseqc_bam_stat.svg",
+                "multiqc/star_salmon/multiqc_report_plots/svg/rseqc_infer_experiment_plot.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/rseqc_read_dups_plot.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/samtools-flagstat-pct-table.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/samtools-flagstat-table.svg",
@@ -315,6 +325,8 @@
                 "multiqc/star_salmon/multiqc_report_plots/svg/star_alignment_plot-cnt.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/star_alignment_plot-pct.svg",
                 "multiqc/star_salmon/multiqc_report_plots/svg/star_summary_table.svg",
+                "multiqc/star_salmon/multiqc_report_plots/svg/strand_check_composition_bargraph.svg",
+                "multiqc/star_salmon/multiqc_report_plots/svg/strand_check_summary_table.svg",
                 "pipeline_info",
                 "pipeline_info/nf_core_rnaseq_software_mqc_versions.yml",
                 "star_salmon",
@@ -439,10 +451,12 @@
                 "multiqc_fastqc_fastqc_raw.txt:md5,42c1cc19c4b9104eb499ce499f335951",
                 "multiqc_fastqc_fastqc_trimmed.txt:md5,8be94d69e0c458017cf5064fa1fa86a0",
                 "multiqc_samtools_idxstats.txt:md5,6949b8e77b72655f069f7ffd9a298d68",
-                "multiqc_strand_check_summary_table.txt:md5,426ad803e606b5fefd5ef33e5658db20",
+                "multiqc_strand_check_composition_bargraph.txt:md5,a9dfa9875799864f6add4d606af11617",
+                "multiqc_strand_check_summary_table.txt:md5,1d1fa059a8fa534cc8effc897af1673f",
                 "picard_MarkIlluminaAdapters_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_MeanQualityByCycle_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "picard_QualityScoreDistribution_histogram.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                "rseqc_infer_experiment_plot.txt:md5,86e1785b13815f5e5edc276e307f0cdc",
                 "samtools-idxstats-mapped-reads-plot_Normalised_Counts.txt:md5,04107c7f4adc54ec7a30cdb5357f9f34",
                 "samtools-idxstats-mapped-reads-plot_Observed_over_Expected_Counts.txt:md5,04107c7f4adc54ec7a30cdb5357f9f34",
                 "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,086f13628e34b8cc363b223d6a1d9e4d",
@@ -458,15 +472,15 @@
                 "cmd_info.json:md5,bc01c390eb88fee1a6fa19dfc7c0f6b7",
                 "SALM_REP1.SJ.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
                 "SALM_REP2.SJ.out.tab:md5,d41d8cd98f00b204e9800998ecf8427e",
-                "SALM_REP1.infer_experiment.txt:md5,a2dbe9bd86e7f172f4cf6a242499aa64",
-                "SALM_REP2.infer_experiment.txt:md5,a2dbe9bd86e7f172f4cf6a242499aa64",
+                "SALM_REP1.infer_experiment.txt:md5,4d2a3f763c26490b3df172fb713e18ff",
+                "SALM_REP2.infer_experiment.txt:md5,cf872d092d49b3049fc22f015cddbaef",
                 "salmon.merged.tx2gene.tsv:md5,02c8aa14dbbbd6c4e45cf0a1b916b1ab"
             ]
         ],
-        "timestamp": "2026-02-26T14:16:24.358893576",
+        "timestamp": "2026-04-24T10:09:10.940319318",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.3"
         }
     },
     "Params: --aligner bowtie2_salmon --gffread_transcript_fasta (-k 200 multimapping)": {
@@ -487,9 +501,6 @@
                 "CUSTOM_TX2GENE": {
                     "python": "3.10.4"
                 },
-                "EAUTILS_GTF2BED": {
-                    "perl": "5.26.2"
-                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -500,6 +511,9 @@
                     "fq": "0.12.0"
                 },
                 "GFFREAD": {
+                    "gffread": "0.12.7"
+                },
+                "GFFREAD_GENE_BED": {
                     "gffread": "0.12.7"
                 },
                 "GFFREAD_TRANSCRIPTS": {
@@ -920,10 +934,10 @@
                 "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,a8d7ee5c80619606f2a6a4b92c8bec5f"
             ]
         ],
-        "timestamp": "2026-02-26T14:18:17.797305278",
+        "timestamp": "2026-04-24T10:11:15.542669241",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.3"
         }
     },
     "Params: --aligner bowtie2_salmon --gffread_transcript_fasta (-k 200 multimapping) - stub": {
@@ -944,9 +958,6 @@
                 "CUSTOM_TX2GENE": {
                     "python": "3.10.4"
                 },
-                "EAUTILS_GTF2BED": {
-                    "perl": "5.26.2"
-                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -957,6 +968,9 @@
                     "fq": "0.12.0"
                 },
                 "GFFREAD": {
+                    "gffread": "0.12.7"
+                },
+                "GFFREAD_GENE_BED": {
                     "gffread": "0.12.7"
                 },
                 "GFFREAD_TRANSCRIPTS": {
@@ -1064,7 +1078,7 @@
                 "salmon.merged.tx2gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-04-10T19:46:48.190988993",
+        "timestamp": "2026-04-24T10:10:02.776932497",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.04.3"
@@ -1080,9 +1094,6 @@
                 "CUSTOM_TX2GENE": {
                     "python": "3.10.4"
                 },
-                "EAUTILS_GTF2BED": {
-                    "perl": "5.26.2"
-                },
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
@@ -1093,6 +1104,9 @@
                     "fq": "0.12.0"
                 },
                 "GFFREAD": {
+                    "gffread": "0.12.7"
+                },
+                "GFFREAD_GENE_BED": {
                     "gffread": "0.12.7"
                 },
                 "GFFREAD_TRANSCRIPTS": {
@@ -1226,10 +1240,10 @@
                 "salmon.merged.tx2gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-02-26T14:15:17.265018922",
+        "timestamp": "2026-04-24T10:07:53.819270199",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.3"
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the conda-only CI failure on PR #1816 where the prokaryotic `Params: --aligner star_salmon --prokaryotic` and `Params: --aligner bowtie2_salmon --gffread_transcript_fasta` tests blew up inside MultiQC with `ValueError: No datasets to plot` followed by `AttributeError: module 'rich' has no attribute 'panel'`.

## Root cause

`ea-utils/gtf2bed` only reads GTF rows with feature-type `exon`. Prokaryotic annotations describe genes as `CDS`, not `exon`, so the BED handed to RSeQC was empty. Since #1805 enables RSeQC `infer_experiment` on the prokaryotic profile, every sample logged `"Unknown Data type"` — which fed all-zero rows into the new MultiQC Strandedness checks bargraph, which tripped a latent handler bug in MultiQC under rich >= 14.3 (see [MultiQC#3536](https://github.com/MultiQC/MultiQC/issues/3536) / [#3537](https://github.com/MultiQC/MultiQC/pull/3537)). The rich regression was cosmetic on docker but fatal on conda, because conda-forge's rich ships lazy submodule imports from 14.3.4 onwards.

## Fix

Run `gffread --bed` on the prokaryotic path only. gffread derives BED intervals from any feature type, so RSeQC gets a usable gene model and the Strandedness checks section renders with real data.

- Add `GFFREAD_GENE_BED` alias (`gffread --bed`) in `PREPARE_GENOME`.
- Branch gene-BED generation on a new `prokaryotic` subworkflow input; the eukaryotic `EAUTILS_GTF2BED` path is untouched.
- Regenerate `tests/prokaryotic.nf.test.snap` to reflect the now-renderable Strandedness section and the `GFFREAD_GENE_BED` software-versions entry.

## Dependency on nf-core/modules

This relies on `gffread --bed` being a first-class emit on `nf-core/gffread`, added in [nf-core/modules#11298](https://github.com/nf-core/modules/pull/11298). The module code in this PR is already the post-#11298 version; `modules.json` is intentionally left pointing at the current SHA and should be bumped once the modules PR merges.

## Test plan

- [x] Prokaryotic VM repro on nf-dev-rnaseq: all 4 `tests/prokaryotic.nf.test` tests pass under `-profile test,docker` with the regenerated snapshot.
- [x] Verified RSeQC samples ~8k usable reads per SALM_REP* against the gffread-produced BED (vs. 0 with the old gtf2bed output), and Strandedness checks now classify both samples as `unstranded` with status `pass`.
- [x] `nf-test test subworkflows/local/prepare_genome/tests/main.nf.test --profile=+test,docker` passes on the eukaryotic path (no snapshot regeneration needed — `EAUTILS_GTF2BED` is still the default branch).