### PR TITLE
Migrate Seqera launch steps to action-seqera-launch

### DIFF
--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -12,22 +12,18 @@ jobs:
     steps:
       # Launch workflow using Seqera Platform CLI tool action
       - name: Launch workflow via Seqera Platform
-        uses: seqeralabs/action-tower-launch@51565b514bff1827cf34620de25d0055759f1fc9 # v2
+        uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ vars.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ vars.TOWER_COMPUTE_ENV }}
+          workspace-id: ${{ vars.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ vars.TOWER_COMPUTE_ENV }}
           revision: ${{ github.sha }}
-          workdir: s3://${{ vars.AWS_S3_BUCKET }}/work/rnaseq/work-${{ github.sha }}
+          work-dir: s3://${{ vars.AWS_S3_BUCKET }}/work/rnaseq/work-${{ github.sha }}
           parameters: |
             {
               "outdir": "s3://${{ vars.AWS_S3_BUCKET }}/rnaseq/results-test-${{ github.sha }}"
             }
           profiles: test
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: Seqera Platform debug log file
-          path: |
-            tower_action_*.log
-            tower_action_*.json
+          # Fail the step if the run does not reach RUNNING, so a bad revision or
+          # parameter set shows up here instead of only in Seqera.
+          wait: running

--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         aligner: ["star_salmon", "star_rsem"]
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_AWS_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "aws_rnaseq_full_${{ matrix.aligner }}"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_AWS_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "aws_rnaseq_full_${{ matrix.aligner }}"
           revision: ${{ github.sha }}
           profiles: test_full_aws
           parameters: |
@@ -35,10 +35,7 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (aws-${{ matrix.aligner }})
-          path: tower_action_*.log
+          wait: running
 
   run-full-tests-on-azure:
     if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'azure' || !github.event.inputs }}
@@ -47,13 +44,13 @@ jobs:
       matrix:
         aligner: ["star_salmon", "star_rsem"]
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_AZURE_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "azure_rnaseq_full_${{ matrix.aligner }}"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_AZURE_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "azure_rnaseq_full_${{ matrix.aligner }}"
           revision: ${{ github.sha }}
           profiles: test_full_azure
           parameters: |
@@ -62,10 +59,7 @@ jobs:
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/",
                 "igenomes_base": "${{ secrets.TOWER_IGENOMES_BASE_AZURE }}"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (azure-${{ matrix.aligner }})
-          path: tower_action_*.log
+          wait: running
 
   run-full-tests-on-gcp:
     if: ${{ github.event.inputs.platform == 'gcp' || !github.event.inputs }}
@@ -74,13 +68,13 @@ jobs:
       matrix:
         aligner: ["star_salmon", "star_rsem"]
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_GCP_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "gcp_rnaseq_full_${{ matrix.aligner }}"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_GCP_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "gcp_rnaseq_full_${{ matrix.aligner }}"
           revision: ${{ github.sha }}
           profiles: test_full_gcp
           parameters: |
@@ -88,7 +82,4 @@ jobs:
                 "aligner": "${{ matrix.aligner }}",
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (gcp-${{ matrix.aligner }})
-          path: tower_action_*.log
+          wait: running

--- a/.github/workflows/cloud_tests_small.yml
+++ b/.github/workflows/cloud_tests_small.yml
@@ -18,64 +18,55 @@ jobs:
     if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'aws' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_AWS_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "aws_rnaseq_small"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_AWS_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "aws_rnaseq_small"
           revision: ${{ github.sha }}
           profiles: test
           parameters: |
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (aws)
-          path: tower_action_*.log
+          wait: running
 
   run-small-tests-on-azure:
     if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'azure' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_AZURE_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "azure_rnaseq_small"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_AZURE_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "azure_rnaseq_small"
           revision: ${{ github.sha }}
           profiles: test
           parameters: |
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (azure)
-          path: tower_action_*.log
+          wait: running
 
   run-small-tests-on-gcp:
     if: ${{ github.event.inputs.platform == 'gcp' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: seqeralabs/action-tower-launch@v2
+      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
-          workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute_env: ${{ secrets.TOWER_CE_GCP_CPU }}
-          workdir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
-          run_name: "gcp_rnaseq_small"
+          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
+          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
+          compute-env: ${{ secrets.TOWER_CE_GCP_CPU }}
+          work-dir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "gcp_rnaseq_small"
           revision: ${{ github.sha }}
           profiles: test
           parameters: |
             {
                 "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}/"
             }
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          name: Tower debug log file (gcp)
-          path: tower_action_*.log
+          wait: running


### PR DESCRIPTION
`action-tower-launch` wraps the `tw` CLI in a Docker container. Its replacement, [`action-seqera-launch`](https://github.com/seqeralabs/action-seqera-launch), calls the Platform API directly. This moves the seven `workflow_dispatch`-only launch steps across `awstest.yml`, `cloud_tests_small.yml` and `cloud_tests_full.yml`.

Input names all change from snake_case to kebab-case, including `workdir` → `work-dir`. Secrets and vars are untouched, so nothing needs configuring to merge this.

The `upload-artifact` steps are deleted rather than renamed. Nothing shells out to `tw` any more, so no `tower_action_*.log` is produced and those steps would upload an empty artifact. Failure detail goes to the step log and a job summary instead. That also closes a small leak: the old debug log wrote `nextflow_config` and `parameters` to a file in plaintext, outside the `***` masking Actions applies to step logs.

**One behaviour change worth reviewing.** The old action defaulted to fire-and-forget, so these steps went green as soon as the API accepted the submission — including when the run failed a second later on a bad revision. Every step here sets `wait: running`, so the step fails if the run never reaches `RUNNING`. It does not wait for the pipeline to finish. `wait: none` restores the old behaviour exactly.

`awsfulltest.yml` is deliberately left alone: it triggers on `pull_request_review`, so approving this PR would launch a full-size run. It should move separately once these are proven.

The action is pinned to `v1.0.0-rc.1`, a **pre-release** — rnaseq would be its first real consumer. All three workflows are dispatch-only, so merging launches nothing; I'd like to validate with a single `awstest.yml` dispatch on this branch first.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] ~~If you've fixed a bug or added code that should be tested, add tests!~~ No pipeline code changed.
- [ ] ~~Make sure your code lints (`nf-core pipelines lint`).~~ No Nextflow code changed; `actionlint` is clean on all three files.
- [ ] ~~`CHANGELOG.md` is updated.~~ CI-only change, matching #1895.
