### PR TITLE
test(rustqc): validate noodles-migration build via pinned dev container

### DIFF
--- a/conf/modules/rustqc.config
+++ b/conf/modules/rustqc.config
@@ -1,5 +1,10 @@
 process {
     withName: 'RUSTQC' {
+        // TEMPORARY (pre-release): pin the noodles-migration build published as the
+        // ghcr `:dev` tag (seqeralabs/RustQC main @ 9cf5121, PR #115) by digest.
+        // Multi-arch (linux/amd64 + linux/arm64). Revert to the released bioconda/Wave
+        // container in modules/nf-core/rustqc/main.nf once a new RustQC version is tagged.
+        container = 'ghcr.io/seqeralabs/rustqc@sha256:8dcaf3dc9a92f63ecd2fe38664adafca7f88b9b4a3f5005afccf4699c77004e3'
         ext.args = {
             def biotype_attr = params.gencode ? "gene_type" : (params.featurecounts_group_type ?: '')
             def strand_arg = meta.strandedness ? "--stranded ${meta.strandedness}" : ''

--- a/modules/nf-core/rustqc/tests/nextflow.config
+++ b/modules/nf-core/rustqc/tests/nextflow.config
@@ -1,5 +1,9 @@
 process {
     withName: 'RUSTQC' {
+        // TEMPORARY (pre-release): pin the noodles-migration build published as the
+        // ghcr `:dev` tag (seqeralabs/RustQC main @ 9cf5121, PR #115) by digest, so the
+        // module nf-test exercises the noodles I/O. Revert once a new version is tagged.
+        container = 'ghcr.io/seqeralabs/rustqc@sha256:8dcaf3dc9a92f63ecd2fe38664adafca7f88b9b4a3f5005afccf4699c77004e3'
         ext.args = '--skip-dup-check --stranded forward'
     }
 }


### PR DESCRIPTION
> [!WARNING]
> **This PR was prepared by an AI agent (Claude Code) and has _not_ been reviewed by a human yet.** Treat all changes and claims below as unverified until a maintainer has checked them.

## Purpose

RustQC migrated its BAM/SAM/CRAM I/O from `rust-htslib` to pure-Rust [noodles](https://github.com/zaeleus/noodles) in [seqeralabs/RustQC#115](https://github.com/seqeralabs/RustQC/pull/115) (merged to `main` @ `9cf5121`). This is an **internal I/O change only** — CLI flags, output directory layout, and MultiQC compatibility are unchanged, and upstream reports scientific outputs are bit-identical (only metadata differs: timestamps, `CITATIONS.md` commit hash, featureCounts header command-line comment).

This PR exists to **prove the noodles build works in this pipeline _before_ a new RustQC release is cut**, by running the RustQC tests against the migrated code on CI.

## Why a `:dev` container instead of a version bump

There is currently **nothing published to bump to**:

| Check | State |
|---|---|
| `Cargo.toml` version on RustQC `main` | still `0.2.1` (not bumped) |
| Latest RustQC tag / release | `v0.2.1` (predates the migration) |
| bioconda recipe | still `0.2.1`, pulls the v0.2.1 release binaries (pre-noodles) |
| Wave container | `rustqc:0.2.1--…` built from that recipe |

So this PR pins the ghcr `:dev` image built from `main` (multi-arch linux/amd64 + linux/arm64) **by digest**, via config overrides, leaving the tracked nf-core module **pristine** (so `nf-core lint` / the modules check stay green):

- `conf/modules/rustqc.config` → pipeline run + pipeline nf-test (`tests/rustqc.nf.test`)
- `modules/nf-core/rustqc/tests/nextflow.config` → module nf-test

```
ghcr.io/seqeralabs/rustqc@sha256:8dcaf3dc9a92f63ecd2fe38664adafca7f88b9b4a3f5005afccf4699c77004e3
```

## Validation performed locally

- **RUSTQC module test** (`modules/nf-core/rustqc/tests/main.nf.test`): ✅ **PASSED** against the `:dev` container. Full-content snapshots of featureCounts / Preseq / RSeQC matched the committed snapshot **byte-for-byte**, version resolved to `0.2.1`, and all scientific assertions held (samtools flagstat 5644, idxstats chr22 5642, Qualimap 5642 / 23.55% exonic, dupRadar `ENSG00000239435` 3389/664).
- **Pipeline test** (`tests/rustqc.nf.test`, `-profile test,docker`): all **5 RUSTQC tasks completed cleanly (exit 0)**. The run as a whole went red **only** on `DESEQ2_QC_BAM_SALMON` / `DESEQ2_QC_PSEUDO` — an unrelated step that consumes quantification counts (not RustQC outputs), runs from an **amd64-only R container under QEMU emulation** on the Apple-Silicon test machine, and is present in the committed snapshot (so it passes on CI's native amd64). This is the reason for opening the PR: to confirm green on CI.

## Out of scope / follow-ups at release time

- No CLI flags, output structure, or replaced-tool set changed.
- The experimental `--use_rustqc` label and the `use_rustqc = false` default are untouched.
- Docs need no change — the pipeline docs never documented building RustQC from source (htslib/cmake), so there are no build-complexity warnings to soften; Preseq/TIN and TIN-difference notes remain accurate.
- **When a new RustQC version is tagged:** revert these two temporary overrides and bump the real pins to the released bioconda/Wave container — `modules/nf-core/rustqc/main.nf`, `meta.yml`, `environment.yml`, and `conf/arm.config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)