### PR TITLE
build(arm): drop seqera channel, build SORTMERNA ARM container from bioconda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1850](https://github.com/nf-core/rnaseq/pull/1850) - Use the active aligner's display name in the MultiQC `fail_mapped` per-sample status row, and drop the hardcoded "STAR" reference from the pipeline-completion `min_mapped_reads` warning, so Bowtie2 reports no longer mislabel the metric as STAR ([#1846](https://github.com/nf-core/rnaseq/issues/1846))
 - [PR #1851](https://github.com/nf-core/rnaseq/pull/1851) - Split `PREPARE_GENOME` into `PREPARE_GENOME_REFERENCES` (FASTA / GTF / BED / transcript FASTA / chrom.sizes / rRNA / Kraken DB) and `PREPARE_GENOME_INDICES` (per-aligner index build/load) for clearer ownership; no user-facing parameter, output, or behaviour change ([#1721](https://github.com/nf-core/rnaseq/issues/1721)).
 - [PR #1852](https://github.com/nf-core/rnaseq/pull/1852) - Flatten `workflows/rnaseq/assets/` back to top-level `assets/` so `nf-core pipelines bump-version` finds `assets/multiqc_config.yml` and updates the report-comment URLs automatically on release bumps
-- Switch the `SORTMERNA` ARM container in `conf/arm.config` to a Wave build from `bioconda::sortmerna=4.3.7`, retiring the last `seqera::` channel reference in the pipeline ([#1431](https://github.com/nf-core/rnaseq/issues/1431))
+- [PR #1854](https://github.com/nf-core/rnaseq/pull/1854) - Switch the `SORTMERNA` ARM container in `conf/arm.config` to a Wave build from `bioconda::sortmerna=4.3.7`, retiring the last `seqera::` channel reference in the pipeline ([#1431](https://github.com/nf-core/rnaseq/issues/1431))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1850](https://github.com/nf-core/rnaseq/pull/1850) - Use the active aligner's display name in the MultiQC `fail_mapped` per-sample status row, and drop the hardcoded "STAR" reference from the pipeline-completion `min_mapped_reads` warning, so Bowtie2 reports no longer mislabel the metric as STAR ([#1846](https://github.com/nf-core/rnaseq/issues/1846))
 - [PR #1851](https://github.com/nf-core/rnaseq/pull/1851) - Split `PREPARE_GENOME` into `PREPARE_GENOME_REFERENCES` (FASTA / GTF / BED / transcript FASTA / chrom.sizes / rRNA / Kraken DB) and `PREPARE_GENOME_INDICES` (per-aligner index build/load) for clearer ownership; no user-facing parameter, output, or behaviour change ([#1721](https://github.com/nf-core/rnaseq/issues/1721)).
 - [PR #1852](https://github.com/nf-core/rnaseq/pull/1852) - Flatten `workflows/rnaseq/assets/` back to top-level `assets/` so `nf-core pipelines bump-version` finds `assets/multiqc_config.yml` and updates the report-comment URLs automatically on release bumps
+- Switch the `SORTMERNA` ARM container in `conf/arm.config` to a Wave build from `bioconda::sortmerna=4.3.7`, retiring the last `seqera::` channel reference in the pipeline ([#1431](https://github.com/nf-core/rnaseq/issues/1431))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/conf/arm.config
+++ b/conf/arm.config
@@ -308,12 +308,8 @@ process {
         container = { workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0d/0d5139459cbdb26c71b7b27fae2cdacda370b2ee42c912a8d8bd37239bb43e74/data' : 'community.wave.seqera.io/library/rustqc:0.2.1--45a3b97950cc2c2c' }
     }
 
-    // SortMeRNA does not yet have aarch64 builds conda forge. Working on it, using builds from Seqera channel for now
-    // See https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7454
-
     withName: 'SORTMERNA' {
-        conda = 'seqera::sortmerna=4.3.7'
-        container = { workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f1/f161ea3d4083b7d8fcbf8524cb5ab69f386b4e36b771bb5abf9ccf8ab29e9775/data' : 'community.wave.seqera.io/library/sortmerna:4.3.7--4cc83a7bffbaaa61' }
+        container = { workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/1e/1eec0580fa97dc5059cd93a9839d8c255996a55fd7a07e56b0f69d50f98cdb1d/data' : 'community.wave.seqera.io/library/sortmerna:4.3.7--f4ee3dd7648af434' }
     }
 
 }


### PR DESCRIPTION
## Summary

Bioconda now publishes `linux-aarch64` builds of `sortmerna=4.3.7`, so the seqera-channel override in `conf/arm.config` is no longer required. This switches `SORTMERNA` to a fresh Wave build off `bioconda::sortmerna=4.3.7` and removes the last `seqera::` reference in the pipeline.

The legacy STAR 2.6.1d entries that previously also used `seqera::` were removed by #1694 when the iGenomes-specific STAR modules were dropped, so `SORTMERNA` was the last holdout.

Closes #1431.

## Changes

- `conf/arm.config`: replace `SORTMERNA` container URLs with a Wave build from `bioconda::sortmerna=4.3.7`; drop the `conda = 'seqera::sortmerna=4.3.7'` override and the stale comment pointing at the now-resolved conda-forge pinning issue.

## Test plan

- [ ] `nf-test` ARM test job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)