### PR TITLE
ci(nf-test): align actions/checkout SHA across pipeline workflows

### DIFF
--- a/.github/workflows/nf-test-arm.yml
+++ b/.github/workflows/nf-test-arm.yml
@@ -40,7 +40,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -90,7 +90,7 @@ jobs:
       TOTAL_SHARDS: ${{ needs.nf-test-changes-arm.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -37,7 +37,7 @@ jobs:
       total_shards: ${{ steps.set-shards.outputs.total_shards }}
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Enhancements and fixes
 
 - [PR #1844](https://github.com/nf-core/rnaseq/pull/1844) - Bump version to 3.27.0dev after release 3.26.0; flip the MultiQC report links and RO-Crate URL/version back to dev
+- [PR #1848](https://github.com/nf-core/rnaseq/pull/1848) - Align `actions/checkout` SHA in `nf-test-arm.yml` and `nf-test-gpu.yml` with the template-derived `nf-test.yml` (`v6`) ([#1847](https://github.com/nf-core/rnaseq/issues/1847))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 


### PR DESCRIPTION
## Summary

Closes #1847 (Task 1 only — see "Task 2 status" below).

Bumps `actions/checkout` in the pipeline-specific nf-test workflows so all three workflows use the same SHA-pinned `v6` that the template-derived `nf-test.yml` already pins:

- `.github/workflows/nf-test-arm.yml` (lines 43, 93): `v5` → `v6` (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `.github/workflows/nf-test-gpu.yml` (lines 40, 85): `v4` → `v6` (same SHA)
- `.github/workflows/nf-test.yml`: unchanged (already `v6`, template-owned)

No other action drift between the three workflows: the shared composite actions (`./.github/actions/get-shards`, `./.github/actions/nf-test`) cover `nf-core/setup-nextflow`, `actions/setup-python`, `nf-core/setup-nf-test`, `eWaterCycle/setup-apptainer`, `conda-incubator/setup-miniconda`, so all three callers get identical pins.

## Task 2 status (snapshot timestamp stripping)

The original issue proposed a second task: strip the `timestamp` field from saved `tests/*.nf.test.snap` files via an `nf-test.config` `snapshot.exclude` option, with a fallback of post-processing if no such option exists. I checked the nf-test 0.9.5 source: `SnapshotFileItem` hardcodes `timestamp` via `DateTimeFormatter.ISO_DATE_TIME.format(LocalDateTime.now())` and `SnapshotFile#createJsonGenerator` only excludes `mapping` from the JSON output. There is no config-level option today, and no upstream issue tracking one. The post-processing fallback (jq/python strip) would diverge from what nf-test writes on every regen and adds maintenance burden, so I'm not pursuing it here.

Task 2 is therefore deferred. Will follow up with an upstream feature request against `askimed/nf-test` and link it from #1847 once it's filed.

## Test plan

- [ ] `Run nf-test on ARM` workflow runs green on this PR (exercises the new `actions/checkout@v6` SHA).
- [ ] `Run GPU nf-tests` workflow runs green on this PR.
- [ ] `Run nf-test` (CPU) workflow runs green — sanity check, unchanged.