### PR TITLE
bump(deps): nf-schema 2.5.1 -> 2.7.2

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -452,7 +452,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
## Summary

- Bumps the nf-schema plugin from 2.5.1 to 2.7.2

nf-schema 2.7.x added automatic coercion of CLI string values to their schema-declared types during validation (e.g. the string `"true"` is accepted for boolean parameters). This fixes a breakage introduced in Nextflow 26.x, where strict syntax parsing disabled legacy CLI type-casting, causing boolean flags like `--remove_ribo_rna true` to fail validation with `Value is [string] but should be [boolean]`.

Tracked upstream in nf-core/tools#4100. Related: #1860.

## Test plan

- [ ] Run pipeline with `--remove_ribo_rna true` under Nextflow 26.x and confirm validation passes
- [ ] Run existing CI test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)