### PR TITLE
fix(trimgalore): allocate memory to match TRIMGALORE's cpu band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1894](https://github.com/nf-core/rnaseq/pull/1894) - Important! Template update for nf-core/tools v4.0.3
 - [PR #1899](https://github.com/nf-core/rnaseq/pull/1899) - Update GPU based STAR (Parabricks rna_fq2bam) to version 4.7.1.
 - [PR #1902](https://github.com/nf-core/rnaseq/pull/1902) - Update `bam_stringtie_merge` and StringTie modules ([nf-core/modules#12661](https://github.com/nf-core/modules/pull/12661)), allowing runs where all samples fail `--min_mapped_reads` to complete with skipped-sample warnings instead of failing an empty StringTie merge ([#1901](https://github.com/nf-core/rnaseq/issues/1901))
+- [PR #1905](https://github.com/nf-core/rnaseq/pull/1905) - Give `TRIMGALORE` an explicit 4 GB memory allocation, replacing the `process_low_memory` label's 1 GB budget that paired with an 8-cpu band and OOM-killed every sample on every retry ([#1903](https://github.com/nf-core/rnaseq/issues/1903))
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/conf/modules/trimgalore.config
+++ b/conf/modules/trimgalore.config
@@ -10,6 +10,7 @@ process {
 
     withName: '.*:FASTQ_FASTQC_UMITOOLS_TRIMGALORE:TRIMGALORE' {
         cpus       = { 8 * task.attempt }
+        memory     = { 4.GB * task.attempt }
         ext.args   = {
             // Initialize the map with preconfigured values
             def preset_args_map = ["--fastqc_args": "'-t ${task.cpus}'"]


### PR DESCRIPTION
`TRIMGALORE` carries both `process_medium` and `process_low_memory`, so it resolves to 8 cpus with
1 GB. Both `cpus` and `memory` scale with `task.attempt`, which pins the budget at 128 MB/cpu on
every attempt — so OOM-killed samples fail identically on all three retries rather than recovering
(#1903). This sets `memory` on the selector that already overrides `cpus`, giving 4 GB against a
measured ~190 MiB peak for paired 150 bp at `--cores 8`. Nothing else changes.

<details>
<summary>Measurements and label resolution (AI-assisted analysis)</summary>

Resolved directives, verified with Nextflow 25.10.4 on a minimal reproducer using this repo's
`base.config` label block verbatim:

| attempt | before | after |
|---|---|---|
| 1 | 8 cpus / 1 GB — 128 MB/cpu | 8 cpus / 4 GB — 512 MB/cpu |
| 2 | 16 cpus / 2 GB — 128 MB/cpu | 16 cpus / 8 GB — 512 MB/cpu |
| 3 | 24 cpus / 3 GB — 128 MB/cpu | 24 cpus / 12 GB — 512 MB/cpu |

Trim Galore v2 peak RSS, paired 150 bp with `--gzip`: 116 MiB at `--cores 4`, 202 MiB at `--cores 8`,
304 MiB at `--cores 16`; 190 MiB at `--cores 8` with `--fastqc_args '-t 24'` on 12M all-unique
reads. Peak plateaus with input size at a fixed read length, so 4 GB leaves ~20x headroom while
still cutting `process_medium`'s 36 GB by ~9x, which was the point of nf-core/modules#11541.

The 1 GB budget came from that PR's "~10× the observed ~100 MB peak on 30M PE". That figure is from
Trim Galore's own docs and was measured paired-end, but on a 65 bp fixture those docs mis-describe as
150 bp; batches hold a fixed number of records rather than of bytes, so 150 bp data needs ~2.3× more.
Re-measured on the original hardware, v2.1.0-beta.7 reproduces the published table, so no released
version regressed. The mislabel is being corrected upstream.

This is the pipeline-local unblock, following the precedent of #1841, which overrode `cpus` on the
same selector for the same reason. The durable fix is upstream — `process_low_memory` is not a safe
pairing with a multi-core cpu band for any tool that streams gzip output — but that needs a module
release and a reinstall, so it shouldn't gate #1903.

</details>

