### PR TITLE
Bump quant_tximport_summarizedexperiment and quantify_rsem for deterministic collect() ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1869](https://github.com/nf-core/rnaseq/pull/1869) - Add pipeline validation error when `--use_rustqc` and `--skip_markduplicates` are set together, since RustQC requires duplicate-marked BAM files ([#1865](https://github.com/nf-core/rnaseq/issues/1865))
 - [PR #1883](https://github.com/nf-core/rnaseq/pull/1883) - Update the `tximeta/tximport` module ([nf-core/modules#12362](https://github.com/nf-core/modules/pull/12362)): add a `jq` build dependency and set `LC_COLLATE=C` for reproducible gene-level output ordering
 - [PR #1884](https://github.com/nf-core/rnaseq/pull/1884) - Update `trimgalore` module to 2.3.0
+- [PR #1885](https://github.com/nf-core/rnaseq/pull/1885) - Bump `quant_tximport_summarizedexperiment` and `quantify_rsem` ([nf-core/modules#12377](https://github.com/nf-core/modules/pull/12377)): sort the collected per-sample inputs to `TXIMETA_TXIMPORT` and `CUSTOM_RSEMMERGECOUNTS` by staged file name, keeping their cache keys stable across `-resume` instead of following non-deterministic task-completion order ([#1879](https://github.com/nf-core/rnaseq/issues/1879))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/modules.json
+++ b/modules.json
@@ -483,7 +483,7 @@
                     },
                     "quant_tximport_summarizedexperiment": {
                         "branch": "master",
-                        "git_sha": "22438ef171adc6f91bd550cef58d8a54f8a7e9ed",
+                        "git_sha": "fbf6cd41f577f23d33a2d8354f6d8b4feafdffe0",
                         "installed_by": ["quantify_pseudo_alignment", "quantify_rsem"]
                     },
                     "quantify_pseudo_alignment": {
@@ -493,7 +493,7 @@
                     },
                     "quantify_rsem": {
                         "branch": "master",
-                        "git_sha": "22438ef171adc6f91bd550cef58d8a54f8a7e9ed",
+                        "git_sha": "fbf6cd41f577f23d33a2d8354f6d8b4feafdffe0",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {

--- a/modules.json
+++ b/modules.json
@@ -483,7 +483,7 @@
                     },
                     "quant_tximport_summarizedexperiment": {
                         "branch": "master",
-                        "git_sha": "77df703775155f3f0f8922f9354501e0289348c2",
+                        "git_sha": "22438ef171adc6f91bd550cef58d8a54f8a7e9ed",
                         "installed_by": ["quantify_pseudo_alignment", "quantify_rsem"]
                     },
                     "quantify_pseudo_alignment": {
@@ -493,7 +493,7 @@
                     },
                     "quantify_rsem": {
                         "branch": "master",
-                        "git_sha": "77378d340769713877b6a7f72fb7b66f89e65a4c",
+                        "git_sha": "22438ef171adc6f91bd550cef58d8a54f8a7e9ed",
                         "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -53,10 +53,9 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // In per-sample mode, run once per sample instead of collecting all
     //
     // Sorted by name for a stable cache key; the R script derives sample
-    // identity from staged file names, not list position. The empty-list
-    // guard preserves the no-op-on-empty behaviour of the plain collect()
-    // this replaced, since toSortedList() always emits (even []) where
-    // collect() does not emit at all on an empty upstream.
+    // identity from staged file names, not list position. Filtered to
+    // skip TXIMETA_TXIMPORT when there are no samples, since
+    // toSortedList() emits [] rather than nothing on an empty channel.
     //
     ch_tximport_input = skip_merge
         ? quant_results

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -53,12 +53,16 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // In per-sample mode, run once per sample instead of collecting all
     //
     // Sorted by name for a stable cache key; the R script derives sample
-    // identity from staged file names, not list position.
+    // identity from staged file names, not list position. The empty-list
+    // guard preserves the no-op-on-empty behaviour of the plain collect()
+    // this replaced, since toSortedList() always emits (even []) where
+    // collect() does not emit at all on an empty upstream.
     //
     ch_tximport_input = skip_merge
         ? quant_results
         : quant_results
             .toSortedList { a, b -> a[1].name <=> b[1].name }
+            .filter { sorted -> sorted.size() > 0 }
             .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] }
 
     TXIMETA_TXIMPORT (

--- a/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
+++ b/subworkflows/nf-core/quant_tximport_summarizedexperiment/main.nf
@@ -28,9 +28,17 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // tx2gene independently per sample. If a use case arises requiring mixed
     // transcriptomes, this will need to be revisited.
     //
+    // The sample is selected by sorting on the staged results name so the same
+    // one is chosen on every run, keeping the CUSTOM_TX2GENE cache key stable
+    // across -resume. Picking by arrival order would vary between runs and
+    // invalidate the cache for tx2gene and everything downstream of it. The
+    // empty-list guard keeps tx2gene from running when no quant results are
+    // supplied, since toSortedList still emits an empty list in that case.
+    //
     ch_tx2gene_quants = quant_results
-        .first()
-        .map { _meta, results -> [ [:], results ] }
+        .toSortedList { a, b -> a[1].name <=> b[1].name }
+        .filter { sorted -> sorted.size() > 0 }
+        .map { sorted -> [ [:], sorted.first()[1] ] }
 
     CUSTOM_TX2GENE (
         gtf.map { gtf_file -> [ [:], gtf_file ] },
@@ -44,9 +52,14 @@ workflow QUANT_TXIMPORT_SUMMARIZEDEXPERIMENT {
     // Import and summarize quantifications with tximport
     // In per-sample mode, run once per sample instead of collecting all
     //
+    // Sorted by name for a stable cache key; the R script derives sample
+    // identity from staged file names, not list position.
+    //
     ch_tximport_input = skip_merge
         ? quant_results
-        : quant_results.collect{ meta_results -> meta_results[1] }.map { results -> [ ['id': 'all_samples'], results ] }
+        : quant_results
+            .toSortedList { a, b -> a[1].name <=> b[1].name }
+            .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] }
 
     TXIMETA_TXIMPORT (
         ch_tximport_input,

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -51,11 +51,9 @@ workflow QUANTIFY_RSEM {
     if (!skip_merge) {
         //
         // Sorted by name for a stable cache key; the script globs the
-        // staged directory, so order doesn't affect output. The empty-list
-        // guards preserve the no-op-on-empty behaviour of the plain
-        // collect() this replaced, since toSortedList() always emits
-        // (even []) where collect() does not emit at all on an empty
-        // upstream.
+        // staged directory, so order doesn't affect output. Filtered to
+        // skip CUSTOM_RSEMMERGECOUNTS when there are no samples, since
+        // toSortedList() emits [] rather than nothing on an empty channel.
         //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -51,14 +51,20 @@ workflow QUANTIFY_RSEM {
     if (!skip_merge) {
         //
         // Sorted by name for a stable cache key; the script globs the
-        // staged directory, so order doesn't affect output.
+        // staged directory, so order doesn't affect output. The empty-list
+        // guards preserve the no-op-on-empty behaviour of the plain
+        // collect() this replaced, since toSortedList() always emits
+        // (even []) where collect() does not emit at all on an empty
+        // upstream.
         //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene
                 .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .filter { sorted -> sorted.size() > 0 }
                 .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] },
             ch_counts_transcript
                 .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .filter { sorted -> sorted.size() > 0 }
                 .map { sorted -> sorted.collect { it[1] } }
         )
         ch_merged_counts_gene       = CUSTOM_RSEMMERGECOUNTS.out.counts_gene

--- a/subworkflows/nf-core/quantify_rsem/main.nf
+++ b/subworkflows/nf-core/quantify_rsem/main.nf
@@ -49,12 +49,17 @@ workflow QUANTIFY_RSEM {
     ch_merged_isoforms_long     = channel.empty()
 
     if (!skip_merge) {
+        //
+        // Sorted by name for a stable cache key; the script globs the
+        // staged directory, so order doesn't affect output.
+        //
         CUSTOM_RSEMMERGECOUNTS (
             ch_counts_gene
-                .collect{ _meta, genes_count -> genes_count }
-                .map { genes_count -> [ ['id': 'all_samples'], genes_count ] },
+                .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .map { sorted -> [ ['id': 'all_samples'], sorted.collect { it[1] } ] },
             ch_counts_transcript
-                .collect{ _meta, transcripts_count -> transcripts_count }
+                .toSortedList { a, b -> a[1].name <=> b[1].name }
+                .map { sorted -> sorted.collect { it[1] } }
         )
         ch_merged_counts_gene       = CUSTOM_RSEMMERGECOUNTS.out.counts_gene
         ch_merged_tpm_gene          = CUSTOM_RSEMMERGECOUNTS.out.tpm_gene


### PR DESCRIPTION
## Description

Bumps `quant_tximport_summarizedexperiment` and `quantify_rsem` to pull in [nf-core/modules#12377](https://github.com/nf-core/modules/pull/12377).

`TXIMETA_TXIMPORT` and `CUSTOM_RSEMMERGECOUNTS` each stage a multi-file input built by collecting per-sample process outputs on a queue channel. Queue channels emit in task-completion order, which is non-deterministic across runs, so the staged input list order - and therefore the task hash - changed run to run even when nothing else did, breaking `-resume` for these processes and everything downstream of them. Same pattern as the `CUSTOM_TX2GENE` fix already merged for this subworkflow.

Both scripts already derive sample identity from the staged file/directory names rather than input list position (`TXIMETA_TXIMPORT`'s R template via `list.files()`, `CUSTOM_RSEMMERGECOUNTS`'s script via a directory glob), so sorting the collected list by name is a no-op on outputs - it only makes the cache key reproducible.

Note the diff also carries forward the `CUSTOM_TX2GENE` determinism fix from #1875, since `dev` hasn't picked that up yet - both fixes live in the same subworkflow file.

## Verification

- `nf-core subworkflows lint` clean for both subworkflows against the new pin.
- Upstream `nf-core subworkflows test --profile docker` for both subworkflows: all pass, snapshots byte-identical before/after (see nf-core/modules#12377).

Closes https://github.com/nf-core/rnaseq/issues/1879

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] `nf-core subworkflows lint` passes for both bumped subworkflows.
- [x] CHANGELOG.md is updated.