### PR TITLE
fix(trimgalore): restore --cores 8 by pinning TRIMGALORE to 12 cpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1837](https://github.com/nf-core/rnaseq/pull/1837) - Bump version to 3.26.0 ahead of release
 - [PR #1839](https://github.com/nf-core/rnaseq/pull/1839) - Address review feedback from #1838: condense the two large `strandCheckSummaryYaml` JSON snapshots in `multiqc_rnaseq` function tests to `.md5()`; add this Software dependencies subsection summarising tool version bumps in 3.26.0
 - [PR #1840](https://github.com/nf-core/rnaseq/pull/1840) - Address further review feedback from #1838: lowercase `Channel.x` → `channel.x` in local test files and `workflows/rnaseq/main.nf`; pin `params.outdir` in the `PIPELINE_COMPLETION` test so Nextflow execution reports land in the nf-test sandbox instead of a literal `null/pipeline_info/` directory; populate the previously empty "Pipeline specific contribution guidelines" section in `docs/CONTRIBUTING.md` with rnaseq-specific notes (test profiles, CI skip env vars, `.nftignore`, snapshots, version-reporting topic, module configs)
+- [PR #1841](https://github.com/nf-core/rnaseq/pull/1841) - Pin `TRIMGALORE` to 12 cpus on the rnaseq-side selector to restore `--cores 8` (paired) after the upstream label downgrade in #1836 dropped `task.cpus` to 6 and halved trim_galore throughput
 
 ### Software dependencies
 

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -9,6 +9,7 @@ process {
     }
 
     withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
+        cpus       = { 12 * task.attempt }
         ext.args   = {
             // Initialize the map with preconfigured values
             def preset_args_map = ["--fastqc_args": "'-t ${task.cpus}'"]


### PR DESCRIPTION
## Summary

- Upstream nf-core/modules relabelled `TRIMGALORE` from `process_high` (12 cpus) to `process_medium` + `process_low_memory` (6 cpus, 1 GB), pulled in via the reinstall in #1836.
- The module's internal `--cores` formula is `task.cpus - 4` (paired), clamped to `[1, 8]`, so the cpu downgrade also drops `--cores` from 8 to 2 and roughly halves trim_galore throughput on hosts that can spare the cores.
- Override `cpus = { 12 * task.attempt }` on the `.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE` selector in `conf/modules/trimgalore.config` to restore the previous behaviour without diverging from the upstream module.

Memory pressure stays low because the upstream `process_low_memory` (1 GB) label still applies for memory accounting; only `cpus` is overridden here.

## Test plan

- [ ] CI nf-test run on this branch is green (test profile resourceLimits cap cpus to 4, so the override is a no-op there - this PR is about behaviour on full-resource environments).
- [ ] On a full-resource run (Seqera Platform / a `process_high`-sized executor), confirm trim_galore is invoked with `--cores 8` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)