### PR TITLE
Collapse per-cloud launch jobs into a platform matrix

### DIFF
--- a/.github/workflows/cloud_tests_full.yml
+++ b/.github/workflows/cloud_tests_full.yml
@@ -14,72 +14,38 @@ on:
           - azure
           - gcp
 jobs:
-  run-full-tests-on-aws:
-    if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'aws' || !github.event.inputs }}
+  run-full-tests:
+    name: Launch full test on ${{ matrix.platform }} (${{ matrix.aligner }})
     runs-on: ubuntu-latest
     strategy:
+      # The per-cloud jobs this matrix replaces were independent; one cloud
+      # failing must not cancel the others.
+      fail-fast: false
       matrix:
+        # "all" deliberately excludes gcp, matching the job-level conditions
+        # this matrix replaces; gcp runs only when selected explicitly.
+        platform: ${{ fromJSON(inputs.platform == 'all' && '["aws", "azure"]' || format('["{0}"]', inputs.platform)) }}
         aligner: ["star_salmon", "star_rsem"]
+    env:
+      COMPUTE_ENV: >-
+        ${{ secrets[format('TOWER_CE_{0}_CPU', fromJSON('{"aws": "AWS", "azure": "AZURE", "gcp": "GCP"}')[matrix.platform])] }}
+      BUCKET: >-
+        ${{ secrets[format('TOWER_BUCKET_{0}', fromJSON('{"aws": "AWS", "azure": "AZURE", "gcp": "GCP"}')[matrix.platform])] }}
     steps:
       - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
           workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_AWS_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "aws_rnaseq_full_${{ matrix.aligner }}"
+          compute-env: ${{ env.COMPUTE_ENV }}
+          work-dir: "${{ env.BUCKET }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "${{ matrix.platform }}_rnaseq_full_${{ matrix.aligner }}"
           revision: ${{ github.sha }}
-          profiles: test_full_aws
+          profiles: test_full_${{ matrix.platform }}
+          # YAML, not JSON: the action accepts either (parseParametersText tries
+          # JSON then YAML), and YAML lets the azure-only igenomes_base line
+          # collapse to a blank line on the other platforms.
           parameters: |
-            {
-                "aligner": "${{ matrix.aligner }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
-            }
-          wait: running
-
-  run-full-tests-on-azure:
-    if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'azure' || !github.event.inputs }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        aligner: ["star_salmon", "star_rsem"]
-    steps:
-      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
-        with:
-          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_AZURE_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "azure_rnaseq_full_${{ matrix.aligner }}"
-          revision: ${{ github.sha }}
-          profiles: test_full_azure
-          parameters: |
-            {
-                "aligner": "${{ matrix.aligner }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/",
-                "igenomes_base": "${{ secrets.TOWER_IGENOMES_BASE_AZURE }}"
-            }
-          wait: running
-
-  run-full-tests-on-gcp:
-    if: ${{ github.event.inputs.platform == 'gcp' || !github.event.inputs }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        aligner: ["star_salmon", "star_rsem"]
-    steps:
-      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
-        with:
-          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_GCP_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "gcp_rnaseq_full_${{ matrix.aligner }}"
-          revision: ${{ github.sha }}
-          profiles: test_full_gcp
-          parameters: |
-            {
-                "aligner": "${{ matrix.aligner }}",
-                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
-            }
+            aligner: "${{ matrix.aligner }}"
+            outdir: "${{ env.BUCKET }}/rnaseq/results-${{ github.sha }}/aligner_${{ matrix.aligner }}/"
+            ${{ matrix.platform == 'azure' && format('igenomes_base: "{0}"', secrets.TOWER_IGENOMES_BASE_AZURE) || '' }}
           wait: running

--- a/.github/workflows/cloud_tests_small.yml
+++ b/.github/workflows/cloud_tests_small.yml
@@ -14,59 +14,34 @@ on:
           - azure
           - gcp
 jobs:
-  run-small-tests-on-aws:
-    if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'aws' }}
+  run-small-tests:
+    name: Launch small test on ${{ matrix.platform }}
     runs-on: ubuntu-latest
+    strategy:
+      # The per-cloud jobs this matrix replaces were independent; one cloud
+      # failing must not cancel the others.
+      fail-fast: false
+      matrix:
+        # "all" deliberately excludes gcp, matching the job-level conditions
+        # this matrix replaces; gcp runs only when selected explicitly.
+        platform: ${{ fromJSON(inputs.platform == 'all' && '["aws", "azure"]' || format('["{0}"]', inputs.platform)) }}
+    env:
+      COMPUTE_ENV: >-
+        ${{ secrets[format('TOWER_CE_{0}_CPU', fromJSON('{"aws": "AWS", "azure": "AZURE", "gcp": "GCP"}')[matrix.platform])] }}
+      BUCKET: >-
+        ${{ secrets[format('TOWER_BUCKET_{0}', fromJSON('{"aws": "AWS", "azure": "AZURE", "gcp": "GCP"}')[matrix.platform])] }}
     steps:
       - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
         with:
           workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_AWS_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_AWS }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "aws_rnaseq_small"
+          compute-env: ${{ env.COMPUTE_ENV }}
+          work-dir: "${{ env.BUCKET }}/work/rnaseq/work-${{ github.sha }}"
+          run-name: "${{ matrix.platform }}_rnaseq_small"
           revision: ${{ github.sha }}
           profiles: test
           parameters: |
             {
-                "outdir": "${{ secrets.TOWER_BUCKET_AWS }}/rnaseq/results-test-${{ github.sha }}/"
-            }
-          wait: running
-
-  run-small-tests-on-azure:
-    if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'azure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
-        with:
-          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_AZURE_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_AZURE }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "azure_rnaseq_small"
-          revision: ${{ github.sha }}
-          profiles: test
-          parameters: |
-            {
-                "outdir": "${{ secrets.TOWER_BUCKET_AZURE }}/rnaseq/results-test-${{ github.sha }}/"
-            }
-          wait: running
-
-  run-small-tests-on-gcp:
-    if: ${{ github.event.inputs.platform == 'gcp' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seqeralabs/action-seqera-launch@1bcb34fe032e7eeda8861d85490e890cf5aa6c76 # v1.0.0-rc.1
-        with:
-          workspace-id: ${{ secrets.TOWER_WORKSPACE_ID }}
-          access-token: ${{ secrets.TOWER_ACCESS_TOKEN }}
-          compute-env: ${{ secrets.TOWER_CE_GCP_CPU }}
-          work-dir: "${{ secrets.TOWER_BUCKET_GCP }}/work/rnaseq/work-${{ github.sha }}"
-          run-name: "gcp_rnaseq_small"
-          revision: ${{ github.sha }}
-          profiles: test
-          parameters: |
-            {
-                "outdir": "${{ secrets.TOWER_BUCKET_GCP }}/rnaseq/results-test-${{ github.sha }}/"
+                "outdir": "${{ env.BUCKET }}/rnaseq/results-test-${{ github.sha }}/"
             }
           wait: running


### PR DESCRIPTION
Stacked on #1908 — the diff to read is this branch against `migrate-to-action-seqera-launch`.

`cloud_tests_small.yml` and `cloud_tests_full.yml` carry six near-identical jobs between them. Each trio differs only in three secret names, a profile suffix, and a run-name prefix. Every action bump, input rename, or `wait` tweak is a six-place edit, which is exactly how they drift.

Each file collapses to one job with a `platform` matrix. Per-platform secrets resolve dynamically:

```yaml
COMPUTE_ENV: >-
  ${{ secrets[format('TOWER_CE_{0}_CPU', fromJSON('{"aws": "AWS", "azure": "AZURE", "gcp": "GCP"}')[matrix.platform])] }}
```

`fail-fast: false` keeps the clouds independent, as the separate jobs were. `platform=all` still excludes gcp — that is the existing behaviour of the job-level `if:` conditions, preserved deliberately; gcp runs only when picked explicitly. The dead `|| !github.event.inputs` branches in the full file are dropped rather than translated: both workflows are dispatch-only and `platform` is required with a default.

The full file's `parameters` switches from JSON to YAML. The action accepts either (`parseParametersText` tries JSON, then YAML), and YAML lets the azure-only `igenomes_base` line collapse to a blank line on the other platforms instead of needing a separate job.

Only cosmetic behaviour change: with `platform=all`, the gcp job previously showed up as *skipped*. Now it isn't created at all.

Validated with one `cloud_tests_small` dispatch on `platform=aws` from this branch: a single job, the matrix filtered azure and gcp out rather than creating them, and the run reached RUNNING on Platform with the right revision.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] ~~If you've fixed a bug or added code that should be tested, add tests!~~ No pipeline code changed.
- [ ] ~~Make sure your code lints (`nf-core pipelines lint`).~~ No Nextflow code changed; `actionlint` is clean on both files.
- [ ] ~~`CHANGELOG.md` is updated.~~ CI-only change, matching #1895.
