### PR TITLE
chore: drop redundant versions.yml filters from saveAs closures

### DIFF
--- a/.github/workflows/nf-test-arm.yml
+++ b/.github/workflows/nf-test-arm.yml
@@ -18,7 +18,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.3"
+  NFT_VER: "0.9.5"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # renovate: datasource=github-releases depName=askimed/nf-test versioning=semver
-  NFT_VER: "0.9.3"
+  NFT_VER: "0.9.5"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity
   NXF_SINGULARITY_LIBRARYDIR: ${{ github.workspace }}/.singularity

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NFT_VER: "0.9.3"
+  NFT_VER: "0.9.5"
   NFT_WORKDIR: "~"
   NXF_ANSI_LOG: false
   NXF_SINGULARITY_CACHEDIR: ${{ github.workspace }}/.singularity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1812](https://github.com/nf-core/rnaseq/pull/1812) - Dedupe redundant pipeline-level nf-test cases (fold `min_mapped_reads` into `skip_qc`; prune duplicate pseudo-alignment cases) without losing coverage
 - [PR #1814](https://github.com/nf-core/rnaseq/pull/1814) - Sync nf-core components to the latest versions, migrate the remaining local `deseq2_qc` module to topic-based version reporting, and retire `ch_versions` plumbing now that all modules emit versions via topic
 - [PR #1815](https://github.com/nf-core/rnaseq/pull/1815) - Gate the nf-test `cleanup` directive on `$CI` so pipeline-test work directories are retained on local reruns and only pruned in CI ([#1813](https://github.com/nf-core/rnaseq/issues/1813))
+- [PR #1818](https://github.com/nf-core/rnaseq/pull/1818) - Drop redundant `versions.yml` clauses from `saveAs` closures on processes that now emit versions via the `versions` topic; name closure parameters instead of implicit `it` in local workflow / subworkflow files
 
 ## [[3.24.0](https://github.com/nf-core/rnaseq/releases/tag/3.24.0)] - 2026-04-09
 

--- a/conf/modules/bigwig.config
+++ b/conf/modules/bigwig.config
@@ -51,8 +51,7 @@ process {
     withName: '.*:BEDGRAPH_BEDCLIP_BEDGRAPHTOBIGWIG_(FORWARD|REVERSE|COMBINED):UCSC_BEDGRAPHTOBIGWIG' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/bigwig" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/modules/fastp.config
+++ b/conf/modules/fastp.config
@@ -4,8 +4,7 @@ process {
         ext.prefix = { "${meta.id}_raw" }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fastqc/raw" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -14,8 +13,7 @@ process {
         ext.prefix = { "${meta.id}_trimmed" }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fastqc/trim" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 

--- a/conf/modules/featurecounts.config
+++ b/conf/modules/featurecounts.config
@@ -7,8 +7,7 @@ process {
         ].join(' ').trim() }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/featurecounts" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 

--- a/conf/modules/multiqc.config
+++ b/conf/modules/multiqc.config
@@ -12,8 +12,7 @@ process {
                     "${params.outdir}/${meta.id}/multiqc" + (params.skip_alignment ? '' : "/${params.aligner}")
                 }
             },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/modules/prepare_genome.config
+++ b/conf/modules/prepare_genome.config
@@ -3,7 +3,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -15,7 +15,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -45,7 +45,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -57,7 +57,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -65,7 +65,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -73,7 +73,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -85,7 +85,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -94,7 +94,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -102,7 +102,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -127,7 +127,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -144,7 +144,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -154,7 +154,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/index" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 
@@ -163,7 +163,7 @@ process {
         publishDir = [
             path: { params.save_reference ? "${params.outdir}/genome/sortmerna" : params.outdir },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : params.save_reference ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 }

--- a/conf/modules/qc_trim_filter.config
+++ b/conf/modules/qc_trim_filter.config
@@ -4,32 +4,28 @@ process {
         ext.args   = { params.extra_fqlint_args ?: '' }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fq_lint/raw" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
     withName: 'FQ_LINT_AFTER_TRIMMING' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fq_lint/trimmed" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
     withName: 'FQ_LINT_AFTER_BBSPLIT' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fq_lint/bbsplit" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
     withName: 'FQ_LINT_AFTER_RIBO_REMOVAL' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fq_lint/${params.ribo_removal_tool ?: 'sortmerna'}" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -42,8 +38,7 @@ process {
         ext.prefix = { "${meta.id}_filtered" }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fastqc/filtered" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -70,8 +65,7 @@ process {
         ext.prefix = { "${meta.id}.rrna_removal_stats" }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}ribodetector" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -103,7 +97,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}bowtie2_rrna/index" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : params.save_reference ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
         ]
     }
 

--- a/conf/modules/qualimap.config
+++ b/conf/modules/qualimap.config
@@ -11,8 +11,7 @@ process {
         ext.args = '--sorted'
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/qualimap" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/modules/quantify_bam_salmon.config
+++ b/conf/modules/quantify_bam_salmon.config
@@ -8,7 +8,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('_meta_info.json') || filename.endsWith('_format_counts.json') ? null : filename }
+            saveAs: { filename -> filename.endsWith('_meta_info.json') || filename.endsWith('_format_counts.json') ? null : filename }
         ]
     }
 

--- a/conf/modules/quantify_pseudo_alignment.config
+++ b/conf/modules/quantify_pseudo_alignment.config
@@ -8,7 +8,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.pseudo_aligner}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('_meta_info.json') || filename.endsWith('_format_counts.json') ? null : filename }
+            saveAs: { filename -> filename.endsWith('_meta_info.json') || filename.endsWith('_format_counts.json') ? null : filename }
         ]
     }
 
@@ -17,7 +17,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.pseudo_aligner}" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('.run_info.json') || filename.endsWith('.log') ? null : filename }
+            saveAs: { filename -> filename.endsWith('.run_info.json') || filename.endsWith('.log') ? null : filename }
         ]
     }
 

--- a/conf/modules/quantify_rsem.config
+++ b/conf/modules/quantify_rsem.config
@@ -21,8 +21,7 @@ process {
     withName: '.*:QUANTIFY_RSEM:CUSTOM_RSEMMERGECOUNTS' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rsem_merge_counts" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 

--- a/conf/modules/rseqc.config
+++ b/conf/modules/rseqc.config
@@ -2,16 +2,14 @@ process {
     withName: '.*:BAM_RSEQC:RSEQC_BAMSTAT' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/bam_stat" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
     withName: '.*:BAM_RSEQC:RSEQC_INFEREXPERIMENT' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/infer_experiment" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -83,8 +81,7 @@ process {
     withName: '.*:BAM_RSEQC:RSEQC_READDISTRIBUTION' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/read_distribution" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -93,8 +90,7 @@ process {
             [
                 path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/inner_distance/txt" },
                 mode: params.publish_dir_mode,
-                pattern: '*.txt',
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                pattern: '*.txt'
             ],
             [
                 path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/inner_distance/pdf" },
@@ -112,8 +108,7 @@ process {
     withName: '.*:BAM_RSEQC:RSEQC_TIN' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/rseqc/tin" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/modules/stringtie.config
+++ b/conf/modules/stringtie.config
@@ -3,8 +3,7 @@ process {
         ext.args = { ['-v', '-e'].join(' ').trim() }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/stringtie" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 
@@ -18,7 +17,6 @@ process {
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/stringtie" },
             mode: params.publish_dir_mode,
             saveAs: { filename ->
-                if (filename.equals('versions.yml')) return null
                 if (filename.endsWith('.transcripts.gtf')) return filename
                 return null
             }
@@ -28,8 +26,7 @@ process {
     withName: 'NFCORE_RNASEQ:RNASEQ:BAM_STRINGTIE_MERGE:STRINGTIE_MERGE' {
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}${params.aligner}/stringtie" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 }

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -4,8 +4,7 @@ process {
         ext.prefix = { "${meta.id}_raw" }
         publishDir = [
             path: { "${params.outdir}/${task.ext.publish_prefix}fastqc/raw" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            mode: params.publish_dir_mode
         ]
     }
 

--- a/subworkflows/local/multiqc_rnaseq/main.nf
+++ b/subworkflows/local/multiqc_rnaseq/main.nf
@@ -131,7 +131,7 @@ workflow MULTIQC_RNASEQ {
         [
             [id: id],
             files,
-            [mqc_default_config, dynamic_config, mqc_custom_config].findAll { it },
+            [mqc_default_config, dynamic_config, mqc_custom_config].findAll { cfg -> cfg },
             mqc_logo,
             replace_names,
             [],
@@ -170,7 +170,7 @@ workflow MULTIQC_RNASEQ {
                 [
                     row[1],
                     row.drop(2)
-                        .findAll { it != null }
+                        .findAll { entry -> entry != null }
                         .collectMany { entry -> (entry instanceof List) ? entry : [entry] },
                 ]
             }
@@ -436,7 +436,7 @@ def strandCheckCompositionYaml(static_config, rows) {
     def config  = new LinkedHashMap(static_config)
     def pconfig = new LinkedHashMap(config.pconfig)
     if (datasets.size() > 1) {
-        pconfig.data_labels = labels.collect { [name: it, ylab: pconfig.ylab] }
+        pconfig.data_labels = labels.collect { label -> [name: label, ylab: pconfig.ylab] }
     }
     config.pconfig = pconfig
     config.data    = datasets.size() == 1 ? datasets[0] : datasets

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -703,12 +703,12 @@ def defineQcTools(params) {
 
         if (!params.skip_rseqc) {
             def rseqc_modules = params.rseqc_modules
-                ? params.rseqc_modules.split(',').collect { it.trim().toLowerCase() }
+                ? params.rseqc_modules.split(',').collect { mod -> mod.trim().toLowerCase() }
                 : []
             if (params.bam_csi_index) {
                 rseqc_modules.removeAll(['read_distribution', 'inner_distance', 'tin'])
             }
-            rseqc_modules.each { tools << "rseqc_${it}" }
+            rseqc_modules.each { mod -> tools << "rseqc_${mod}" }
         }
     }
 

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -118,7 +118,7 @@ workflow RNASEQ {
     // meta per sample — if a future module mutates meta on one of them,
     // this aggregation silently emits duplicate rows.
     ch_mqc_per_sample_bundle = channel.empty()
-    def collapseAgg = { row -> [row[0].id, row.drop(1).findAll { it != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
+    def collapseAgg = { row -> [row[0].id, row.drop(1).findAll { e -> e != null }.collectMany { e -> (e instanceof List) ? e : [e] }] }
 
     //
     // Collect versions from the topic channel. Entries are either
@@ -551,7 +551,7 @@ workflow RNASEQ {
     // Pre-compute param-derived values for QC subworkflow
     //
     def biotype = params.gencode ? "gene_type" : params.featurecounts_group_type
-    def rseqc_modules = qc_tools.findAll { it.startsWith('rseqc_') }.collect { it.replace('rseqc_', '') }
+    def rseqc_modules = qc_tools.findAll { tool -> tool.startsWith('rseqc_') }.collect { tool -> tool.replace('rseqc_', '') }
 
     ch_inferexperiment_txt = channel.empty()
 
@@ -604,10 +604,10 @@ workflow RNASEQ {
             // Extract infer_experiment from rseqc channel
             ch_inferexperiment_txt = RUSTQC.out.rseqc
                 .map { meta, files ->
-                    def ie = (files instanceof List ? files : [files]).find { it.name.endsWith('.infer_experiment.txt') }
+                    def ie = (files instanceof List ? files : [files]).find { f -> f.name.endsWith('.infer_experiment.txt') }
                     ie ? [meta, ie] : null
                 }
-                .filter { it != null }
+                .filter { entry -> entry != null }
         } else {
             //
             // SUBWORKFLOW: Post-alignment QC


### PR DESCRIPTION
Addresses review feedback on [#1816](https://github.com/nf-core/rnaseq/pull/1816) about `saveAs: { filename -> filename.equals('versions.yml') ? null : filename }` closures that are no longer necessary.

Modules that emit versions via the `versions` topic no longer produce a `versions.yml` output file, so the filter is a no-op for them. This PR drops the `versions.yml` clause from every affected closure (or drops the closure entirely where the filter was its only purpose).

Modules that still emit a `versions.yml` path keep their filter:

- `CUSTOM_MULTIQCCUSTOMBIOTYPE`
- `EAUTILS_GTF2BED`
- `CUSTOM_CATADDITIONALFASTA`
- `CUSTOM_GTFFILTER`
- `CUSTOM_TX2GENE`, `TXIMETA_TXIMPORT`
- `SE_*` (summarizedexperiment)

## saveAs cleanup

13 `conf/modules/*.config` files touched. Three shapes of minimal edit:

```diff
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
+        ]
```

```diff
-            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('.log') ? null : filename }
+            saveAs: { filename -> filename.endsWith('.log') ? null : filename }
```

```diff
-            saveAs: { filename -> (filename != 'versions.yml' && params.save_reference) ? filename : null }
+            saveAs: { filename -> params.save_reference ? filename : null }
```

## Named closure parameters

Replace implicit `it` with explicit parameter names in `main.nf`, `subworkflows/local/multiqc_rnaseq/main.nf`, `subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf`, and `workflows/rnaseq/main.nf`, for readability in nested closures.

## nf-test version bump

`NFT_VER` bumped from `0.9.3` to `0.9.5` across the three `.github/workflows/nf-test*.yml` files. The 0.9.3 harness template emits `${process}(*input)` using Groovy's spread operator, which Nextflow 26.03.x-edge's new strict parser rejects (breaking every `latest-everything` shard on #1816). 0.9.4+ switched the template to `${process}.run(input.toArray())`, which parses cleanly.