### PR TITLE
fix(strandedness): stop Salmon auto-strandedness inference crashing when no genome fasta is supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #1894](https://github.com/nf-core/rnaseq/pull/1894) - Important! Template update for nf-core/tools v4.0.3
 - [PR #1899](https://github.com/nf-core/rnaseq/pull/1899) - Update GPU based STAR (Parabricks rna_fq2bam) to version 4.7.1.
 - [PR #1902](https://github.com/nf-core/rnaseq/pull/1902) - Update `bam_stringtie_merge` and StringTie modules ([nf-core/modules#12661](https://github.com/nf-core/modules/pull/12661)), allowing runs where all samples fail `--min_mapped_reads` to complete with skipped-sample warnings instead of failing an empty StringTie merge ([#1901](https://github.com/nf-core/rnaseq/issues/1901))
+- [PR #1907](https://github.com/nf-core/rnaseq/pull/1907) - Update `fastq_qc_trim_filter_setstrandedness` ([nf-core/modules#12745](https://github.com/nf-core/modules/pull/12745)), fixing a crash in Salmon auto-strandedness inference when no `--fasta` is supplied (e.g. kallisto-only pseudoalignment runs)
 
 ## [[3.26.0](https://github.com/nf-core/rnaseq/releases/tag/3.26.0)] - 2026-05-07
 

--- a/modules.json
+++ b/modules.json
@@ -468,7 +468,7 @@
                     },
                     "fastq_qc_trim_filter_setstrandedness": {
                         "branch": "master",
-                        "git_sha": "2e0ae2fa5d14f045f2e1360928a5d003fa5d903d",
+                        "git_sha": "06d95c8ca20cbb78d4364f4e59d7b86fa5c61662",
                         "installed_by": ["subworkflows"]
                     },
                     "fastq_remove_rrna": {

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/main.nf
@@ -155,7 +155,6 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     ch_ribodetector_log   = channel.empty()
     ch_seqkit_stats       = channel.empty()
     ch_bowtie2_log        = channel.empty()
-    ch_bowtie2_index      = channel.empty()
     ch_seqkit_prefixed    = channel.empty()
     ch_seqkit_converted   = channel.empty()
     ch_fastqc_filtered_html = channel.empty()
@@ -380,10 +379,10 @@ workflow FASTQ_QC_TRIM_FILTER_SETSTRANDEDNESS {
     // SUBWORKFLOW: Sub-sample FastQ files and pseudoalign with Salmon to auto-infer strandedness
     //
     // Return empty channel if ch_strand_fastq.auto_strand is empty so salmon index isn't created
-
     ch_fasta
+        .map { fasta -> [fasta] }
         .combine(ch_strand_fastq.auto_strand)
-        .map { items -> items.first() }
+        .map { items -> items[0] }
         .first()
         .set { ch_genome_fasta }
 

--- a/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
+++ b/subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test
@@ -502,6 +502,71 @@ nextflow_workflow {
         }
     }
 
+    test("auto strandedness - should infer strandedness when no genome fasta is supplied") {
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false, strandedness:'auto' ],
+                    [
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/fastq/test_rnaseq_2.fastq.gz', checkIfExists: true),
+                    ]
+                ])
+                input[1] = Channel.of([]) // ch_fasta: no genome fasta supplied (e.g. pseudoalignment-only run)
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/homo_sapiens/genome/transcriptome.fasta", checkIfExists: true))
+                input[3] = Channel.of(file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true))
+                input[4] = []              // ch_salmon_index
+                input[5] = []              // ch_sortmerna_index
+                input[6] = []              // ch_bowtie2_index
+                input[7] = []              // ch_bbsplit_index
+                input[8] = []              // ch_rrna_fastas
+
+                // Skip options
+                input[9] = true            // skip_bbsplit
+                input[10] = true           // skip_fastqc
+                input[11] = true           // skip_trimming
+                input[12] = true           // skip_umi_extract
+                input[13] = true           // skip_linting
+
+                // Index generation
+                input[14] = true           // make_salmon_index
+                input[15] = false          // make_sortmerna_index
+                input[16] = false          // make_bowtie2_index
+
+                // Trimming options
+                input[17] = 'fastp'        // trimmer
+                input[18] = 10             // min_trimmed_reads
+                input[19] = false          // save_trimmed
+                input[20] = false          // fastp_merge
+
+                // rRNA removal options
+                input[21] = false          // remove_ribo_rna
+                input[22] = 'sortmerna'    // ribo_removal_tool
+
+                // UMI options
+                input[23] = false          // with_umi
+                input[24] = 0              // umi_discard_read
+
+                // Merging options
+                input[25] = false          // save_merged_fastq
+
+                // Strandedness thresholds
+                input[26] = 0.8            // stranded_threshold
+                input[27] = 0.1            // unstranded_threshold
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert workflow.out.reads[0][0].strandedness != 'auto' }
+            )
+        }
+    }
+
     test("homo_sapiens single-end [fastq] fastp bowtie2") {
 
         setup {


### PR DESCRIPTION
Auto strandedness inference always routes through Salmon, even for pseudoalignment-only runs with kallisto. When no `--fasta` is given and a sample has `strandedness: auto`, the subworkflow crashed with:

```
Not a valid path value type: java.util.LinkedHashMap ([id:sample1, strandedness:auto, ...])
```

Root cause and fix landed upstream in nf-core/modules#12745: `ch_fasta`'s "no fasta" sentinel (`[]`) was getting flattened away by a `combine()` call, leaking the sample meta map into `SALMON_INDEX` as the genome fasta path instead.

This PR runs `nf-core subworkflows update fastq_qc_trim_filter_setstrandedness` to pull that fix in. It also picks up nf-core/modules#12490 along the way, which stops the same subworkflow discarding a caller-supplied bowtie2 rRNA index (unrelated bug, fixed upstream in the interim since our last sync).

Reported by a user via NBIS support, running `--pseudo_aligner kallisto --skip_alignment true` with no `--fasta` and `strandedness: auto` in the samplesheet.

## Test plan

- [x] `nf-test test subworkflows/nf-core/fastq_qc_trim_filter_setstrandedness/tests/main.nf.test --profile docker` in nf-core/modules — all 7 tests pass, including a new regression test for this exact scenario
- Vendored subworkflow tests aren't run against rnaseq's own test-data mirror (deliberately excluded in `nf-test.config`); verification was done against nf-core/modules' own CI-equivalent config, which is where the fix lives