### PR TITLE
Supply the slack token within platform, instead of from github

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -43,7 +43,8 @@ jobs:
             slack {
               enabled = true
               bot {
-                token = '${{ secrets.NFSLACK_BOT_TOKEN }}'
+                // Resolved by Seqera Platform secret store at launch
+                token = secrets.NFSLACK_BOT_TOKEN
                 channel = 'rnaseq'
               }
               onStart {
@@ -70,3 +71,4 @@ jobs:
           path: |
             tower_action_*.log
             tower_action_*.json
+          retention-days: 3


### PR DESCRIPTION
Security patch: don't supply the token from GitHub (where it can make its way into logs etc), but supply directly within platform.

NOTE: I haven't actually created this secret in Platform yet, and it's untested.