### PR TITLE
fix(trimgalore): drop TRIMGALORE override from 12 to 8 cpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Special thanks to the following for their contributions to the release:
 - [PR #1839](https://github.com/nf-core/rnaseq/pull/1839) - Address review feedback from #1838: condense the two large `strandCheckSummaryYaml` JSON snapshots in `multiqc_rnaseq` function tests to `.md5()`; add this Software dependencies subsection summarising tool version bumps in 3.26.0
 - [PR #1840](https://github.com/nf-core/rnaseq/pull/1840) - Address further review feedback from #1838: lowercase `Channel.x` → `channel.x` in local test files and `workflows/rnaseq/main.nf`; pin `params.outdir` in the `PIPELINE_COMPLETION` test so Nextflow execution reports land in the nf-test sandbox instead of a literal `null/pipeline_info/` directory; populate the previously empty "Pipeline specific contribution guidelines" section in `docs/CONTRIBUTING.md` with rnaseq-specific notes (test profiles, CI skip env vars, `.nftignore`, snapshots, version-reporting topic, module configs)
 - [PR #1841](https://github.com/nf-core/rnaseq/pull/1841) - Pin `TRIMGALORE` to 12 cpus on the rnaseq-side selector to restore `--cores 8` (paired) after the upstream label downgrade in #1836 dropped `task.cpus` to 6 and halved trim_galore throughput
+- [PR #1842](https://github.com/nf-core/rnaseq/pull/1842) - Drop the `TRIMGALORE` override from 12 to 8 cpus (`--cores 4` paired); megatests on #1841 showed `--cores 8` only saturates ~2.78 cores effectively, so the lower allocation gives near-identical wall-clock at lower cost
 
 ### Software dependencies
 

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -9,7 +9,7 @@ process {
     }
 
     withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
-        cpus       = { 12 * task.attempt }
+        cpus       = { 8 * task.attempt }
         ext.args   = {
             // Initialize the map with preconfigured values
             def preset_args_map = ["--fastqc_args": "'-t ${task.cpus}'"]


### PR DESCRIPTION
## Summary

Follow-up to #1841. Megatests on the merge commit (`979a7c2`, `cpus=12` → `--cores 8`) show trim_galore only saturates ~2.78 of the 12 allocated cores per paired-end task:

| | `--cores 2` (cpus=6) | `--cores 8` (cpus=12) |
|---|---|---|
| avg `realtime` | ~14.9 min | ~9.6 min |
| avg `pcpu` | ~175% | ~278% |
| effective cores in use | ~1.75 | ~2.78 |
| `pcpu × realtime` (CPU-seconds) | ~1590 s | ~1610 s |

Same total CPU work either way, just smeared across slightly more cores. The module's internal `--cores` formula (`task.cpus - 4`) was tuned for the original Perl/cutadapt/pigz wrapper where each `--cores` unit also implied a cutadapt subprocess and pigz I/O thread; with the Rust rewrite (`trim_galore` 2.x) those subprocesses are gone and the per-`--cores` accounting overshoots the useful parallelism. Empirically the ceiling lands around 3 effective cores even when `--cores 8` is requested.

Dropping the override to 8 cpus → `--cores 4` (paired) should land within a minute or two of `--cores 8` while freeing 4 cores per task on AWS Batch.

## Test plan

- [ ] CI nf-test runs are green (test profile resourceLimits cap at 4 cpus, so this is a no-op there - PR is about full-resource behaviour).
- [ ] Next megatests run on this commit to confirm wall-clock stays close to the `--cores 8` numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)