### PR TITLE
Deterministic tx2gene sample selection in quant_tximport_summarizedexperiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1862](https://github.com/nf-core/rnaseq/pull/1862) - Correct the `docs/usage.md` note to state that `--extra_star_align_args` applies to `--aligner star_rsem`, since STAR runs as a standalone step and RSEM quantifies the resulting BAM ([#1857](https://github.com/nf-core/rnaseq/issues/1857))
 - [PR #1864](https://github.com/nf-core/rnaseq/pull/1864) - Bump nf-schema to 2.7.2, fixing boolean CLI parameter validation failures under Nextflow 26.x strict syntax ([#1860](https://github.com/nf-core/rnaseq/issues/1860))
 - [PR #1869](https://github.com/nf-core/rnaseq/pull/1869) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
+- [PR #1875](https://github.com/nf-core/rnaseq/pull/1875) - Select the tx2gene sample deterministically in `quant_tximport_summarizedexperiment` so the `CUSTOM_TX2GENE` cache survives `-resume` (nf-core/modules#12166)
 - [PR #1883](https://github.com/nf-core/rnaseq/pull/1883) - Update the `tximeta/tximport` module ([nf-core/modules#12362](https://github.com/nf-core/modules/pull/12362)): add a `jq` build dependency and set `LC_COLLATE=C` for reproducible gene-level output ordering
 - [PR #1884](https://github.com/nf-core/rnaseq/pull/1884) - Update `trimgalore` module to 2.3.0
 

--- a/modules.json
+++ b/modules.json
@@ -483,7 +483,7 @@
                     },
                     "quant_tximport_summarizedexperiment": {
                         "branch": "master",
-                        "git_sha": "77df703775155f3f0f8922f9354501e0289348c2",
+                        "git_sha": "2724f164f1c751b368918fb78e7f4049df6f736d",
                         "installed_by": ["quantify_pseudo_alignment", "quantify_rsem"]
                     },
                     "quantify_pseudo_alignment": {

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -28,9 +28,17 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // tx2gene independently per sample. If a use case arises requiring mixed
     // transcriptomes, this will need to be revisited.
     //
+    // The sample is selected by sorting on the staged results name so the same
+    // one is chosen on every run, keeping the CUSTOM_TX2GENE cache key stable
+    // across -resume. Picking by arrival order would vary between runs and
+    // invalidate the cache for tx2gene and everything downstream of it. The
+    // empty-list guard keeps tx2gene from running when no quant results are
+    // supplied, since toSortedList still emits an empty list in that case.
+    //
     ch_tx2gene_quants = quant_results
-        .first()
-        .map { _meta, results -> [ [:], results ] }
+        .toSortedList { a, b -> a[1].name <=> b[1].name }
+        .filter { sorted -> sorted.size() > 0 }
+        .map { sorted -> [ [:], sorted.first()[1] ] }
 
     CUSTOM_TX2GENE (
         gtf.map { gtf_file -> [ [:], gtf_file ] },


### PR DESCRIPTION
## Description

Bumps the `quant_tximport_summarizedexperiment` subworkflow to pull in [nf-core/modules#12166](https://github.com/nf-core/modules/pull/12166) and [nf-core/modules#12168](https://github.com/nf-core/modules/pull/12168).

In `QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT`, the quant results fed to `CUSTOM_TX2GENE` were selected with `.first()`. tx2gene only needs a single sample's quant files (it reads them to find which GTF attribute holds the transcript IDs; all samples share a transcriptome), so picking one sample is correct - but `.first()` picks whichever per-sample quant *arrives first*, and queue-channel arrival order equals task-completion order, which is non-deterministic across runs.

That made `CUSTOM_TX2GENE`'s input non-deterministic: a different sample's `quant` directory was staged on different runs, the task hash changed, and `-resume` re-ran tx2gene even when nothing changed. Since `TXIMETA_TXIMPORT` and the `SummarizedExperiment` builds depend on `CUSTOM_TX2GENE.out.tx2gene`, the cache miss cascaded through the subworkflow.

The subworkflow now selects the sample deterministically, with a guard for the empty-channel case:

```groovy
ch_tx2gene_quants = quant_results
    .toSortedList { a, b -> a[1].name <=> b[1].name }
    .filter { sorted -> sorted.size() > 0 }
    .map { sorted -> [ [:], sorted.first()[1] ] }
```

The chosen sample is arbitrary biologically (tx2gene output is identical for any sample sharing the transcriptome), so pipeline outputs and snapshots are unchanged - this only makes the selection reproducible so `-resume` works. The `.filter` preserves the original no-op-on-empty behaviour for runs that invoke the subworkflow with no quant results (e.g. the unused alignment path when only pseudo-alignment runs).

## Changes

- Bump `quant_tximport_summarizedexperiment` to nf-core/modules#12168 in `modules.json`.
- The synced subworkflow `main.nf` carries the deterministic, empty-safe selection.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core subworkflows lint quant_tximport_summarizedexperiment` passes.
- [x] Verified against `tests/kallisto.nf.test --skip_alignment`; no pipeline output or snapshot change.
- [x] CHANGELOG.md is updated.
- [x] Documentation not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)