### PR TITLE
fix(validation): error when --use_rustqc and --skip_markduplicates are both set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1861](https://github.com/nf-core/rnaseq/pull/1861) - Drop the outdated RiboDetector ONNX multiprocessing hang warnings from `docs/usage.md`, `docs/output.md`, and the `ribo_removal_tool` schema help text, resolved upstream in the pinned `ribodetector=0.3.3` ([#1856](https://github.com/nf-core/rnaseq/issues/1856))
 - [PR #1862](https://github.com/nf-core/rnaseq/pull/1862) - Correct the `docs/usage.md` note to state that `--extra_star_align_args` applies to `--aligner star_rsem`, since STAR runs as a standalone step and RSEM quantifies the resulting BAM ([#1857](https://github.com/nf-core/rnaseq/issues/1857))
 - [PR #1864](https://github.com/nf-core/rnaseq/pull/1864) - Bump nf-schema to 2.7.2, fixing boolean CLI parameter validation failures under Nextflow 26.x strict syntax ([#1860](https://github.com/nf-core/rnaseq/issues/1860))
-- [PR #1866](https://github.com/nf-core/rnaseq/pull/1866) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
+- [PR #1869](https://github.com/nf-core/rnaseq/pull/1869) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1861](https://github.com/nf-core/rnaseq/pull/1861) - Drop the outdated RiboDetector ONNX multiprocessing hang warnings from `docs/usage.md`, `docs/output.md`, and the `ribo_removal_tool` schema help text, resolved upstream in the pinned `ribodetector=0.3.3` ([#1856](https://github.com/nf-core/rnaseq/issues/1856))
 - [PR #1862](https://github.com/nf-core/rnaseq/pull/1862) - Correct the `docs/usage.md` note to state that `--extra_star_align_args` applies to `--aligner star_rsem`, since STAR runs as a standalone step and RSEM quantifies the resulting BAM ([#1857](https://github.com/nf-core/rnaseq/issues/1857))
 - [PR #1864](https://github.com/nf-core/rnaseq/pull/1864) - Bump nf-schema to 2.7.2, fixing boolean CLI parameter validation failures under Nextflow 26.x strict syntax ([#1860](https://github.com/nf-core/rnaseq/issues/1860))
+- [PR #1866](https://github.com/nf-core/rnaseq/pull/1866) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_rnaseq_pipeline/main.nf
@@ -331,6 +331,10 @@ def validateInputParameters() {
         error("Parabricks (--use_parabricks_star) is not compatible with --genome. iGenomes STAR indices are built with a different STAR version than Parabricks bundles. Please supply --fasta and --gtf explicitly instead.")
     }
 
+    if (params.use_rustqc && params.skip_markduplicates) {
+        error("--use_rustqc requires duplicate-marked BAM files. Please remove --skip_markduplicates when using --use_rustqc.")
+    }
+
     if (params.with_umi && !params.skip_umi_extract) {
         if (!params.umitools_bc_pattern && !params.umitools_bc_pattern2) {
             error("UMI-tools requires a barcode pattern to extract barcodes from the reads.")


### PR DESCRIPTION
## Summary

- Adds an upfront pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are used together
- RustQC requires BAM files with duplicates marked (SAM flag `0x400`) but not removed - this combination will always fail at runtime with an opaque error
- The check produces a clear, actionable message pointing the user to remove `--skip_markduplicates`

Fixes #1865.

## Test plan

- [ ] Confirm existing CI passes (no behaviour change for valid param combinations)
- [ ] Manual check: `--use_rustqc --skip_markduplicates` exits with the expected error message before alignment starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)