### PR TITLE
Update trimgalore module to 2.3.0

### DIFF
--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -58,7 +58,7 @@ jobs:
 
   nf-test-gpu:
     needs: [get-shards]
-    runs-on: "runs-on=${{ github.run_id }}/family=g5.2xlarge/image=ubuntu24-gpu-x64"
+    runs-on: "runs-on=${{ github.run_id }}/family=g5.2xlarge+g6.2xlarge/image=ubuntu24-gpu-x64"
     name: "GPU Test | ${{ matrix.profile }} | ${{ matrix.shard }} | ${{ matrix.NXF_VER }} | ${{ matrix.filters }}"
     env:
       NXF_VER: ${{ matrix.NXF_VER }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1862](https://github.com/nf-core/rnaseq/pull/1862) - Correct the `docs/usage.md` note to state that `--extra_star_align_args` applies to `--aligner star_rsem`, since STAR runs as a standalone step and RSEM quantifies the resulting BAM ([#1857](https://github.com/nf-core/rnaseq/issues/1857))
 - [PR #1864](https://github.com/nf-core/rnaseq/pull/1864) - Bump nf-schema to 2.7.2, fixing boolean CLI parameter validation failures under Nextflow 26.x strict syntax ([#1860](https://github.com/nf-core/rnaseq/issues/1860))
 - [PR #1869](https://github.com/nf-core/rnaseq/pull/1869) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
+- [PR #1884](https://github.com/nf-core/rnaseq/pull/1884) - Update `trimgalore` module to 2.3.0
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/conf/arm.config
+++ b/conf/arm.config
@@ -273,7 +273,7 @@ process {
     }
 
     withName: 'TRIMGALORE' {
-        container = { workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e2/e23b3b324ac8b49a691ba4e74359846850ea082630e13b8ef0bc0392665efc33/data' : 'community.wave.seqera.io/library/trim-galore:2.1.0--7df2aae1e1928c85' }
+        container = { workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/06/0603053a9577911611d7b23a623f29959586c33792e6484d396e26cf09552fd9/data' : 'community.wave.seqera.io/library/trim-galore:2.3.0--41c957a42f06d443' }
     }
 
     withName: 'TXIMETA_TXIMPORT' {

--- a/modules.json
+++ b/modules.json
@@ -349,7 +349,7 @@
                     },
                     "trimgalore": {
                         "branch": "master",
-                        "git_sha": "0991b1032cccfcd9245ef59c6e56d6092ac0b3e7",
+                        "git_sha": "2a30bfb6a1b4667692d734e33e000a3bd1d74a0d",
                         "installed_by": ["fastq_fastqc_umitools_trimgalore", "modules"]
                     },
                     "tximeta/tximport": {

--- a/modules/nf-core/trimgalore/environment.yml
+++ b/modules/nf-core/trimgalore/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::trim-galore=2.1.0
+  - bioconda::trim-galore=2.3.0

--- a/modules/nf-core/trimgalore/main.nf
+++ b/modules/nf-core/trimgalore/main.nf
@@ -5,8 +5,8 @@ process TRIMGALORE {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/7e/7e44249e3fafe3d136ea726225551b51bca642387e16d9687b3e602207dedb20/data' :
-        'community.wave.seqera.io/library/trim-galore:2.1.0--27e6376b8f6c1872'}"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e0/e00369598bd6b7b34a7c83d5496c381104bf8b885c31a4b65b92e6ea2059fbb3/data' :
+        'community.wave.seqera.io/library/trim-galore:2.3.0--6a38a479b4972363'}"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/trimgalore/tests/main.nf.test.snap
+++ b/modules/nf-core/trimgalore/tests/main.nf.test.snap
@@ -30,7 +30,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -74,7 +74,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -110,7 +110,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -142,7 +142,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }
@@ -170,7 +170,7 @@
                     [
                         "TRIMGALORE",
                         "trimgalore",
-                        "2.1.0"
+                        "2.3.0"
                     ]
                 ]
             }

--- a/tests/contaminant_screening_input.nf.test.snap
+++ b/tests/contaminant_screening_input.nf.test.snap
@@ -34,7 +34,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_KRAKEN_DB": {
                     "untar": 1.34
@@ -139,7 +139,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34
@@ -236,7 +236,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_KRAKEN_DB": {
                     "untar": 1.34
@@ -425,7 +425,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1814,7 +1814,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -3107,7 +3107,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_KRAKEN_DB": {
                     "untar": 1.34

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -39,7 +39,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -238,7 +238,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/featurecounts_group_type.nf.test.snap
+++ b/tests/featurecounts_group_type.nf.test.snap
@@ -36,7 +36,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -162,7 +162,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/gpu_ribodetector.nf.test.snap
+++ b/tests/gpu_ribodetector.nf.test.snap
@@ -44,7 +44,7 @@
                     "seqkit": "2.9.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -151,7 +151,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34

--- a/tests/hisat2.nf.test.snap
+++ b/tests/hisat2.nf.test.snap
@@ -37,7 +37,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34
@@ -210,7 +210,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_HISAT2_INDEX": {
                     "untar": 1.34

--- a/tests/kallisto.nf.test.snap
+++ b/tests/kallisto.nf.test.snap
@@ -55,7 +55,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -324,7 +324,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34

--- a/tests/nofasta.nf.test.snap
+++ b/tests/nofasta.nf.test.snap
@@ -47,7 +47,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/parabricks_default.nf.test.snap
+++ b/tests/parabricks_default.nf.test.snap
@@ -85,7 +85,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -677,7 +677,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -773,7 +773,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -915,7 +915,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/prokaryotic.nf.test.snap
+++ b/tests/prokaryotic.nf.test.snap
@@ -77,7 +77,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -558,7 +558,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -998,7 +998,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1146,7 +1146,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/remove_ribo_rna.nf.test.snap
+++ b/tests/remove_ribo_rna.nf.test.snap
@@ -42,7 +42,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -181,7 +181,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -826,7 +826,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -977,7 +977,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/rustqc.nf.test.snap
+++ b/tests/rustqc.nf.test.snap
@@ -39,7 +39,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -205,7 +205,7 @@
                     "stringtie": "2.2.3"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/salmon.nf.test.snap
+++ b/tests/salmon.nf.test.snap
@@ -52,7 +52,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1486,7 +1486,7 @@
                     "bioconductor-summarizedexperiment": "1.32.0"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1840,7 +1840,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -1994,7 +1994,7 @@
                     "samtools": "1.23.1"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34

--- a/tests/sentieon_default.nf.test.snap
+++ b/tests/sentieon_default.nf.test.snap
@@ -39,7 +39,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34
@@ -233,7 +233,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"

--- a/tests/skip_qc.nf.test.snap
+++ b/tests/skip_qc.nf.test.snap
@@ -92,7 +92,7 @@
                     "stringtie": "2.2.3"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -760,7 +760,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34

--- a/tests/star_rsem.nf.test.snap
+++ b/tests/star_rsem.nf.test.snap
@@ -147,7 +147,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1329,7 +1329,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UNTAR_SALMON_INDEX": {
                     "untar": 1.34

--- a/tests/umi.nf.test.snap
+++ b/tests/umi.nf.test.snap
@@ -123,7 +123,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -1354,7 +1354,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"
@@ -2606,7 +2606,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UMICOLLAPSE": {
                     "umicollapse": "1.1.0-0"
@@ -3545,7 +3545,7 @@
                     "star": "2.7.11b"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "UMITOOLS_EXTRACT": {
                     "umitools": "1.1.6"

--- a/tests/uncompressed_fastq.nf.test.snap
+++ b/tests/uncompressed_fastq.nf.test.snap
@@ -129,7 +129,7 @@
                     "subread": "2.0.6"
                 },
                 "TRIMGALORE": {
-                    "trimgalore": "2.1.0"
+                    "trimgalore": "2.3.0"
                 },
                 "TXIMETA_TXIMPORT": {
                     "bioconductor-tximeta": "1.20.1"


### PR DESCRIPTION
## Summary
- Bumps the `nf-core/trimgalore` module from 2.1.0 to 2.3.0 via `nf-core modules update` (conda pin, container, `modules.json` git_sha, module test snapshot)
- Updates the `trimgalore` version string in the affected pipeline-level `tests/*.nf.test.snap` snapshots to match

## Test plan
- [x] `nf-core modules lint trimgalore` — same pre-existing warnings as on `dev` (container registry connectivity, `process_low_memory` label), no new issues
- [x] `nf-test test tests/default.nf.test --profile=+test,docker` — passes (real + stub)
- [x] `nf-test test tests/hisat2.nf.test tests/salmon.nf.test tests/star_rsem.nf.test --profile=+test,docker` — passes (real + stub), covering HISAT2, Salmon, and STAR/RSEM paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)