### PR TITLE
Bump Parabricks to version 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1884](https://github.com/nf-core/rnaseq/pull/1884) - Update `trimgalore` module to 2.3.0
 - [PR #1885](https://github.com/nf-core/rnaseq/pull/1885) - Bump `quant_tximport_summarizedexperiment` and `quantify_rsem` ([nf-core/modules#12377](https://github.com/nf-core/modules/pull/12377)): sort the collected per-sample inputs to `TXIMETA_TXIMPORT` and `CUSTOM_RSEMMERGECOUNTS` by staged file name, keeping their cache keys stable across `-resume` instead of following non-deterministic task-completion order ([#1879](https://github.com/nf-core/rnaseq/issues/1879))
 - [PR #1894](https://github.com/nf-core/rnaseq/pull/1894) - Important! Template update for nf-core/tools v4.0.3
+- [PR #1899](https://github.com/nf-core/rnaseq/pull/1899) - Update GPU based STAR (Parabricks rna_fq2bam) to version 4.7.1.
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/modules.json
+++ b/modules.json
@@ -141,7 +141,7 @@
                     },
                     "parabricks/rnafq2bam": {
                         "branch": "master",
-                        "git_sha": "0c44f69eefe8a8c373c7cdd9528b3e1d60cb895f",
+                        "git_sha": "3e0ec6464725c64d81abe928e15a6750d5fdd272",
                         "installed_by": ["modules"]
                     },
                     "picard/markduplicates": {

--- a/modules/nf-core/parabricks/rnafq2bam/main.nf
+++ b/modules/nf-core/parabricks/rnafq2bam/main.nf
@@ -5,7 +5,7 @@ process PARABRICKS_RNAFQ2BAM {
     // needed by the module to work properly can be removed when fixed upstream - see: https://github.com/nf-core/modules/issues/7226
     stageInMode 'copy'
 
-    container "nvcr.io/nvidia/clara/clara-parabricks:4.6.0-1"
+    container "nvcr.io/nvidia/clara/clara-parabricks:4.7.1-1"
 
     input:
     tuple val(meta),  path(reads)

--- a/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test
+++ b/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test
@@ -30,16 +30,13 @@ nextflow_process {
         }
     }
 
-    test("homo_sapiens") {
+    config "./nextflow.config"
 
-        config "./nextflow.config"
+    test("homo_sapiens") {
 
         when {
             params {
-                module_args = '--low-memory --read-files-command zcat --x3'
-                // Ref: https://forums.developer.nvidia.com/t/problem-with-gpu/256825/6
-                // Parabricks’s rnafq2bam requires 24GB of memory.
-                // Using --low-memory for testing
+                module_args = '--num-streams-per-gpu 1 --read-files-command zcat --x3'
             }
             process {
                 """
@@ -72,7 +69,6 @@ nextflow_process {
 
     test("homo_sapiens - stub") {
 
-        config "./nextflow.config"
         options "-stub"
 
         when {
@@ -106,14 +102,9 @@ nextflow_process {
 
     test("homo_sapiens_chimeric") {
 
-        config "./nextflow.config"
-
         when {
             params {
-                module_args = '--low-memory --read-files-command zcat --out-chim-type Junctions --min-chim-segment 15 --x3'
-                // Ref: https://forums.developer.nvidia.com/t/problem-with-gpu/256825/6
-                // Parabricks’s rnafq2bam requires 24GB of memory.
-                // Using --low-memory for testing
+                module_args = '--num-streams-per-gpu 1 --read-files-command zcat --out-chim-type Junctions --min-chim-segment 15 --x3'
             }
             process {
                 """
@@ -147,7 +138,6 @@ nextflow_process {
 
     test("homo_sapiens_chimeric - stub") {
 
-        config "./nextflow.config"
         options "-stub"
 
         when {

--- a/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test.snap
+++ b/modules/nf-core/parabricks/rnafq2bam/tests/main.nf.test.snap
@@ -97,7 +97,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "2": [
@@ -342,7 +342,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "wig": [
@@ -358,9 +358,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-09T09:28:46.515275982"
+        "timestamp": "2026-04-17T08:08:44.920007509"
     },
     "homo_sapiens_chimeric - stub": {
         "content": [
@@ -460,7 +460,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "2": [
@@ -705,7 +705,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ],
                 "wig": [
@@ -721,9 +721,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-09T09:29:54.340122816"
+        "timestamp": "2026-04-17T08:09:51.697962968"
     },
     "homo_sapiens": {
         "content": [
@@ -733,7 +733,7 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             },
@@ -741,9 +741,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-09T09:27:02.147122093"
+        "timestamp": "2026-04-17T08:08:34.03461553"
     },
     "homo_sapiens_chimeric": {
         "content": [
@@ -755,15 +755,15 @@
                     [
                         "PARABRICKS_RNAFQ2BAM",
                         "parabricks",
-                        "4.6.0-1"
+                        "4.7.1-1"
                     ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2026-02-09T09:29:44.105218347"
+        "timestamp": "2026-04-17T08:09:41.244103512"
     }
 }

--- a/modules/nf-core/parabricks/rnafq2bam/tests/nextflow.config
+++ b/modules/nf-core/parabricks/rnafq2bam/tests/nextflow.config
@@ -1,8 +1,11 @@
 process {
-    // Parabricks rnafq2bam requires more memory
     withName: 'PARABRICKS_RNAFQ2BAM' {
-        ext.args = params.module_args
-        accelerator.request = 1
+        ext.args = { params.module_args }
+        accelerator = [request: 1]
+        // The nf-test config caps system memory usage to 4.GB
+        // This module requires at least 30 GB to run without error
+        // Note: The Github runners run highmem GPU tests on a machine with 31 GB available memory
+        // See .github/workflows/nf-test-gpu.yml for exact machine specs
         memory = 30.GB
     }
 

--- a/tests/parabricks_default.nf.test.snap
+++ b/tests/parabricks_default.nf.test.snap
@@ -50,7 +50,7 @@
                     "gunzip": 1.13
                 },
                 "PARABRICKS_RNA_FQ2BAM": {
-                    "parabricks": "4.6.0-1"
+                    "parabricks": "4.7.1-1"
                 },
                 "PARABRICKS_STARGENOMEGENERATE": {
                     "gawk": "5.1.0",
@@ -633,9 +633,9 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "26.04.6"
         },
-        "timestamp": "2026-02-09T11:01:14.364447839"
+        "timestamp": "2026-07-31T12:53:06.381504124"
     },
     "Params: parabricks star_salmon (with markdups) - stub": {
         "content": [
@@ -880,7 +880,7 @@
                     "gunzip": 1.13
                 },
                 "PARABRICKS_RNA_FQ2BAM": {
-                    "parabricks": "4.6.0-1"
+                    "parabricks": "4.7.1-1"
                 },
                 "PARABRICKS_STARGENOMEGENERATE": {
                     "gawk": "5.1.0",
@@ -1453,8 +1453,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
+            "nextflow": "26.04.6"
         },
-        "timestamp": "2026-02-09T11:13:00.399098759"
+        "timestamp": "2026-07-31T12:58:57.904720898"
     }
 }


### PR DESCRIPTION
This newer Parabricks version offers performance improvements for rna_fq2bam (STAR). 

See release notes for [4.7](https://docs.nvidia.com/clara/parabricks/about-parabricks/release-notes/4-7-0-1-release-notes) and [4.7.1](https://docs.nvidia.com/clara/parabricks/about-parabricks/release-notes/4-7-1-1-release-notes) for more information. 