### PR TITLE
Change Slack channel from 'rnaseq' to 'rnaseq_dev' for awsfulltest notifications

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -44,7 +44,7 @@ jobs:
               enabled = true
               bot {
                 token = '${{ secrets.NFSLACK_BOT_TOKEN }}'
-                channel = 'rnaseq'
+                channel = 'rnaseq_dev'
               }
               onStart {
                 enabled = false


### PR DESCRIPTION
Is the more logical place imo.
