### PR TITLE
Address review feedback from #1838 (Vag)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1836](https://github.com/nf-core/rnaseq/pull/1836) - Reinstall `trimgalore` module to pick up upstream label change (`process_high` → `process_medium` + `process_low_memory`); add the matching `process_low_memory` definition (1 GB) to `conf/base.config` per the nf-core/tools template
 - [PR #1837](https://github.com/nf-core/rnaseq/pull/1837) - Bump version to 3.26.0 ahead of release
 - [PR #1839](https://github.com/nf-core/rnaseq/pull/1839) - Address review feedback from #1838: condense the two large `strandCheckSummaryYaml` JSON snapshots in `multiqc_rnaseq` function tests to `.md5()`; add this Software dependencies subsection summarising tool version bumps in 3.26.0
+- [PR #1840](https://github.com/nf-core/rnaseq/pull/1840) - Address further review feedback from #1838: lowercase `Channel.x` → `channel.x` in local test files and `workflows/rnaseq/main.nf`; pin `params.outdir` in the `PIPELINE_COMPLETION` test so Nextflow execution reports land in the nf-test sandbox instead of a literal `null/pipeline_info/` directory; populate the previously empty "Pipeline specific contribution guidelines" section in `docs/CONTRIBUTING.md` with rnaseq-specific notes (test profiles, CI skip env vars, `.nftignore`, snapshots, version-reporting topic, module configs)
 
 ### Software dependencies
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -185,4 +185,46 @@ If you update images or graphics, follow the nf-core [style guidelines](https://
 
 ## Pipeline specific contribution guidelines
 
-<!-- TODO nf-core: Add any pipeline specific contribution guidelines here, such as coding styles, procedures, checklists etc. -->
+A few conventions that are specific to nf-core/rnaseq and tend to surprise new contributors:
+
+#### Test profiles
+
+The pipeline ships three test profile families: `test` (CPU smoke test, ~15 GB resourceLimits), `test_prokaryotic` (composes on top of `test`, swaps in the bacterial/archaeal samplesheet and `bowtie2_salmon` aligner), and `test_gpu` (~30 GB resourceLimits for GPU CI). `nf-test.config` deliberately does **not** set a default profile - you must always pass one explicitly (e.g. `--profile +test,docker`).
+
+GPU/license-server-bound CI cases are gated on env vars so they don't run by default on contributor laptops:
+
+- `SKIP_GPU=1` skips Parabricks and GPU ribodetector tests
+- `SKIP_SENTIEON=1` skips Sentieon STAR tests
+- `SKIP_PARABRICKS=1` is a finer-grained subset of `SKIP_GPU`
+
+#### Test data
+
+Eukaryotic test data is pulled from the iGenomes S3 mirror (`pipelines_testdata_base_path = s3://ngi-igenomes/testdata/nf-core/pipelines/rnaseq/3.15/`); prokaryotic test data is pulled from `nf-core/test-datasets` on GitHub (Salmonella SL1344 subset). Both are pinned in `conf/test.config` and `conf/test_prokaryotic.config`; if you need to add a new fixture, prefer extending one of those rather than introducing a new bucket.
+
+#### nf-core modules and subworkflows
+
+Modules and subworkflows under `modules/nf-core/` and `subworkflows/nf-core/` are managed by the nf-core tooling - install or update them with `nf-core modules install` / `nf-core subworkflows update`, do **not** edit them directly. Edits should go through a PR to [nf-core/modules](https://github.com/nf-core/modules) first; the pipeline then picks up the new SHA via a `modules.json` bump. Pipeline-specific code (anything not portable to other pipelines) lives under `modules/local/` and `subworkflows/local/`.
+
+#### Module configs
+
+Per-tool publishDir, ext.args, and ext.prefix settings are split into one file per logical group under `conf/modules/` (e.g. `conf/modules/align_star.config`, `conf/modules/quantify_rsem.config`) and included from `nextflow.config`. When you add a new local module, add or extend the matching file rather than dropping settings into `nextflow.config` directly.
+
+#### Version reporting
+
+Modules emit their versions onto the `versions` channel topic so the calling workflow does not have to thread a `ch_versions` through every process (PR #1689). Modules that still also declare a `path "versions.yml", emit: versions` output do so because they are templated (the `.r`/`.py` template script writes the YAML); those modules populate the topic too and don't need migrating - leave them alone.
+
+#### `--genome` reference catalogues
+
+`--genome <key>` resolves a bundle of reference paths from the `params.genomes` map. The pipeline ships the iGenomes catalogue out of the box, but the same mechanism works with a user-authored catalogue - that is the recommended path for modern reference data, since the iGenomes annotations are stale. If you add new fields to genome map entries, make them optional and gate behaviour on their presence (see e.g. the `star_legacy` flag in `conf/igenomes.config`).
+
+#### Snapshots
+
+Non-deterministic outputs (STAR, Salmon, Kallisto, RSEM, HISAT2 indices; qualimap reports) are snapshotted by file-name-only (`getSnapshot()` filtered) rather than content. Deterministic text outputs are snapshotted by md5. Verbose JSON test output (e.g. helper-function tests) should snapshot `.md5()` of the result rather than inlining the JSON. Don't snapshot timestamps or paths that contain hash directories.
+
+#### `.nftignore`
+
+`tests/.nftignore` (and `tests/.nftignore_rustqc` for the RustQC variant) is a list of glob patterns that nf-test excludes from `${outputDir}` snapshots at the pipeline-test level. It is the right place to drop outputs that are content-stable but not byte-stable (e.g. files that include a timestamp, paths under multiqc/multiqc_data, log files where ordering varies), or that are already covered elsewhere. If a pipeline-level snapshot is fluttering on a file you don't actually need to assert on, add it here rather than rerunning until you get lucky.
+
+#### CHANGELOG
+
+One-line entry per PR under the unreleased section, focused on the *what*, not the implementation history. A `### Software dependencies` table at the end of each release section captures tool version bumps (Old → New).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -227,4 +227,4 @@ Non-deterministic outputs (STAR, Salmon, Kallisto, RSEM, HISAT2 indices; qualima
 
 #### CHANGELOG
 
-One-line entry per PR under the unreleased section, focused on the *what*, not the implementation history. A `### Software dependencies` table at the end of each release section captures tool version bumps (Old → New).
+One-line entry per PR under the unreleased section, focused on the _what_, not the implementation history. A `### Software dependencies` table at the end of each release section captures tool version bumps (Old → New).

--- a/modules/local/star_genomeparams_upgrade/tests/main.nf.test
+++ b/modules/local/star_genomeparams_upgrade/tests/main.nf.test
@@ -13,11 +13,11 @@ nextflow_process {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -65,11 +65,11 @@ nextflow_process {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -110,11 +110,11 @@ nextflow_process {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])

--- a/subworkflows/local/align_star/tests/main.extra_args.nf.test
+++ b/subworkflows/local/align_star/tests/main.extra_args.nf.test
@@ -12,11 +12,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -33,7 +33,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -41,12 +41,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)

--- a/subworkflows/local/align_star/tests/main.nf.test
+++ b/subworkflows/local/align_star/tests/main.nf.test
@@ -12,11 +12,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -33,7 +33,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -41,12 +41,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
@@ -97,11 +97,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -126,7 +126,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -134,12 +134,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEPARAMS_UPGRADE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
@@ -186,11 +186,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -207,7 +207,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -215,12 +215,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)

--- a/subworkflows/local/align_star/tests/main.parabricks.nf.test
+++ b/subworkflows/local/align_star/tests/main.parabricks.nf.test
@@ -11,11 +11,11 @@ nextflow_workflow {
             script "../../../../modules/nf-core/star/genomegenerate/main.nf"
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test_fasta' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                 ])
-                input[1] = Channel.of([
+                input[1] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
@@ -33,7 +33,7 @@ nextflow_workflow {
                 use_parabricks_star = true
                 skip_markduplicates = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -41,12 +41,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = PARABRICKS_STARGENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
@@ -95,7 +95,7 @@ nextflow_workflow {
                 use_parabricks_star = true
                 skip_markduplicates = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -103,12 +103,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = PARABRICKS_STARGENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)

--- a/subworkflows/local/align_star/tests/main.rg.nf.test
+++ b/subworkflows/local/align_star/tests/main.rg.nf.test
@@ -12,11 +12,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -33,7 +33,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false, seq_platform:'ILLUMINA' ],
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -41,12 +41,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
@@ -83,11 +83,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -104,7 +104,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false, seq_platform:'ILLUMINA', seq_center:'SAMPLE_CENTER' ],
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -112,12 +112,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)

--- a/subworkflows/local/align_star/tests/main.sentieon.nf.test
+++ b/subworkflows/local/align_star/tests/main.sentieon.nf.test
@@ -12,11 +12,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -33,7 +33,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -41,12 +41,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
@@ -93,11 +93,11 @@ nextflow_workflow {
                 script "../../../../modules/nf-core/star/genomegenerate/main.nf"
                 process {
                     """
-                    input[0] = Channel.of([
+                    input[0] = channel.of([
                         [ id:'test_fasta' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ]
                     ])
-                    input[1] = Channel.of([
+                    input[1] = channel.of([
                         [ id:'test_gtf' ],
                         [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                     ])
@@ -114,7 +114,7 @@ nextflow_workflow {
                 use_parabricks_star  = false
                 skip_markduplicates  = false
 
-                input[0] = Channel.of([
+                input[0] = channel.of([
                     [ id:'test', single_end:false ], // meta map
                     [
                         file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
@@ -122,12 +122,12 @@ nextflow_workflow {
                     ]
                 ])
                 input[1] = STAR_GENOMEGENERATE.out.index
-                input[2] = Channel.of([
+                input[2] = channel.of([
                     [ id:'test_gtf' ],
                     [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ]
                 ])
                 input[3] = star_ignore_sjdbgtf
-                input[4] = Channel.of([
+                input[4] = channel.of([
                     [ id:'test_fasta' ],
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test
@@ -7,17 +7,23 @@ nextflow_workflow {
     test("test PIPELINE_COMPLETION successfully completes") {
 
         when {
+            params {
+                // Anchor Nextflow's report/timeline/trace/dag files (wired against
+                // params.outdir in nextflow.config) inside the nf-test sandbox;
+                // without this they land in a literal `null/pipeline_info/` dir.
+                outdir = "${outputDir}"
+            }
             workflow {
                 """
-                input[0] = null // email (string)
-                input[1] = null // email_on_fail (string)
-                input[2] = true // plaintext_email (boolean)
-                input[3] = "${outputDir}" // outputDir (string)
-                input[4] = true // monochrome_logs (boolean)
-                input[5] = "${outputDir}/multiqc_report.html" // multiqc_report (string)
-                input[6] = Channel.of(['test_sample', true])
-                input[7] = Channel.of(['test_sample', true])
-                input[8] = Channel.of(['test_sample', true])
+                input[0] = null                              // email (only used by completionEmail when set)
+                input[1] = null                              // email_on_fail (likewise)
+                input[2] = true                              // plaintext_email
+                input[3] = "${outputDir}"                    // outdir (unused in this null-email path)
+                input[4] = true                              // monochrome_logs
+                input[5] = "${outputDir}/multiqc_report.html" // multiqc_report
+                input[6] = channel.of(['test_sample', true])
+                input[7] = channel.of(['test_sample', true])
+                input[8] = channel.of(['test_sample', true])
                 """
             }
         }

--- a/workflows/rnaseq/main.nf
+++ b/workflows/rnaseq/main.nf
@@ -613,7 +613,7 @@ workflow RNASEQ {
                 ch_gtf.map { gtf -> [ [:], gtf ] },
                 ch_gene_bed,
                 ch_fasta_fai,
-                Channel.value([ [:], ch_biotypes_header_multiqc ]),
+                channel.value([ [:], ch_biotypes_header_multiqc ]),
                 qc_tools,
                 biotype
             )


### PR DESCRIPTION
Picks up the actionable points from @vagkaratzas's review on #1838.

## `Channel.x` → `channel.x` in local code

Vag flagged a few `Channel.of` leftovers and asked whether `nextflow lint` would catch them (it does). Lowercased every uppercase `Channel.` reference in local test files (`subworkflows/local/align_star/tests/*`, `subworkflows/local/utils_nfcore_rnaseq_pipeline/tests/main.pipeline_completion.workflow.nf.test`, `modules/local/star_genomeparams_upgrade/tests/main.nf.test`) and the one in `workflows/rnaseq/main.nf`.

`nf-core/` components are deliberately untouched - those would need upstream PRs and SHA bumps via `nf-core modules update`, which is out of scope here.

## `outputDir` in the `PIPELINE_COMPLETION` test

Vag asked whether `input[3] = "${outputDir}"` in the pipeline_completion test was actually scoped to the nf-test sandbox or leaking to pipeline-level. Verified on the VM:

- `${outputDir}` is the per-test sandbox (`.nf-test/tests/<id>/output`), good.
- The `outdir` workflow input is consumed by `completionEmail()` only when `email || email_on_fail` is set. Both are null in this test, so `input[3]` is unused on this code path.
- However, `nextflow.config` wires `report.file`, `timeline.file`, `trace.file`, `dag.file` against `params.outdir`, which is null at the test level. That's why a literal `null/pipeline_info/` directory was being created in the test sandbox.

Fix: add a `params { outdir = "${outputDir}" }` block to the test so the Nextflow execution reports land in `output/pipeline_info/` instead. Verified the `null/` directory no longer appears post-fix and the test still passes.

## `docs/CONTRIBUTING.md`

Replaced the empty `<!-- TODO nf-core: ... -->` placeholder under "Pipeline specific contribution guidelines" with rnaseq-specific notes: test profile families, CI skip env vars (`SKIP_GPU` / `SKIP_SENTIEON` / `SKIP_PARABRICKS`), test data sources, the "edit nf-core modules upstream, not in-tree" rule, `conf/modules/` config split, version-reporting topic (and the templated-module exception), `--genome` catalogues, snapshot conventions, and `.nftignore`. Kept it tight, no walls of prose.

## CHANGELOG

Adds a #1840 entry under the 3.26.0 release section.

## Test plan

- [x] `pipeline_completion` test passes on VM, no `null/` dir
- [x] `align_star` tests (rg, extra_args) pass on VM after `Channel.x` → `channel.x` rewrite
- [x] `star_genomeparams_upgrade` module tests pass on VM
- [ ] CI nf-test passes
- [ ] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)