### PR TITLE
bump(trimgalore): module to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1821](https://github.com/nf-core/rnaseq/pull/1821) - Bump version to 3.26.0dev after release 3.25.0; flip the MultiQC report links and RO-Crate URL/version back to dev
 - [PR #1823](https://github.com/nf-core/rnaseq/pull/1823) - Reinstall `trimgalore` module to pull in [nf-core/modules#11308](https://github.com/nf-core/modules/pull/11308), which removes orphan `*_trimmed.fq.gz` outputs left in the workdir by an interrupted previous trim_galore attempt (e.g. AWS Batch retry after a Spot reclaim) that were breaking `FQ_LINT_AFTER_TRIMMING` ([#1807](https://github.com/nf-core/rnaseq/issues/1807))
 - [PR #1829](https://github.com/nf-core/rnaseq/pull/1829) - Disambiguate the three FastQC instances (raw / trimmed / filtered) in MultiQC General Statistics by suffixing each instance's column titles with `(raw)`, `(trim)` and `(filt)` ([#1828](https://github.com/nf-core/rnaseq/issues/1828))
-- [PR #1832](https://github.com/nf-core/rnaseq/pull/1832) - Bump `trimgalore` module to 2.1.0 ([nf-core/modules#11524](https://github.com/nf-core/modules/pull/11524))
+- [PR #1833](https://github.com/nf-core/rnaseq/pull/1833) - Bump `trimgalore` module to 2.1.0 ([nf-core/modules#11524](https://github.com/nf-core/modules/pull/11524))
 
 ## [[3.25.0](https://github.com/nf-core/rnaseq/releases/tag/3.25.0)] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1821](https://github.com/nf-core/rnaseq/pull/1821) - Bump version to 3.26.0dev after release 3.25.0; flip the MultiQC report links and RO-Crate URL/version back to dev
 - [PR #1823](https://github.com/nf-core/rnaseq/pull/1823) - Reinstall `trimgalore` module to pull in [nf-core/modules#11308](https://github.com/nf-core/modules/pull/11308), which removes orphan `*_trimmed.fq.gz` outputs left in the workdir by an interrupted previous trim_galore attempt (e.g. AWS Batch retry after a Spot reclaim) that were breaking `FQ_LINT_AFTER_TRIMMING` ([#1807](https://github.com/nf-core/rnaseq/issues/1807))
 - [PR #1829](https://github.com/nf-core/rnaseq/pull/1829) - Disambiguate the three FastQC instances (raw / trimmed / filtered) in MultiQC General Statistics by suffixing each instance's column titles with `(raw)`, `(trim)` and `(filt)` ([#1828](https://github.com/nf-core/rnaseq/issues/1828))
+- [PR #1832](https://github.com/nf-core/rnaseq/pull/1832) - Bump `trimgalore` module to 2.1.0 ([nf-core/modules#11524](https://github.com/nf-core/modules/pull/11524))
 
 ## [[3.25.0](https://github.com/nf-core/rnaseq/releases/tag/3.25.0)] - 2026-04-24
 

--- a/modules.json
+++ b/modules.json
@@ -349,7 +349,7 @@
                     },
                     "trimgalore": {
                         "branch": "master",
-                        "git_sha": "169eb38ed007a09d0c1fc6eb9f461597dbd66ef7",
+                        "git_sha": "8af1cb1c621cd41413e2ddeaca34717d1a0ff95d",
                         "installed_by": ["fastq_fastqc_umitools_trimgalore", "modules"]
                     },
                     "tximeta/tximport": {

--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -4,5 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::trim-galore=0.6.10
-  - bioconda::cutadapt=5.2
+  - bioconda::trim-galore=2.1.0

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -4,8 +4,8 @@ process TRIMGALORE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/trim-galore:0.6.10--hdfd78af_2' :
-        'quay.io/biocontainers/trim-galore:0.6.10--hdfd78af_2'}"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7e/7e44249e3fafe3d136ea726225551b51bca642387e16d9687b3e602207dedb20/data' :
+        'community.wave.seqera.io/library/trim-galore:2.1.0--27e6376b8f6c1872'}"
 
     input:
     tuple val(meta), path(reads)
@@ -46,8 +46,6 @@ process TRIMGALORE {
         def args_list = args.split("\\s(?=--)").toList()
         args_list.removeAll { arg -> arg.toLowerCase().contains('_r2 ') }
         """
-        # Drop any trim_galore output left over from an interrupted previous attempt.
-        rm -f ${prefix}_trimmed.fq.gz
         [ ! -f  ${prefix}.fastq.gz ] && ln -s ${reads} ${prefix}.fastq.gz
         trim_galore \\
             ${args_list.join(' ')} \\
@@ -58,10 +56,6 @@ process TRIMGALORE {
     }
     else {
         """
-        # Drop the per-mate intermediates --paired writes before validate_paired_end_files
-        # unlinks them. An attempt interrupted between cutadapt and validation leaves these
-        # behind and the output glob then matches 3 fastqs instead of 2.
-        rm -f ${prefix}_1_trimmed.fq.gz ${prefix}_2_trimmed.fq.gz
         [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
         [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
         trim_galore \\

--- a/modules/nf-core/trimgalore/tests/main.nf.test
+++ b/modules/nf-core/trimgalore/tests/main.nf.test
@@ -26,9 +26,8 @@ nextflow_process {
                 { assert process.success },
                 { assert snapshot(
                     process.out.reads,
-                    file(process.out.log[0][1]).readLines()[0..9], // line 11 changes
-                    file(process.out.log[0][1]).readLines()[11..59].findAll { !it.startsWith("This is cutadapt") }, // strip python version
-                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    path(process.out.log[0][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -53,13 +52,10 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads[0][1][0],
-                    process.out.reads[0][1][1],
-                    file(process.out.log[0][1][0]).readLines()[0..9], // line 11 changes
-                    file(process.out.log[0][1][0]).readLines()[11..58].findAll { !it.startsWith("This is cutadapt") }, // strip python version
-                    file(process.out.log[0][1][1]).readLines()[0..9], // line 11 changes
-                    file(process.out.log[0][1][1]).readLines()[11..60].findAll { !it.startsWith("This is cutadapt") }, // strip python version
-                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    process.out.reads,
+                    path(process.out.log[0][1][0]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    path(process.out.log[0][1][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -90,15 +86,11 @@ nextflow_process {
             assertAll (
                 { assert process.success },
                 { assert snapshot(
-                    process.out.reads[0][1][0],
-                    process.out.reads[0][1][1],
-                    process.out.unpaired[0][1][0],
-                    process.out.unpaired[0][1][1],
-                    file(process.out.log[0][1][0]).readLines()[0..9], // line 11 changes
-                    file(process.out.log[0][1][0]).readLines()[11..59].findAll { !it.startsWith("This is cutadapt") }, // strip python version
-                    file(process.out.log[0][1][1]).readLines()[0..9], // line 11 changes
-                    file(process.out.log[0][1][1]).readLines()[11..63].findAll { !it.startsWith("This is cutadapt") }, // strip python version
-                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    process.out.reads,
+                    process.out.unpaired,
+                    path(process.out.log[0][1][0]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    path(process.out.log[0][1][1]).readLines().dropWhile { !it.startsWith("=== Summary") }.join('\n').md5(),
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -125,7 +117,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.reads,
                     process.out.log,
-                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }
@@ -133,7 +125,7 @@ nextflow_process {
 
     test("sarscov2 - fastq - paired-end - stub") {
 
-    options "-stub"
+        options "-stub"
 
         when {
             process {
@@ -154,7 +146,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.reads,
                     process.out.log,
-                    process.out.findAll { key, val -> key.startsWith("versions")}
+                    process.out.findAll { key, val -> key.startsWith("versions") }
                 ).match() }
             )
         }

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -30,166 +30,60 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "0.6.10"
+                        "2.1.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-05-05T08:48:10.832490464",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-15T14:40:14.896140126"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - fastq - paired-end - keep-unpaired": {
         "content": [
-            "test_1_val_1.fq.gz:md5,75413e85910bbc2e1556e12f6479f935",
-            "test_2_val_2.fq.gz:md5,d3c588c12646ebd36a0812fe02d0bda6",
-            "test_1_unpaired_1.fq.gz:md5,17e0e878f6d0e93b9008a05f128660b6",
-            "test_2_unpaired_2.fq.gz:md5,b09a064368a867e099e66df5ef69b044",
             [
-                "",
-                "SUMMARISING RUN PARAMETERS",
-                "==========================",
-                "Input filename: test_1.fastq.gz",
-                "Trimming mode: paired-end",
-                "Trim Galore version: 0.6.10",
-                "Cutadapt version: 5.2",
-                "Number of cores used for trimming: 1",
-                "Quality Phred score cutoff: 20",
-                "Quality encoding type selected: ASCII+33"
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_val_1.fq.gz:md5,75413e85910bbc2e1556e12f6479f935",
+                        "test_2_val_2.fq.gz:md5,d3c588c12646ebd36a0812fe02d0bda6"
+                    ]
+                ]
             ],
             [
-                "Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).",
-                "Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))",
-                "Maximum trimming error rate: 0.1 (default)",
-                "Minimum required adapter overlap (stringency): 1 bp",
-                "Minimum required sequence length for both reads before a sequence pair gets removed: 150 bp",
-                "Length cut-off for read 1: 35 bp (default)",
-                "Length cut-off for read 2: 35 bp (default)",
-                "Output file will be GZIP compressed",
-                "",
-                "",
-                "Command line parameters: -j 1 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC test_1.fastq.gz",
-                "Processing single-end reads on 1 core ...",
-                "",
-                "=== Summary ===",
-                "",
-                "Total reads processed:                     100",
-                "Reads with adapters:                        31 (31.0%)",
-                "Reads written (passing filters):           100 (100.0%)",
-                "",
-                "Total basepairs processed:        13,897 bp",
-                "Quality-trimmed:                       0 bp (0.0%)",
-                "Total written (filtered):         13,851 bp (99.7%)",
-                "",
-                "=== Adapter 1 ===",
-                "",
-                "Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 31 times",
-                "",
-                "Minimum overlap: 1",
-                "No. of allowed errors:",
-                "1-9 bp: 0; 10-13 bp: 1",
-                "",
-                "Bases preceding removed adapters:",
-                "  A: 35.5%",
-                "  C: 25.8%",
-                "  G: 9.7%",
-                "  T: 29.0%",
-                "  none/other: 0.0%",
-                "",
-                "Overview of removed sequences",
-                "length\tcount\texpect\tmax.err\terror counts",
-                "1\t19\t25.0\t0\t19",
-                "2\t10\t6.2\t0\t10",
-                "3\t1\t1.6\t0\t1",
-                "4\t1\t0.4\t0\t1",
-                "",
-                "RUN STATISTICS FOR INPUT FILE: test_1.fastq.gz",
-                "=============================================",
-                "100 sequences processed in total"
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_unpaired_1.fq.gz:md5,17e0e878f6d0e93b9008a05f128660b6",
+                        "test_2_unpaired_2.fq.gz:md5,b09a064368a867e099e66df5ef69b044"
+                    ]
+                ]
             ],
-            [
-                "",
-                "SUMMARISING RUN PARAMETERS",
-                "==========================",
-                "Input filename: test_2.fastq.gz",
-                "Trimming mode: paired-end",
-                "Trim Galore version: 0.6.10",
-                "Cutadapt version: 5.2",
-                "Number of cores used for trimming: 1",
-                "Quality Phred score cutoff: 20",
-                "Quality encoding type selected: ASCII+33"
-            ],
-            [
-                "Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).",
-                "Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))",
-                "Maximum trimming error rate: 0.1 (default)",
-                "Minimum required adapter overlap (stringency): 1 bp",
-                "Minimum required sequence length for both reads before a sequence pair gets removed: 150 bp",
-                "Length cut-off for read 1: 35 bp (default)",
-                "Length cut-off for read 2: 35 bp (default)",
-                "Output file will be GZIP compressed",
-                "",
-                "",
-                "Command line parameters: -j 1 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC test_2.fastq.gz",
-                "Processing single-end reads on 1 core ...",
-                "",
-                "=== Summary ===",
-                "",
-                "Total reads processed:                     100",
-                "Reads with adapters:                        40 (40.0%)",
-                "Reads written (passing filters):           100 (100.0%)",
-                "",
-                "Total basepairs processed:        13,748 bp",
-                "Quality-trimmed:                       0 bp (0.0%)",
-                "Total written (filtered):         13,693 bp (99.6%)",
-                "",
-                "=== Adapter 1 ===",
-                "",
-                "Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 40 times",
-                "",
-                "Minimum overlap: 1",
-                "No. of allowed errors:",
-                "1-9 bp: 0; 10-13 bp: 1",
-                "",
-                "Bases preceding removed adapters:",
-                "  A: 35.0%",
-                "  C: 25.0%",
-                "  G: 5.0%",
-                "  T: 35.0%",
-                "  none/other: 0.0%",
-                "",
-                "Overview of removed sequences",
-                "length\tcount\texpect\tmax.err\terror counts",
-                "1\t28\t25.0\t0\t28",
-                "2\t10\t6.2\t0\t10",
-                "3\t1\t1.6\t0\t1",
-                "4\t1\t0.4\t0\t1",
-                "",
-                "RUN STATISTICS FOR INPUT FILE: test_2.fastq.gz",
-                "=============================================",
-                "100 sequences processed in total",
-                "",
-                "Total number of sequences analysed for the sequence pair length validation: 100",
-                "",
-                "Number of sequence pairs removed because at least one read was shorter than the length cutoff (150 bp): 81 (81.00%)"
-            ],
+            "4cbef464fbc09252a1282078ec23942e",
+            "ee1b8a371f1490e5faf5e346523b8886",
             {
                 "versions_trimgalore": [
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "0.6.10"
+                        "2.1.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-05-05T09:34:57.668635539",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-15T14:39:53.811844594"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - fastq - single-end - stub": {
         "content": [
@@ -216,160 +110,48 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "0.6.10"
+                        "2.1.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-05-05T08:48:05.803691794",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-15T14:40:03.991561892"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - fastq - paired-end": {
         "content": [
-            "test_1_val_1.fq.gz:md5,566d44cca0d22c522d6cf0e50c7165dc",
-            "test_2_val_2.fq.gz:md5,3c023e8e890b897821df3dc98f48c2b3",
             [
-                "",
-                "SUMMARISING RUN PARAMETERS",
-                "==========================",
-                "Input filename: test_1.fastq.gz",
-                "Trimming mode: paired-end",
-                "Trim Galore version: 0.6.10",
-                "Cutadapt version: 5.2",
-                "Number of cores used for trimming: 1",
-                "Quality Phred score cutoff: 20",
-                "Quality encoding type selected: ASCII+33"
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test_1_val_1.fq.gz:md5,566d44cca0d22c522d6cf0e50c7165dc",
+                        "test_2_val_2.fq.gz:md5,3c023e8e890b897821df3dc98f48c2b3"
+                    ]
+                ]
             ],
-            [
-                "Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).",
-                "Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))",
-                "Maximum trimming error rate: 0.1 (default)",
-                "Minimum required adapter overlap (stringency): 1 bp",
-                "Minimum required sequence length for both reads before a sequence pair gets removed: 20 bp",
-                "Output file will be GZIP compressed",
-                "",
-                "",
-                "Command line parameters: -j 1 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC test_1.fastq.gz",
-                "Processing single-end reads on 1 core ...",
-                "",
-                "=== Summary ===",
-                "",
-                "Total reads processed:                     100",
-                "Reads with adapters:                        31 (31.0%)",
-                "Reads written (passing filters):           100 (100.0%)",
-                "",
-                "Total basepairs processed:        13,897 bp",
-                "Quality-trimmed:                       0 bp (0.0%)",
-                "Total written (filtered):         13,851 bp (99.7%)",
-                "",
-                "=== Adapter 1 ===",
-                "",
-                "Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 31 times",
-                "",
-                "Minimum overlap: 1",
-                "No. of allowed errors:",
-                "1-9 bp: 0; 10-13 bp: 1",
-                "",
-                "Bases preceding removed adapters:",
-                "  A: 35.5%",
-                "  C: 25.8%",
-                "  G: 9.7%",
-                "  T: 29.0%",
-                "  none/other: 0.0%",
-                "",
-                "Overview of removed sequences",
-                "length\tcount\texpect\tmax.err\terror counts",
-                "1\t19\t25.0\t0\t19",
-                "2\t10\t6.2\t0\t10",
-                "3\t1\t1.6\t0\t1",
-                "4\t1\t0.4\t0\t1",
-                "",
-                "RUN STATISTICS FOR INPUT FILE: test_1.fastq.gz",
-                "=============================================",
-                "100 sequences processed in total",
-                ""
-            ],
-            [
-                "",
-                "SUMMARISING RUN PARAMETERS",
-                "==========================",
-                "Input filename: test_2.fastq.gz",
-                "Trimming mode: paired-end",
-                "Trim Galore version: 0.6.10",
-                "Cutadapt version: 5.2",
-                "Number of cores used for trimming: 1",
-                "Quality Phred score cutoff: 20",
-                "Quality encoding type selected: ASCII+33"
-            ],
-            [
-                "Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).",
-                "Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))",
-                "Maximum trimming error rate: 0.1 (default)",
-                "Minimum required adapter overlap (stringency): 1 bp",
-                "Minimum required sequence length for both reads before a sequence pair gets removed: 20 bp",
-                "Output file will be GZIP compressed",
-                "",
-                "",
-                "Command line parameters: -j 1 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC test_2.fastq.gz",
-                "Processing single-end reads on 1 core ...",
-                "",
-                "=== Summary ===",
-                "",
-                "Total reads processed:                     100",
-                "Reads with adapters:                        40 (40.0%)",
-                "Reads written (passing filters):           100 (100.0%)",
-                "",
-                "Total basepairs processed:        13,748 bp",
-                "Quality-trimmed:                       0 bp (0.0%)",
-                "Total written (filtered):         13,693 bp (99.6%)",
-                "",
-                "=== Adapter 1 ===",
-                "",
-                "Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 40 times",
-                "",
-                "Minimum overlap: 1",
-                "No. of allowed errors:",
-                "1-9 bp: 0; 10-13 bp: 1",
-                "",
-                "Bases preceding removed adapters:",
-                "  A: 35.0%",
-                "  C: 25.0%",
-                "  G: 5.0%",
-                "  T: 35.0%",
-                "  none/other: 0.0%",
-                "",
-                "Overview of removed sequences",
-                "length\tcount\texpect\tmax.err\terror counts",
-                "1\t28\t25.0\t0\t28",
-                "2\t10\t6.2\t0\t10",
-                "3\t1\t1.6\t0\t1",
-                "4\t1\t0.4\t0\t1",
-                "",
-                "RUN STATISTICS FOR INPUT FILE: test_2.fastq.gz",
-                "=============================================",
-                "100 sequences processed in total",
-                "",
-                "Total number of sequences analysed for the sequence pair length validation: 100",
-                ""
-            ],
+            "4da0165f1c5a0d3f1d5eea9ad17fb1fb",
+            "808929d2f70ffea0ddd7750bbb400b02",
             {
                 "versions_trimgalore": [
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "0.6.10"
+                        "2.1.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-05-05T09:34:52.551563029",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-15T14:39:43.937555685"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - fastq - single-end": {
         "content": [
@@ -382,82 +164,21 @@
                     "test_trimmed.fq.gz:md5,566d44cca0d22c522d6cf0e50c7165dc"
                 ]
             ],
-            [
-                "",
-                "SUMMARISING RUN PARAMETERS",
-                "==========================",
-                "Input filename: test.fastq.gz",
-                "Trimming mode: single-end",
-                "Trim Galore version: 0.6.10",
-                "Cutadapt version: 5.2",
-                "Number of cores used for trimming: 1",
-                "Quality Phred score cutoff: 20",
-                "Quality encoding type selected: ASCII+33"
-            ],
-            [
-                "Defaulting to Illumina universal adapter ( AGATCGGAAGAGC ). Specify -a SEQUENCE to avoid this behavior).",
-                "Adapter sequence: 'AGATCGGAAGAGC' (Illumina TruSeq, Sanger iPCR; default (inconclusive auto-detection))",
-                "Maximum trimming error rate: 0.1 (default)",
-                "Minimum required adapter overlap (stringency): 1 bp",
-                "Minimum required sequence length before a sequence gets removed: 20 bp",
-                "Output file will be GZIP compressed",
-                "",
-                "",
-                "Command line parameters: -j 1 -e 0.1 -q 20 -O 1 -a AGATCGGAAGAGC test.fastq.gz",
-                "Processing single-end reads on 1 core ...",
-                "",
-                "=== Summary ===",
-                "",
-                "Total reads processed:                     100",
-                "Reads with adapters:                        31 (31.0%)",
-                "Reads written (passing filters):           100 (100.0%)",
-                "",
-                "Total basepairs processed:        13,897 bp",
-                "Quality-trimmed:                       0 bp (0.0%)",
-                "Total written (filtered):         13,851 bp (99.7%)",
-                "",
-                "=== Adapter 1 ===",
-                "",
-                "Sequence: AGATCGGAAGAGC; Type: regular 3'; Length: 13; Trimmed: 31 times",
-                "",
-                "Minimum overlap: 1",
-                "No. of allowed errors:",
-                "1-9 bp: 0; 10-13 bp: 1",
-                "",
-                "Bases preceding removed adapters:",
-                "  A: 35.5%",
-                "  C: 25.8%",
-                "  G: 9.7%",
-                "  T: 29.0%",
-                "  none/other: 0.0%",
-                "",
-                "Overview of removed sequences",
-                "length\tcount\texpect\tmax.err\terror counts",
-                "1\t19\t25.0\t0\t19",
-                "2\t10\t6.2\t0\t10",
-                "3\t1\t1.6\t0\t1",
-                "4\t1\t0.4\t0\t1",
-                "",
-                "RUN STATISTICS FOR INPUT FILE: test.fastq.gz",
-                "=============================================",
-                "100 sequences processed in total",
-                "Sequences removed because they became shorter than the length cutoff of 20 bp:\t0 (0.0%)",
-                ""
-            ],
+            "76dd6b9d009e332d2aa6443de525c182",
             {
                 "versions_trimgalore": [
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "0.6.10"
+                        "2.1.0"
                     ]
                 ]
             }
         ],
+        "timestamp": "2026-05-05T09:34:47.273738299",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2025-12-15T14:39:33.985021562"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/tests/contaminant_screening_input.nf.test.snap
+++ b/tests/contaminant_screening_input.nf.test.snap
@@ -37,7 +37,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34
@@ -93,10 +93,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:09:08.666478589",
+        "timestamp": "2026-05-05T10:11:59.316390728",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: contaminant_screening_input=trimmed screens pre-alignment reads": {
@@ -230,7 +230,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1478,10 +1478,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:16:09.077795332",
+        "timestamp": "2026-05-05T10:16:15.017657178",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: contaminant_screening_input=unmapped (default) screens post-alignment reads": {
@@ -1615,7 +1615,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -2863,10 +2863,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:16:18.890515571",
+        "timestamp": "2026-05-05T10:20:02.740758289",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: contaminant screening trimmed input with skip_alignment - stub": {
@@ -2904,7 +2904,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_KRAKEN_DB": {
                     "untar": 1.34
@@ -2956,10 +2956,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:09:11.755621085",
+        "timestamp": "2026-05-05T10:12:23.896766027",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -39,7 +39,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -89,10 +89,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:05:15.139623477",
+        "timestamp": "2026-05-05T11:05:33.03319282",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: default": {
@@ -238,7 +238,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1555,10 +1555,10 @@
                 "i_data.ctab:md5,041edee3193df311f621c09f4991892b"
             ]
         ],
-        "timestamp": "2026-04-22T16:55:37.518809226",
+        "timestamp": "2026-05-05T11:05:05.219464085",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/featurecounts_group_type.nf.test.snap
+++ b/tests/featurecounts_group_type.nf.test.snap
@@ -36,7 +36,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -75,10 +75,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:17:16.00263487",
+        "timestamp": "2026-05-05T10:23:47.13648427",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --featurecounts_group_type false": {
@@ -162,7 +162,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -734,10 +734,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:20:28.012909805",
+        "timestamp": "2026-05-05T10:23:23.176698281",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/hisat2.nf.test.snap
+++ b/tests/hisat2.nf.test.snap
@@ -37,7 +37,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34
@@ -90,10 +90,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:11:20.845830751",
+        "timestamp": "2026-05-05T10:26:23.205424505",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner hisat2": {
@@ -210,7 +210,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34
@@ -1206,10 +1206,10 @@
                 "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,6c323b383a6506d124506405b9463d93"
             ]
         ],
-        "timestamp": "2026-04-22T17:17:55.017730677",
+        "timestamp": "2026-05-05T10:25:55.780218499",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/kallisto.nf.test.snap
+++ b/tests/kallisto.nf.test.snap
@@ -55,7 +55,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -284,10 +284,10 @@
                 "multiqc_strand_check_summary_table.txt:md5,7825c502243e9901873965fd870cd789"
             ]
         ],
-        "timestamp": "2026-04-21T20:09:28.421156775",
+        "timestamp": "2026-05-05T10:27:55.474205553",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --pseudo_aligner kallisto --skip_qc --skip_alignment - stub": {
@@ -322,7 +322,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -360,10 +360,10 @@
                 
             ]
         ],
-        "timestamp": "2026-02-04T17:10:11.124774782",
+        "timestamp": "2026-05-05T10:28:18.775869295",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/nofasta.nf.test.snap
+++ b/tests/nofasta.nf.test.snap
@@ -47,7 +47,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -418,10 +418,10 @@
                 "salmon.merged.tx2gene.tsv:md5,1be389a28cc26d94b19ea918959ac72e"
             ]
         ],
+        "timestamp": "2026-05-05T10:07:08.080043401",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-26T14:11:36.231165357"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/tests/prokaryotic.nf.test.snap
+++ b/tests/prokaryotic.nf.test.snap
@@ -77,7 +77,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -477,10 +477,10 @@
                 "salmon.merged.tx2gene.tsv:md5,02c8aa14dbbbd6c4e45cf0a1b916b1ab"
             ]
         ],
-        "timestamp": "2026-04-24T10:09:10.940319318",
+        "timestamp": "2026-05-05T10:59:39.645057743",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.3"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner bowtie2_salmon --gffread_transcript_fasta (-k 200 multimapping)": {
@@ -556,7 +556,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -924,10 +924,10 @@
                 "samtools-idxstats-mapped-reads-plot_Raw_Counts.txt:md5,a8d7ee5c80619606f2a6a4b92c8bec5f"
             ]
         ],
-        "timestamp": "2026-04-24T14:15:38.453121457",
+        "timestamp": "2026-05-05T11:01:14.47329685",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.3"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner bowtie2_salmon --gffread_transcript_fasta (-k 200 multimapping) - stub": {
@@ -994,7 +994,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1068,10 +1068,10 @@
                 "salmon.merged.tx2gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-04-24T10:10:02.776932497",
+        "timestamp": "2026-05-05T11:00:18.857709829",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.3"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner star_salmon --prokaryotic - stub": {
@@ -1140,7 +1140,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1230,10 +1230,10 @@
                 "salmon.merged.tx2gene.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-04-24T10:07:53.819270199",
+        "timestamp": "2026-05-05T10:58:42.211291025",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.04.3"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/remove_ribo_rna.nf.test.snap
+++ b/tests/remove_ribo_rna.nf.test.snap
@@ -48,7 +48,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -93,10 +93,10 @@
                 "smr_v4.3_fast_db_prefixed.fasta.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
             ]
         ],
-        "timestamp": "2026-04-22T17:21:48.312879133",
+        "timestamp": "2026-05-05T10:57:57.883025981",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --remove_ribo_rna": {
@@ -192,7 +192,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -784,10 +784,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:21:44.295368206",
+        "timestamp": "2026-05-05T10:52:10.446271503",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --remove_ribo_rna - stub": {
@@ -833,7 +833,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -872,10 +872,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:24:56.139466018",
+        "timestamp": "2026-05-05T10:52:36.973527885",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --remove_ribo_rna --ribo_removal_tool bowtie2": {
@@ -990,7 +990,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1595,10 +1595,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:24:58.844418127",
+        "timestamp": "2026-05-05T10:57:30.129165882",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/rustqc.nf.test.snap
+++ b/tests/rustqc.nf.test.snap
@@ -39,7 +39,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -89,10 +89,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:25:36.47970729",
+        "timestamp": "2026-05-05T10:11:24.377798423",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: use_rustqc": {
@@ -205,7 +205,7 @@
                     "stringtie": "2.2.3"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1539,10 +1539,10 @@
                 "i_data.ctab:md5,041edee3193df311f621c09f4991892b"
             ]
         ],
-        "timestamp": "2026-04-22T17:26:31.584067743",
+        "timestamp": "2026-05-05T10:10:57.38038054",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/salmon.nf.test.snap
+++ b/tests/salmon.nf.test.snap
@@ -52,7 +52,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1422,10 +1422,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:29:06.762359837",
+        "timestamp": "2026-05-05T10:31:37.894212004",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --pseudo_aligner salmon --skip_qc --skip_alignment": {
@@ -1481,7 +1481,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1792,10 +1792,10 @@
                 "salmon.merged.tx2gene.tsv:md5,0e2418a69d2eba45097ebffc2f700bfe"
             ]
         ],
-        "timestamp": "2026-04-22T17:27:10.699537381",
+        "timestamp": "2026-05-05T10:29:49.822939673",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --pseudo_aligner salmon --skip_alignment --skip_quantification_merge - stub": {
@@ -1833,7 +1833,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -1949,10 +1949,10 @@
                 "multiqc_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
-        "timestamp": "2026-04-22T17:26:23.085720345",
+        "timestamp": "2026-05-05T10:32:04.709046363",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --pseudo_aligner salmon --skip_qc --skip_alignment - stub": {
@@ -1987,7 +1987,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -2025,10 +2025,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:22:31.000255519",
+        "timestamp": "2026-05-05T10:30:13.849250938",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/skip_qc.nf.test.snap
+++ b/tests/skip_qc.nf.test.snap
@@ -92,7 +92,7 @@
                     "stringtie": "2.2.3"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -713,10 +713,10 @@
                 "i_data.ctab:md5,525413b70bcf62c24c8f96182e09883e"
             ]
         ],
-        "timestamp": "2026-04-22T17:31:56.890594261",
+        "timestamp": "2026-05-05T10:05:34.813987688",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --skip_qc --min_mapped_reads 90 - stub": {
@@ -756,7 +756,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -795,10 +795,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:23:19.511258206",
+        "timestamp": "2026-05-05T10:05:59.404490958",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/star_rsem.nf.test.snap
+++ b/tests/star_rsem.nf.test.snap
@@ -147,7 +147,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1278,10 +1278,10 @@
                 "i_data.ctab:md5,7e81ace0a68bfe42482420b7275de195"
             ]
         ],
-        "timestamp": "2026-04-22T17:31:07.391686257",
+        "timestamp": "2026-05-05T10:35:22.651323033",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner star_rsem - stub": {
@@ -1327,7 +1327,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -1377,10 +1377,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:32:41.06267044",
+        "timestamp": "2026-05-05T10:35:47.84104358",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/umi.nf.test.snap
+++ b/tests/umi.nf.test.snap
@@ -123,7 +123,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1231,10 +1231,10 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-22T17:34:37.104038632",
+        "timestamp": "2026-05-05T10:44:25.200204538",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "--umi_dedup_tool 'umitools'": {
@@ -1352,7 +1352,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -2497,10 +2497,10 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-22T17:37:05.820604066",
+        "timestamp": "2026-05-05T10:41:38.77987356",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Params: --aligner hisat2 --umi_dedup_tool 'umicollapse'": {
@@ -2602,7 +2602,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UMICOLLAPSE": {
                     "umicollapse": "1.1.0-0"
@@ -3495,10 +3495,10 @@
                 "WT_REP2.umi_extract_2.fastq.gz:md5,067ff23f8d1307ad241cd70bc186b5c1"
             ]
         ],
-        "timestamp": "2026-04-22T17:25:23.385280417",
+        "timestamp": "2026-05-05T10:38:26.215367524",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "--umi_dedup_tool 'umitools - stub": {
@@ -3541,7 +3541,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "UMITOOLS_EXTRACT": {
                     "umitools": "1.1.6"
@@ -3600,10 +3600,10 @@
                 
             ]
         ],
-        "timestamp": "2026-04-22T17:33:28.968724315",
+        "timestamp": "2026-05-05T10:44:56.544257063",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/uncompressed_fastq.nf.test.snap
+++ b/tests/uncompressed_fastq.nf.test.snap
@@ -129,7 +129,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "0.6.10"
+                    "trimgalore": "2.1.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1347,10 +1347,10 @@
                 "i_data.ctab:md5,fca03502dd5b5e2831a64ff133d8c0b5"
             ]
         ],
-        "timestamp": "2026-04-22T17:29:28.690498135",
+        "timestamp": "2026-05-05T10:02:03.931128932",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Force-installs `trimgalore` from [nf-core/modules#11524](https://github.com/nf-core/modules/pull/11524), bumping `trim-galore` from 0.6.10 to 2.1.0 (Wave-built containers; the module no longer carries `cutadapt` as an explicit dep since 2.x reimplements adapter trimming internally).
- Drops the `rm -f` intermediate-file workarounds that #1823 (#1807) added against 0.6.10. trim-galore 2.x no longer writes the per-mate `*_trimmed.fq.gz` intermediates that were causing the `FQ_LINT_AFTER_TRIMMING` glob mismatch on Spot retries, so the workaround is no longer load-bearing.
- Updates 14 pipeline-level snapshots under `tests/` for the version string flip. No md5 changes: trim-galore 2.x produces bit-identical trimmed reads to 0.6.10 on the test datasets, so all downstream BAM/count hashes are stable.
- `CHANGELOG.md` entry under `dev`.

Snapshots regenerated locally with `nf-test test --update-snapshot --profile=test,docker --tag pipeline` against each affected pipeline test (sentieon/GPU tests skipped via `SKIP_SENTIEON` / `SKIP_GPU`).

## Test plan

- [ ] CI green on `dev` matrix (docker + conda)