### PR TITLE
Address review feedback from #1838

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,13 @@ Special thanks to the following for their contributions to the release:
 
 ### Software dependencies
 
-| Dependency    | Old version | New version |
-| ------------- | ----------- | ----------- |
-| `trim-galore` | 0.6.10      | 2.1.0       |
-| `gawk`        |             | 5.3.1       |
-| `STAR`        | 2.6.1d      |             |
+| Dependency      | Old version | New version |
+| --------------- | ----------- | ----------- |
+| `trim-galore`   | 0.6.10      | 2.1.0       |
+| `gawk`          |             | 5.3.1       |
+| `STAR` (legacy) | 2.6.1d      |             |
 
-`gawk` is added as a dependency of the new `STAR_GENOMEPARAMS_UPGRADE` local module. The STAR 2.6.1d row reflects removal of the parallel legacy aligner pin; pipeline-default STAR (2.7.4a) is unchanged.
+`gawk` is added as a dependency of the new `STAR_GENOMEPARAMS_UPGRADE` local module. The `STAR` (legacy) row reflects removal of the parallel STAR 2.6.1d build that ran alongside the default aligner for legacy iGenomes indices; the pipeline-default STAR is unchanged.
 
 ## [[3.25.0](https://github.com/nf-core/rnaseq/releases/tag/3.25.0)] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ Special thanks to the following for their contributions to the release:
 - [PR #1835](https://github.com/nf-core/rnaseq/pull/1835) - Drop the STAR 2.6.1d alignment pin in favour of a metadata-only upgrade adapter. Genome-map entries flagged `star_legacy = true` route through a new `STAR_GENOMEPARAMS_UPGRADE` process that rewrites the legacy `genomeParameters.txt` to the 2.7.4a schema, so stock STAR runs the modern build the pipeline ships; Sentieon and Parabricks STAR branches bypass the upgrade. Removes `STAR_ALIGN_LEGACY`, the parallel STAR 2.6.1d Wave/conda containers, `conf/legacy_star.config`, and the ARM-specific 2.6.1d override
 - [PR #1836](https://github.com/nf-core/rnaseq/pull/1836) - Reinstall `trimgalore` module to pick up upstream label change (`process_high` → `process_medium` + `process_low_memory`); add the matching `process_low_memory` definition (1 GB) to `conf/base.config` per the nf-core/tools template
 - [PR #1837](https://github.com/nf-core/rnaseq/pull/1837) - Bump version to 3.26.0 ahead of release
+- [PR #1839](https://github.com/nf-core/rnaseq/pull/1839) - Address review feedback from #1838: condense the two large `strandCheckSummaryYaml` JSON snapshots in `multiqc_rnaseq` function tests to `.md5()`; add this Software dependencies subsection summarising tool version bumps in 3.26.0
+
+### Software dependencies
+
+| Dependency    | Old version | New version |
+| ------------- | ----------- | ----------- |
+| `trim-galore` | 0.6.10      | 2.1.0       |
+| `gawk`        |             | 5.3.1       |
+| `STAR`        | 2.6.1d      |             |
+
+`gawk` is added as a dependency of the new `STAR_GENOMEPARAMS_UPGRADE` local module. The STAR 2.6.1d row reflects removal of the parallel legacy aligner pin; pipeline-default STAR (2.7.4a) is unchanged.
 
 ## [[3.25.0](https://github.com/nf-core/rnaseq/releases/tag/3.25.0)] - 2026-04-24
 

--- a/subworkflows/local/multiqc_rnaseq/tests/main.function.nf.test
+++ b/subworkflows/local/multiqc_rnaseq/tests/main.function.nf.test
@@ -431,7 +431,7 @@ headers:
         then {
             assertAll(
                 { assert function.success },
-                { assert snapshot(function.result).match() },
+                { assert snapshot(function.result.md5()).match() },
             )
         }
     }
@@ -496,7 +496,7 @@ headers:
                     def sorted = keys.toSorted()
                     assert keys == sorted : "Expected sample keys in alphabetical order, got: ${keys}"
                 },
-                { assert snapshot(function.result).match() },
+                { assert snapshot(function.result.md5()).match() },
             )
         }
     }

--- a/subworkflows/local/multiqc_rnaseq/tests/main.function.nf.test.snap
+++ b/subworkflows/local/multiqc_rnaseq/tests/main.function.nf.test.snap
@@ -11,9 +11,9 @@
     },
     "Test Function strandCheckSummaryYaml emits JSON keyed by sample id": {
         "content": [
-            "{\n    \"id\": \"demo\",\n    \"headers\": {\n        \"provided\": {\n            \"title\": \"Provided\"\n        },\n        \"salmon_inferred\": {\n            \"title\": \"Salmon inferred\"\n        },\n        \"salmon_pct\": {\n            \"title\": \"Salmon %\"\n        },\n        \"salmon_s\": {\n            \"title\": \"Salmon Sense %\"\n        },\n        \"salmon_a\": {\n            \"title\": \"Salmon Antisense %\"\n        },\n        \"salmon_u\": {\n            \"title\": \"Salmon Unstranded %\"\n        },\n        \"rseqc_inferred\": {\n            \"title\": \"RSeQC inferred\"\n        },\n        \"rseqc_pct\": {\n            \"title\": \"RSeQC %\"\n        },\n        \"rseqc_s\": {\n            \"title\": \"RSeQC Sense %\"\n        },\n        \"rseqc_a\": {\n            \"title\": \"RSeQC Antisense %\"\n        },\n        \"rseqc_u\": {\n            \"title\": \"RSeQC Unstranded %\"\n        },\n        \"status\": {\n            \"title\": \"Status\"\n        }\n    },\n    \"data\": {\n        \"WT_REP1\": {\n            \"provided\": \"auto\",\n            \"salmon_inferred\": \"reverse\",\n            \"salmon_pct\": 89.5,\n            \"salmon_s\": 10.0,\n            \"salmon_a\": 85.0,\n            \"salmon_u\": 5.0,\n            \"rseqc_inferred\": \"reverse\",\n            \"rseqc_pct\": 90.5,\n            \"rseqc_s\": 9.1,\n            \"rseqc_a\": 86.3,\n            \"rseqc_u\": 4.6,\n            \"status\": \"pass\"\n        }\n    }\n}"
+            "6d6bfe594a0468fb488595e11423ffdf"
         ],
-        "timestamp": "2026-05-06T12:55:34.777936317",
+        "timestamp": "2026-05-07T11:54:31.102190125",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"
@@ -65,9 +65,9 @@
     },
     "Test Function strandCheckSummaryYaml sorts multi-sample rows by sample id": {
         "content": [
-            "{\n    \"id\": \"demo\",\n    \"headers\": {\n        \"provided\": {\n            \"title\": \"Provided\"\n        },\n        \"salmon_inferred\": {\n            \"title\": \"Salmon inferred\"\n        },\n        \"salmon_pct\": {\n            \"title\": \"Salmon %\"\n        },\n        \"salmon_s\": {\n            \"title\": \"Salmon Sense %\"\n        },\n        \"salmon_a\": {\n            \"title\": \"Salmon Antisense %\"\n        },\n        \"salmon_u\": {\n            \"title\": \"Salmon Unstranded %\"\n        },\n        \"rseqc_inferred\": {\n            \"title\": \"RSeQC inferred\"\n        },\n        \"rseqc_pct\": {\n            \"title\": \"RSeQC %\"\n        },\n        \"rseqc_s\": {\n            \"title\": \"RSeQC Sense %\"\n        },\n        \"rseqc_a\": {\n            \"title\": \"RSeQC Antisense %\"\n        },\n        \"rseqc_u\": {\n            \"title\": \"RSeQC Unstranded %\"\n        },\n        \"status\": {\n            \"title\": \"Status\"\n        }\n    },\n    \"data\": {\n        \"RAP1_IAA_30M_REP1\": {\n            \"provided\": \"auto\",\n            \"salmon_inferred\": \"reverse\",\n            \"salmon_pct\": 88.4,\n            \"salmon_s\": 11.0,\n            \"salmon_a\": 84.0,\n            \"salmon_u\": 5.0,\n            \"rseqc_inferred\": \"reverse\",\n            \"rseqc_pct\": 89.9,\n            \"rseqc_s\": 9.5,\n            \"rseqc_a\": 85.0,\n            \"rseqc_u\": 5.5,\n            \"status\": \"pass\"\n        },\n        \"WT_REP1\": {\n            \"provided\": \"auto\",\n            \"salmon_inferred\": \"reverse\",\n            \"salmon_pct\": 89.5,\n            \"salmon_s\": 10.0,\n            \"salmon_a\": 85.0,\n            \"salmon_u\": 5.0,\n            \"rseqc_inferred\": \"reverse\",\n            \"rseqc_pct\": 90.5,\n            \"rseqc_s\": 9.1,\n            \"rseqc_a\": 86.3,\n            \"rseqc_u\": 4.6,\n            \"status\": \"pass\"\n        },\n        \"WT_REP2\": {\n            \"provided\": \"auto\",\n            \"salmon_inferred\": \"reverse\",\n            \"salmon_pct\": 89.5,\n            \"salmon_s\": 10.0,\n            \"salmon_a\": 85.0,\n            \"salmon_u\": 5.0,\n            \"rseqc_inferred\": \"reverse\",\n            \"rseqc_pct\": 90.5,\n            \"rseqc_s\": 9.1,\n            \"rseqc_a\": 86.3,\n            \"rseqc_u\": 4.6,\n            \"status\": \"pass\"\n        }\n    }\n}"
+            "dca737b419d8f202cf81d15cd1ae1ab1"
         ],
-        "timestamp": "2026-05-06T12:55:44.044854451",
+        "timestamp": "2026-05-07T11:54:40.203882744",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"


### PR DESCRIPTION
Picks up the actionable nitpicks from @famosab's review on #1838:

## Snapshot rendering

The two `strandCheckSummaryYaml` function tests in `multiqc_rnaseq` were emitting ~1 KB of inlined JSON per snapshot entry, which is hard to scan in `git diff`. They now snapshot `function.result.md5()` instead. The structural assertion in the multi-sample test (alphabetical key order via `JsonSlurper`) is unchanged, so we still catch ordering regressions; byte-stability is covered by the md5 snap.

## Software dependencies table for 3.26.0

Added a `### Software dependencies` subsection to the 3.26.0 changelog entry summarising tool changes since 3.25.0:

| Dependency    | Old version | New version |
| ------------- | ----------- | ----------- |
| `trim-galore` | 0.6.10      | 2.1.0       |
| `gawk`        |             | 5.3.1       |
| `STAR`        | 2.6.1d      |             |

(`gawk` is the new local `STAR_GENOMEPARAMS_UPGRADE` dependency; the STAR row reflects #1835 dropping the legacy 2.6.1d pin, not a change to the default STAR.)

## Not addressed (covered in #1838 thread)

- iGenomes "still ship if not recommended": kept for backward compat, will revisit at 4.0.
- Removed-comment in `prepare_genome/main.nf`: those comments were specific to the STAR 2.6.1d legacy path that #1835 removed entirely.
- Nextflow version bump to 25.10.x: nothing in this release needs it; will bump when something does.

## Test plan

- [x] `nf-test test subworkflows/local/multiqc_rnaseq/tests/main.function.nf.test` passes (regenerated snap on a 0.9.5 host so only the two intended entries change)
- [ ] CI nf-test passes
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)