### PR TITLE
Drop resolved RiboDetector ONNX multiprocessing hang warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1852](https://github.com/nf-core/rnaseq/pull/1852) - Flatten `workflows/rnaseq/assets/` back to top-level `assets/` so `nf-core pipelines bump-version` finds `assets/multiqc_config.yml` and updates the report-comment URLs automatically on release bumps
 - [PR #1853](https://github.com/nf-core/rnaseq/pull/1853) - Replace remaining pre-admonition `> **NB:**` / `> **Note**` / `> **Warning**` quoteblocks across `docs/usage.md`, `docs/output.md`, and `README.md` with nf-core flavored `:::note` / `:::warning` admonitions
 - [PR #1854](https://github.com/nf-core/rnaseq/pull/1854) - Switch the `SORTMERNA` ARM container in `conf/arm.config` to a Wave build from `bioconda::sortmerna=4.3.7`, retiring the last `seqera::` channel reference in the pipeline ([#1431](https://github.com/nf-core/rnaseq/issues/1431))
+- [PR #1861](https://github.com/nf-core/rnaseq/pull/1861) - Drop the outdated RiboDetector ONNX multiprocessing hang warnings from `docs/usage.md`, `docs/output.md`, and the `ribo_removal_tool` schema help text, resolved upstream in the pinned `ribodetector=0.3.3` ([#1856](https://github.com/nf-core/rnaseq/issues/1856))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -257,9 +257,6 @@ When `--ribo_removal_tool bowtie2` is specified, the pipeline uses [Bowtie2](htt
 
 #### RiboDetector
 
-> [!WARNING]
-> RiboDetector has known issues with ONNX multiprocessing that can cause hangs in containerized environments. We recommend using SortMeRNA or Bowtie2 instead. See [hzi-bifo/RiboDetector#61](https://github.com/hzi-bifo/RiboDetector/pull/61) for details.
-
 <details markdown="1">
 <summary>Output files</summary>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -240,9 +240,6 @@ nextflow run nf-core/rnaseq --remove_ribo_rna --ribo_removal_tool bowtie2 ...
 
 ### RiboDetector
 
-> [!WARNING]
-> RiboDetector has known issues with ONNX multiprocessing that can cause hangs in containerized environments (Docker, Singularity). This makes it unreliable for production use in Nextflow pipelines. We recommend using SortMeRNA or Bowtie2 for rRNA removal until these issues are resolved upstream. See [hzi-bifo/RiboDetector#61](https://github.com/hzi-bifo/RiboDetector/pull/61) for details.
-
 [RiboDetector](https://github.com/hzi-bifo/RiboDetector) uses machine learning to identify rRNA reads without requiring a reference database. This makes it particularly useful when working with organisms that lack well-characterized rRNA sequences, or when you want to avoid database licensing requirements.
 
 ```bash

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -327,7 +327,7 @@
                     "default": "sortmerna",
                     "fa_icon": "fas fa-tools",
                     "description": "Tool to use for rRNA removal.",
-                    "help_text": "Choose between 'sortmerna' (default), 'bowtie2', or 'ribodetector' for rRNA removal.\n\n- **sortmerna**: Reference-based filtering (default). Requires `--ribo_database_manifest`. Note: Default databases include SILVA sequences requiring licensing for commercial use.\n- **bowtie2**: Alignment-based filtering. Requires `--ribo_database_manifest`. Recommended for users with SILVA licensing concerns as it supports custom databases.\n- **ribodetector**: \u26a0\ufe0f EXPERIMENTAL - ML-based detection without reference requirement. Known ONNX multiprocessing issues can cause hangs in containerized environments. See https://github.com/hzi-bifo/RiboDetector/pull/61",
+                    "help_text": "Choose between 'sortmerna' (default), 'bowtie2', or 'ribodetector' for rRNA removal.\n\n- **sortmerna**: Reference-based filtering (default). Requires `--ribo_database_manifest`. Note: Default databases include SILVA sequences requiring licensing for commercial use.\n- **bowtie2**: Alignment-based filtering. Requires `--ribo_database_manifest`. Recommended for users with SILVA licensing concerns as it supports custom databases.\n- **ribodetector**: ML-based detection without a reference requirement. Useful for organisms lacking well-characterized rRNA sequences or to avoid database licensing requirements.",
                     "enum": ["sortmerna", "ribodetector", "bowtie2"]
                 },
                 "use_gpu_ribodetector": {


### PR DESCRIPTION
## Summary

The RiboDetector developer reports ([#1856](https://github.com/nf-core/rnaseq/issues/1856)) that the ONNX multiprocessing hang ([hzi-bifo/RiboDetector#61](https://github.com/hzi-bifo/RiboDetector/pull/61)) was fixed upstream in v0.3.3. The pipeline already pins `ribodetector=0.3.3` in both the CPU and GPU module environments, so the warnings telling users to avoid RiboDetector are no longer accurate.

This removes the outdated warnings:

- `docs/usage.md` - the RiboDetector `[!WARNING]` callout
- `docs/output.md` - the RiboDetector `[!WARNING]` callout
- `nextflow_schema.json` - the "EXPERIMENTAL / known ONNX multiprocessing issues" text in the `ribo_removal_tool` help, replaced with a neutral description of when RiboDetector is useful

Closes #1856

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `CHANGELOG.md` is updated.
- [x] Documentation is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)